### PR TITLE
Minor improvement to f16 matmul, Longer prompt and token generation for testing

### DIFF
--- a/examples/mistral/main.rs
+++ b/examples/mistral/main.rs
@@ -17,8 +17,20 @@ type DeviceCompiler = CudaFp16Compiler;
 type DeviceCompiler = CPUCompiler;
 
 fn main() {
-    let prompt = "[INST]Write me a python implementation of merge sort[/INST]\n";
-    let tokens_to_generate = 50;
+    // let prompt = "[INST]Write me a python implementation of merge sort[/INST]\n";
+    let prompt = "
+# Three Laws of Robotics
+
+**The Three Laws of Robotics** (often shortened to **The Three Laws** or **Asimov's Laws**) are a set of rules devised by science fiction author Isaac Asimov, which were to be followed by robots in several of his stories. The rules were introduced in his 1942 short story \"Runaround\" (included in the 1950 collection I, Robot), although similar restrictions had been implied in earlier stories.
+
+## The Laws
+
+The Three Laws, presented to be from the fictional \"Handbook of Robotics, 56th Edition, 2058 A.D.\", are:
+ - The First Law: A robot may not injure a human being or, through inaction, allow a human being to come to harm.
+ - The Second Law: A robot must obey the orders given it by human beings except where such orders would conflict with the First Law.
+ - The Third Law: A robot must protect its own existence as long as such protection does not conflict with the First or Second Law.
+    ".trim();
+    let tokens_to_generate = 128;
 
     let tokenizer = SentencePieceBpeTokenizer::from_file(
         "./examples/mistral/setup/mistral-7b-hf/tokenizer.model",

--- a/src/compilers/metal/fp16/matmul.rs
+++ b/src/compilers/metal/fp16/matmul.rs
@@ -206,12 +206,12 @@ kernel void kernel_matmul_2d(
     data1 += block_pos.x * 32 * K;
     data2 += global_pos.y * 32;
 
-    simdgroup_float8x8 acc[4][4];
+    simdgroup_half8x8 acc[4][4];
     #pragma unroll(4)
     for (int i = 0; i < 4; ++i) {
         #pragma unroll(4)
         for (int j = 0; j < 4; ++j) {
-            acc[i][j] = simdgroup_float8x8(0);
+            acc[i][j] = simdgroup_half8x8(0);
         }
     }
 
@@ -381,12 +381,12 @@ kernel void kernel_batch_matmul_2d(
     data1 += M * K * block_pos.z + block_pos.x * 32 * K;
     data2 += global_pos.y * 32;
 
-    simdgroup_float8x8 acc[4][4];
+    simdgroup_half8x8 acc[4][4];
     #pragma unroll(4)
     for (int i = 0; i < 4; ++i) {
         #pragma unroll(4)
         for (int j = 0; j < 4; ++j) {
-            acc[i][j] = simdgroup_float8x8(0);
+            acc[i][j] = simdgroup_half8x8(0);
         }
     }
 


### PR DESCRIPTION
Changed f16 matmul kernels to only use half (no more floats) and made mistral prompt longer for testing.

~ 132 tok/s prompt processing -> ~140 tok/s