### PR TITLE
Fix tolerance for floating point equality

### DIFF
--- a/crates/luminal_cpu/src/binary.rs
+++ b/crates/luminal_cpu/src/binary.rs
@@ -113,7 +113,7 @@ impl Operator for Equal {
             } else {
                 0.0
             };
-            data[i] = if a < b { 1. } else { 0. };
+            data[i] = if (a - b).abs() < 1e-6 { 1. } else { 0. };
         }
         vec![Tensor::new(data)]
     }


### PR DESCRIPTION
## Summary
- update CPU equality operator to consider numbers equal within 1e-6

## Testing
- `cargo +nightly test -p luminal_cpu --quiet` *(fails: could not compile `dfdx`)*

------
https://chatgpt.com/codex/tasks/task_e_68485267cf448325a44654042d3795ee