### PR TITLE
fix typos/formatting in graphtensor + update ops to 12 in docs

### DIFF
--- a/docs/blog/gpu.mdx
+++ b/docs/blog/gpu.mdx
@@ -52,7 +52,7 @@ The typical approach in Luminal for supporting new backends would be:
 Since we looked at a CUDA kernel above, let's go through how we do this for the Metal backend to support Apple GPUs.
 
 ### Step 1: Metal Primops
-We want to generically support all possible models in Luminal, so our first step is to replicate all primitive operations with a Metal version. Since there are 11 primitive operations, we need 11 Metal ops. You can see these in `crates/luminal_metal/src/prim.rs`. The compiler simply loops through all ops in the graph and swaps them out with the Metal variant.
+We want to generically support all possible models in Luminal, so our first step is to replicate all primitive operations with a Metal version. Since there are 12 primitive operations, we need 12 Metal ops. You can see these in `crates/luminal_metal/src/prim.rs`. The compiler simply loops through all ops in the graph and swaps them out with the Metal variant.
 
 These primitive operations are very simple. Here's the [MetalExp2](https://github.com/jafioti/luminal/blob/d3178b3443ee7fc887f8f0988a77736b73e618d0/crates/luminal_metal/src/prim.rs#L346) op, slightly simplified for clarity:
 ```rust

--- a/docs/blog/intro.mdx
+++ b/docs/blog/intro.mdx
@@ -10,7 +10,7 @@ Current ML libraries tend to be large and complex because they try to map high l
 
 But does it need to be so complex? ML models tend to be static dataflow graphs made up of a few simple operators. This allows us to have a dirt simple core only supporting a few primitive operations, and use them to build up complex neural networks. We can then write compilers that modify the graph after we build it, to swap more efficient ops back in depending on which backend we're running on.
 
-Luminal takes this approach to the extreme, supporting only 11 primitive operations (primops):
+Luminal takes this approach to the extreme, supporting only 12 primitive operations (primops):
 - **Unary** - Log2, Exp2, Sin, Sqrt, Recip
 - **Binary** - Add, Mul, Mod, LessThan
 - **Other** - SumReduce, MaxReduce, Contiguous

--- a/docs/docs/graphtensor.mdx
+++ b/docs/docs/graphtensor.mdx
@@ -28,15 +28,15 @@ cx.execute();
 println!("Result: {:?}", c);
 // Prints out [2.0, 4.0, 6.0]
 ```
-Wow! A lot is going on here just to add two tensors together. That's because luminal isn't really designed for such simple computation, and there's little benifit to using it here. But we'll see it pay off when we start doing more complex operations.
+Wow! A lot is going on here just to add two tensors together. That's because luminal isn't really designed for such simple computation, and there's little benefit to using it here. But we'll see it pay off when we start doing more complex operations.
 
 So what's happening here?
 1) We're setting up a new `Graph` which tracks all computation and actually does execution. We're also defining two new tensors, both of shape (3,). At this point, these "tensors" are actually `GraphTensor`s that don't hold any data. Also, notice we pass in the shape as a type generic. *Types are known at compile time, similar to [dfdx](https://github.com/coreylowman/dfdx)!*
-2) Now we can start doing the thing we came here for: the addition. So we add two `GraphTensor`s together, and get a new `GraphTensor`. Notice this *does not* consume anything, and we're free to use a or b later on. This is because `GraphTensor` is a super lightweight tracking struct which implements copy. "But wait, we never set tbe values of a and b, how can we add them? **We aren't actually adding them here.** Instead, we're writing this addition to the graph, and getting out c, which points to the result when it's actually done.
+2) Now we can start doing the thing we came here for: the addition. So we add two `GraphTensor`s together, and get a new `GraphTensor`. Notice this *does not* consume anything, and we're free to use `a` or `b` later on. This is because `GraphTensor` is a super lightweight tracking struct which implements copy. "But wait, we never set the values of `a` and `b`, how can we add them?" **We aren't actually adding them here.** Instead, we're writing this addition to the graph, and getting out `c`, which points to the result when it's actually done.
+Then we set the data for these tensors. But if `GraphTensor` doesn't hold data, how can we set it? Well we aren't actually setting it *in* the tensor, just passing it through to the graph to say *once you run, set this tensor to this value.* We also need to mark the output we want to retrieve later. This is so that when the graph runs, it doesn't delete the data for `c` part-way through execution (a common optimization for unused tensors). Notice we're setting the sources *after* we define the computation. This is backward from a lot of other libs, but it means we can redefine the data and rerun everything without redefining the computation later on.
 
-Then we set the data for these tensors. But if `GraphTensor` doesn't hold data, how can we set it? Well we aren't actually setting it *in* the tensor, just passing it through to the graph to say *once you run, set this tensor to this value.* We also need to mark the output we want to retrieve later. This is so that when the graph runs, it doesn't delete the data for c part-way through execution (a common optimization for unused tensors). Notice we're setting the sources *after* we define the computation. This is backward from a lot of other libs, but it means we can redefine the data and rerun everything without redefining the computation later on.
-3) Once we call `cx.execute()`, we've already set all our sources, so our addition actually gets ran and stored in c!
-4) Now since we're done computing c, we can fetch the data for c and see the result.
+3) Once we call `cx.execute()`, we've already set all our sources, so our addition actually gets ran and stored in `c`!
+4) Now since we're done computing `c`, we can fetch the data for `c` and see the result.
 
 Alright, that was a lot but now we've touched on all the main aspects of running a model in luminal.
 
@@ -51,7 +51,7 @@ let a: GraphTensor<R1<3>> = cx.tensor(); // Here we create a new node on the gra
 ```
 Notice the type of `a`: `GraphTensor<R1<3>>`. So what's that generic all about? It's the shape! We make tensor shapes part of the type, so they're tracked at compile time! In this case, the shape is rank 1, with 3 elements, or in other words, a vector of 3 dimensions. (Side note: `R1<N>` is a typedef of `(Const<N>,)`) It should be impossible to accidentally get a runtime shape mismatch.
 
-Now we can use the `a` as you would in a library like PyTorch, performing linear algebra:
+Now we can use `a` as you would in a library like PyTorch, performing linear algebra:
 ```rust
 let b = a.exp().sqrt();
 let c = b + a;

--- a/docs/docs/why.mdx
+++ b/docs/docs/why.mdx
@@ -34,7 +34,7 @@ Let's learn the same lesson in ML. If you want to know how something is achieved
 
 How simple *could* an ML library get? Surely after you made a linear algebra library you'd need to deal with datatypes, devices, backprop, and all the usual list of ML concerns, right? What if you could throw all those things away and just worry about doing the minimum to support arbitrary neural networks?
 
-It turns out, it can get extremely simple. The core of Luminal is a few thousand lines of code and only 11 operations, which allows anyone to understand the whole thing in an afternoon.
+It turns out, it can get extremely simple. The core of Luminal is a few thousand lines of code and only 12 operations, which allows anyone to understand the whole thing in an afternoon.
 
 But wouldn't that make your library so limited it's useless? **No!** Not if you can use compilers to add functionality back, in a composable, isolated way.
 
@@ -43,7 +43,7 @@ Let's see what we can do.
 #### Devices
 Since devices aren't handled by the core library, what if we had a compiler take each op present in the network and swap it out with equivalent operations on other devices, like CUDA GPUs? Or TPUs? Or quantum photonic retro-encabulators?
 
-If you only have 11 ops, it's extremely straightforward. We can also have the compilers insert copy-to-device and copy-from-device ops so our data is moved correctly without us thinking about it.
+If you only have 12 ops, it's extremely straightforward. We can also have the compilers insert copy-to-device and copy-from-device ops so our data is moved correctly without us thinking about it.
 
 So compilers get us support for other devices.
 


### PR DESCRIPTION
Hi! I was reading through the documentation to get up to speed on the project and noticed a few typos and formatting issues on the `GraphTensor` page. I went ahead and cleaned those up. Let me know if the structure for the 1–4 bullet points matches your intent.

Also, I saw you recently updated the README to say 12 ops, even though `Contiguous` shouldn't be an op. I figured it was worth updating in the docs for consistency.