### PR TITLE
Cuda `GatherCompiler` fails on low dimensionality (failing test)

### DIFF
--- a/crates/luminal_cuda/src/binary.rs
+++ b/crates/luminal_cuda/src/binary.rs
@@ -376,7 +376,7 @@ impl<T: CudaFloat> Compiler for GatherCompiler<T> {
                 .as_data()
                 .unwrap()
                 .2;
-            let embed_dim = emb_shape.shape()[2].to_usize().unwrap();
+            let embed_dim = emb_shape.shape().last().unwrap().to_usize().unwrap();
             let index_shape = graph
                 .edges_connecting(s.get(&indexes), s.get(&ind_copy))
                 .next()
@@ -408,8 +408,8 @@ mod tests {
 
     #[test]
     fn test_gather_compiler_r0() {
-        const CLASSES: usize = 10;
-        const TARGET: usize = 3;
+        const CLASSES: usize = 2;
+        const TARGET: usize = 1;
 
         let mut cx = Graph::new();
         let mut input: TR0 = cx.tensor();
@@ -433,8 +433,8 @@ mod tests {
 
     #[test]
     fn test_gather_compiler_r1() {
-        const CLASSES: usize = 10;
-        const TARGET: usize = 3;
+        const CLASSES: usize = 2;
+        const TARGET: usize = 1;
 
         let mut cx = Graph::new();
         let mut input: TR1<1> = cx.tensor();

--- a/crates/luminal_cuda/src/binary.rs
+++ b/crates/luminal_cuda/src/binary.rs
@@ -396,3 +396,64 @@ impl<T: CudaFloat> Compiler for GatherCompiler<T> {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    luminal::test_imports!();
+
+    type TR0 = GraphTensor<R0>;
+    type TR1<const A: usize> = GraphTensor<R1<A>>;
+    type TR2<const A: usize, const B: usize> = GraphTensor<R2<A, B>>;
+
+    #[test]
+    fn test_gather_compiler_r0() {
+        const CLASSES: usize = 10;
+        const TARGET: usize = 3;
+
+        let mut cx = Graph::new();
+        let mut input: TR0 = cx.tensor();
+        let embedder: TR2<CLASSES, TARGET> = cx.tensor();
+
+        let input_one_hot: TR1<CLASSES> = input
+            .graph()
+            .arange::<LConst<CLASSES>>()
+            .equals(input.expand());
+        let input_embedding: TR1<TARGET> = (input_one_hot.expand::<R2<CLASSES, TARGET>, _>()
+            * embedder)
+            .sum_reduce::<_, LAxis<0>>();
+        let mut loss: TR0 = input_embedding.sum_reduce();
+        let mut weights = vec![embedder.id];
+
+        cx.compile(
+            crate::CudaCompiler::<f32>::default(),
+            (&mut input, &mut loss, &mut weights),
+        );
+    }
+
+    #[test]
+    fn test_gather_compiler_r1() {
+        const CLASSES: usize = 10;
+        const TARGET: usize = 3;
+
+        let mut cx = Graph::new();
+        let mut input: TR1<1> = cx.tensor();
+        let embedder: TR2<CLASSES, TARGET> = cx.tensor();
+
+        let input_one_hot: TR2<1, CLASSES> = input
+            .graph()
+            .arange::<LConst<CLASSES>>()
+            .expand::<R2<1, CLASSES>, _>()
+            .equals(input.expand());
+        let input_embedding: TR2<1, TARGET> = (input_one_hot.expand::<R3<1, CLASSES, TARGET>, _>()
+            * embedder.expand())
+        .sum_reduce::<_, LAxis<1>>();
+        let mut loss: TR0 = input_embedding.sum_reduce();
+        let mut weights = vec![embedder.id];
+
+        cx.compile(
+            crate::CudaCompiler::<f32>::default(),
+            (&mut input, &mut loss, &mut weights),
+        );
+    }
+}


### PR DESCRIPTION
Related to #70.

This showcases a failure for the Cuda `GatherCompiler` compilation pass.

To fetch the PR and run the tests:
```bash
git fetch origin pull/71/head:cuda_gather_failure
git switch cuda_gather_failure
cd crates/luminal_cuda
cargo test test_gather_compiler
```

The `test_gather_compiler_r1` passes:
https://github.com/jafioti/luminal/pull/71/files#diff-ead6d80249befe24da4ea23c236763f82cc1eccfccbb92035217e620e8bf5184R434-R459

While `test_gather_compiler_r0` fails:
https://github.com/jafioti/luminal/pull/71/files#diff-ead6d80249befe24da4ea23c236763f82cc1eccfccbb92035217e620e8bf5184R409-R432

The failure error is:
```
---- binary::tests::test_gather_compiler_r0 stdout ----
thread 'binary::tests::test_gather_compiler_r0' panicked at src/binary.rs:379:46:
index out of bounds: the len is 2 but the index is 2
```

The relevant line of code is:
https://github.com/jafioti/luminal/blob/f61d53f859293d4c5e4d57d264dfc423a98007e0/crates/luminal_cuda/src/binary.rs#L379

I'm not sure how cuda relates to those operations, but the first thought would be to maybe take the last dimension value instead of the third (`emb_shape.shape()[2]`) one?