### PR TITLE
Fix leftover recip uses

### DIFF
--- a/crates/luminal_cuda/src/binary.rs
+++ b/crates/luminal_cuda/src/binary.rs
@@ -404,10 +404,7 @@ mod tests {
         let mut input = cx.tensor(());
         let embedder = cx.tensor((CLASSES, TARGET));
 
-        let input_one_hot = input
-            .graph()
-            .arange(CLASSES)
-            .eq(input.expand(0, CLASSES));
+        let input_one_hot = input.graph().arange(CLASSES).eq(input.expand(0, CLASSES));
         let input_embedding = (input_one_hot.expand(1, TARGET) * embedder).sum(0);
         let mut loss = input_embedding.sum(0);
         let mut weights = vec![embedder.id];
@@ -432,8 +429,7 @@ mod tests {
             .arange(CLASSES)
             .expand(0, 1)
             .eq(input.expand(1, CLASSES));
-        let input_embedding =
-            (input_one_hot.expand(2, TARGET) * embedder.expand(0, 1)).sum(1);
+        let input_embedding = (input_one_hot.expand(2, TARGET) * embedder.expand(0, 1)).sum(1);
         let mut loss = input_embedding.sum(0);
         let mut weights = vec![embedder.id];
 

--- a/crates/luminal_cuda/src/binary.rs
+++ b/crates/luminal_cuda/src/binary.rs
@@ -407,9 +407,9 @@ mod tests {
         let input_one_hot = input
             .graph()
             .arange(CLASSES)
-            .equals(input.expand(0, CLASSES));
-        let input_embedding = (input_one_hot.expand(1, TARGET) * embedder).sum_reduce(0);
-        let mut loss = input_embedding.sum_reduce(0);
+            .eq(input.expand(0, CLASSES));
+        let input_embedding = (input_one_hot.expand(1, TARGET) * embedder).sum(0);
+        let mut loss = input_embedding.sum(0);
         let mut weights = vec![embedder.id];
 
         cx.compile(
@@ -431,10 +431,10 @@ mod tests {
             .graph()
             .arange(CLASSES)
             .expand(0, 1)
-            .equals(input.expand(1, CLASSES));
+            .eq(input.expand(1, CLASSES));
         let input_embedding =
-            (input_one_hot.expand(2, TARGET) * embedder.expand(0, 1)).sum_reduce(1);
-        let mut loss = input_embedding.sum_reduce(0);
+            (input_one_hot.expand(2, TARGET) * embedder.expand(0, 1)).sum(1);
+        let mut loss = input_embedding.sum(0);
         let mut weights = vec![embedder.id];
 
         cx.compile(

--- a/crates/luminal_cuda/src/elementwise_fusion.rs
+++ b/crates/luminal_cuda/src/elementwise_fusion.rs
@@ -566,7 +566,7 @@ mod tests {
         let a = cx.named_tensor("a", 10).set(random_vec(10)).keep();
         let b = cx.named_tensor("b", 10).set(random_vec(10)).keep();
         let d = cx.named_tensor("d", 10).set(random_vec(10)).keep();
-        let mut out = ((a.exp2() - b.sin()).sin() * 3.4).less_than(d).retrieve();
+        let mut out = ((a.exp2() - b.sin()).sin() * 3.4).lt(d).retrieve();
 
         cx.execute();
         let unopt_out = out.data();

--- a/crates/luminal_cuda/src/tests/fp16.rs
+++ b/crates/luminal_cuda/src/tests/fp16.rs
@@ -9,12 +9,12 @@ luminal::test_imports!();
 
 unary_test!(|a| a.sin(), |a| a.sin(), test_sin, f16);
 unary_test!(|a| a.sqrt(), |a| a.sqrt(), test_sqrt, f16);
-unary_test!(|a| a.recip(), |a| a.recip(), test_recip, f16);
+unary_test!(|a| a.reciprocal(), |a| a.reciprocal(), test_reciprocal, f16);
 unary_test!(|a| a * a, |a| a.clone() * a, test_square, f16);
-unary_test!(|a| a.ln(), |a| a.ln(), test_ln, f16);
+unary_test!(|a| a.log(), |a| a.log(), test_log, f16);
 unary_test!(
     |a| a.log2(),
-    |a| (a.to_dtype::<f32>().ln() / 2_f32.ln()).to_dtype::<f16>(),
+    |a| (a.to_dtype::<f32>().log() / 2_f32.ln()).to_dtype::<f16>(),
     test_log2,
     f16
 );
@@ -110,13 +110,13 @@ fn test_constant() {
 // Reduction op tests
 
 #[test]
-fn test_sum_reduce() {
+fn test_sum() {
     let data = random_vec(40960);
     let mut cx = Graph::new();
     let a = cx.tensor((1, 10, 4096)).set(data.clone());
-    let mut b = a.sum_reduce(2).retrieve();
-    let mut c = a.sum_reduce(1).retrieve();
-    let mut d = a.sum_reduce(0).retrieve();
+    let mut b = a.sum(2).retrieve();
+    let mut c = a.sum(1).retrieve();
+    let mut d = a.sum(0).retrieve();
 
     cx.compile(CudaCompiler::<f16>::default(), (&mut b, &mut c, &mut d));
     cx.execute();
@@ -134,11 +134,11 @@ fn test_sum_reduce() {
 }
 
 #[test]
-fn test_sum_reduce2() {
+fn test_sum2() {
     let mut cx = Graph::new();
     let data = random_vec(32 * 10 * 10 * 128);
     let a = cx.tensor((1, 32, 10, 10, 128)).set(data.clone());
-    let mut d = a.sum_reduce(2).retrieve();
+    let mut d = a.sum(2).retrieve();
 
     cx.compile(CudaCompiler::<f16>::default(), &mut d);
     cx.execute();
@@ -162,13 +162,13 @@ fn test_sum_reduce2() {
 }
 
 #[test]
-fn test_max_reduce() {
+fn test_max() {
     let data = random_vec(40960);
     let mut cx = Graph::new();
     let a = cx.tensor((1, 10, 4096)).set(data.clone());
-    let mut b = a.max_reduce(2).retrieve();
-    let mut c = a.max_reduce(1).retrieve();
-    let mut d = a.max_reduce(0).retrieve();
+    let mut b = a.max(2).retrieve();
+    let mut c = a.max(1).retrieve();
+    let mut d = a.max(0).retrieve();
 
     cx.compile(CudaCompiler::<f16>::default(), (&mut b, &mut c, &mut d));
     cx.execute();
@@ -186,13 +186,13 @@ fn test_max_reduce() {
 }
 
 #[test]
-fn test_mean_reduce() {
+fn test_mean() {
     let data = random_vec(40960);
     let mut cx = Graph::new();
     let a = cx.tensor((1, 10, 4096)).set(data.clone());
-    let mut b = a.mean_reduce(2).retrieve();
-    let mut c = a.mean_reduce(1).retrieve();
-    let mut d = a.mean_reduce(0).retrieve();
+    let mut b = a.mean(2).retrieve();
+    let mut c = a.mean(1).retrieve();
+    let mut d = a.mean(0).retrieve();
 
     cx.compile(CudaCompiler::<f16>::default(), (&mut b, &mut c, &mut d));
     cx.execute();

--- a/crates/luminal_cuda/src/tests/fp32.rs
+++ b/crates/luminal_cuda/src/tests/fp32.rs
@@ -9,10 +9,10 @@ luminal::test_imports!();
 
 unary_test!(|a| a.sin(), |a| a.sin(), test_sin, f32);
 unary_test!(|a| a.sqrt(), |a| a.sqrt(), test_sqrt, f32);
-unary_test!(|a| a.recip(), |a| a.recip(), test_recip, f32);
+unary_test!(|a| a.reciprocal(), |a| a.reciprocal(), test_reciprocal, f32);
 unary_test!(|a| a * a, |a| a.clone() * a, test_square, f32);
-unary_test!(|a| a.ln(), |a| a.ln(), test_ln, f32);
-unary_test!(|a| a.log2(), |a| a.ln() / 2_f32.ln(), test_log2, f32);
+unary_test!(|a| a.log(), |a| a.log(), test_log, f32);
+unary_test!(|a| a.log2(), |a| a.log() / 2_f32.ln(), test_log2, f32);
 unary_test!(|a| a.exp2(), |a| (a * 2_f32.ln()).exp(), test_exp2, f32);
 unary_test!(
     |a| a.softmax(0),
@@ -59,14 +59,14 @@ fn test_contiguous() {
 // Reduction op tests
 
 #[test]
-fn test_sum_reduce() {
+fn test_sum() {
     let mut cx = Graph::new();
     let data = random_vec(4 * 4096);
     let a = cx.tensor((1, 4, 4096));
     a.set(data.clone());
-    let mut b = a.sum_reduce(1).retrieve();
-    let mut c = a.sum_reduce(0).retrieve();
-    let mut d = a.sum_reduce(2).retrieve();
+    let mut b = a.sum(1).retrieve();
+    let mut c = a.sum(0).retrieve();
+    let mut d = a.sum(2).retrieve();
 
     cx.compile(CudaCompiler::<f32>::default(), (&mut b, &mut c, &mut d));
     cx.execute();
@@ -83,14 +83,14 @@ fn test_sum_reduce() {
 }
 
 #[test]
-fn test_max_reduce() {
+fn test_max() {
     let mut cx = Graph::new();
     let data = random_vec(12);
     let a = cx.tensor((2, 2, 3));
     a.set(data.clone());
-    let mut b = a.max_reduce(1).retrieve();
-    let mut c = a.max_reduce(0).retrieve();
-    let mut d = a.max_reduce(2).retrieve();
+    let mut b = a.max(1).retrieve();
+    let mut c = a.max(0).retrieve();
+    let mut d = a.max(2).retrieve();
 
     cx.compile(CudaCompiler::<f32>::default(), (&mut b, &mut c, &mut d));
     cx.execute();
@@ -107,11 +107,11 @@ fn test_max_reduce() {
 }
 
 #[test]
-fn test_mean_reduce() {
+fn test_mean() {
     let data = random_vec(40960);
     let mut cx = Graph::new();
     let a = cx.tensor((1, 10, 4096)).set(data.clone());
-    let mut b = a.mean_reduce(2).retrieve();
+    let mut b = a.mean(2).retrieve();
 
     cx.compile(CudaCompiler::<f32>::default(), &mut b);
     cx.execute();

--- a/crates/luminal_metal/src/elementwise_fusion.rs
+++ b/crates/luminal_metal/src/elementwise_fusion.rs
@@ -697,7 +697,7 @@ mod tests {
         let a = cx.named_tensor("a", 10).set(random_vec(10)).keep();
         let b = cx.named_tensor("b", 10).set(random_vec(10)).keep();
         let d = cx.named_tensor("d", 10).set(random_vec(10)).keep();
-        let mut out = ((a.exp2() - b.sin()).sin() * 3.4).less_than(d).retrieve();
+        let mut out = ((a.exp2() - b.sin()).sin() * 3.4).lt(d).retrieve();
 
         cx.execute();
         let unopt_out = out.data();
@@ -821,7 +821,7 @@ mod tests {
             .set(random_vec_rng(BATCH * N_HEADS * SEQ * HEAD_DIM, &mut rng))
             .keep();
         let freqs = (cx.arange(HEAD_DIM / 2) * 2.0) / (HEAD_DIM as f32);
-        let freqs = 1000000_f32.pow(freqs).recip();
+        let freqs = 1000000_f32.pow(freqs).reciprocal();
         let pos = cx.arange(SEQ) + 0;
         let emb = pos.expand(1, 1).matmul(freqs.expand(0, SEQ));
         // Split input into evens and odds

--- a/crates/luminal_metal/src/storage_buffer.rs
+++ b/crates/luminal_metal/src/storage_buffer.rs
@@ -393,7 +393,7 @@ fn test_shared_buffers() {
     let a = cx.tensor(5).set(random_vec(5)).keep();
     let b = a.exp2();
     let c = a.log2() * b;
-    let d = b.recip();
+    let d = b.reciprocal();
     let mut e = (c + d).retrieve();
 
     cx.execute();

--- a/crates/luminal_metal/src/tests/fp16.rs
+++ b/crates/luminal_metal/src/tests/fp16.rs
@@ -10,12 +10,12 @@ luminal::test_imports!();
 
 unary_test!(|a| a.sin(), |a| a.sin(), test_sin, f16);
 unary_test!(|a| a.sqrt(), |a| a.sqrt(), test_sqrt, f16);
-unary_test!(|a| a.reciprocal(), |a| a.reciprocal(), test_reciprocal, f16);
+unary_test!(|a| a.reciprocal(), |a| a.recip(), test_reciprocal, f16);
 unary_test!(|a| a * a, |a| a.clone() * a, test_square, f16);
-unary_test!(|a| a.log(), |a| a.log(), test_log, f16);
+unary_test!(|a| a.log(), |a| a.ln(), test_log, f16);
 unary_test!(
     |a| a.log2(),
-    |a| (a.to_dtype::<f32>().log() / 2_f32.ln()).to_dtype::<f16>(),
+    |a| (a.to_dtype::<f32>().ln() / 2_f32.ln()).to_dtype::<f16>(),
     test_log2,
     f16
 );
@@ -40,8 +40,8 @@ binary_test!(|a, b| a + b, |a, b| a + b, test_add, f16);
 binary_test!(|a, b| a - b, |a, b| a - b, test_sub, f16);
 binary_test!(|a, b| a * b, |a, b| a * b, test_mul, f16);
 binary_test!(|a, b| a / b, |a, b| a / b, test_div, f16);
-binary_test!(|a, b| a.max(b), |a, b| a.maximum(b), test_max, f16);
-binary_test!(|a, b| a.min(b), |a, b| a.minimum(b), test_min, f16);
+binary_test!(|a, b| a.maximum(b), |a, b| a.maximum(b), test_max, f16);
+binary_test!(|a, b| a.minimum(b), |a, b| a.minimum(b), test_min, f16);
 binary_test!(
     |a, b| a % b,
     |a, b| (a.clone().to_dtype::<f32>()

--- a/crates/luminal_metal/src/tests/fp16.rs
+++ b/crates/luminal_metal/src/tests/fp16.rs
@@ -10,12 +10,12 @@ luminal::test_imports!();
 
 unary_test!(|a| a.sin(), |a| a.sin(), test_sin, f16);
 unary_test!(|a| a.sqrt(), |a| a.sqrt(), test_sqrt, f16);
-unary_test!(|a| a.recip(), |a| a.recip(), test_recip, f16);
+unary_test!(|a| a.reciprocal(), |a| a.reciprocal(), test_reciprocal, f16);
 unary_test!(|a| a * a, |a| a.clone() * a, test_square, f16);
-unary_test!(|a| a.ln(), |a| a.ln(), test_ln, f16);
+unary_test!(|a| a.log(), |a| a.log(), test_log, f16);
 unary_test!(
     |a| a.log2(),
-    |a| (a.to_dtype::<f32>().ln() / 2_f32.ln()).to_dtype::<f16>(),
+    |a| (a.to_dtype::<f32>().log() / 2_f32.ln()).to_dtype::<f16>(),
     test_log2,
     f16
 );
@@ -111,13 +111,13 @@ fn test_constant() {
 // Reduction op tests
 
 #[test]
-fn test_sum_reduce() {
+fn test_sum() {
     let data = random_vec(40960);
     let mut cx = Graph::new();
     let a = cx.tensor((1, 10, 4096)).set(data.clone());
-    let mut b = a.sum_reduce(2).retrieve();
-    let mut c = a.sum_reduce(1).retrieve();
-    let mut d = a.sum_reduce(0).retrieve();
+    let mut b = a.sum(2).retrieve();
+    let mut c = a.sum(1).retrieve();
+    let mut d = a.sum(0).retrieve();
 
     cx.compile(MetalCompiler::<f16>::default(), (&mut b, &mut c, &mut d));
     cx.execute();
@@ -135,11 +135,11 @@ fn test_sum_reduce() {
 }
 
 #[test]
-fn test_sum_reduce2() {
+fn test_sum2() {
     let mut cx = Graph::new();
     let data = random_vec(32 * 10 * 10 * 128);
     let a = cx.tensor((1, 32, 10, 10, 128)).set(data.clone());
-    let mut d = a.sum_reduce(2).retrieve();
+    let mut d = a.sum(2).retrieve();
 
     cx.compile(MetalCompiler::<f16>::default(), &mut d);
     cx.execute();
@@ -163,13 +163,13 @@ fn test_sum_reduce2() {
 }
 
 #[test]
-fn test_max_reduce() {
+fn test_max() {
     let data = random_vec(40960);
     let mut cx = Graph::new();
     let a = cx.tensor((1, 10, 4096)).set(data.clone());
-    let mut b = a.max_reduce(2).retrieve();
-    let mut c = a.max_reduce(1).retrieve();
-    let mut d = a.max_reduce(0).retrieve();
+    let mut b = a.max(2).retrieve();
+    let mut c = a.max(1).retrieve();
+    let mut d = a.max(0).retrieve();
 
     cx.compile(MetalCompiler::<f16>::default(), (&mut b, &mut c, &mut d));
     cx.execute();
@@ -187,13 +187,13 @@ fn test_max_reduce() {
 }
 
 #[test]
-fn test_mean_reduce() {
+fn test_mean() {
     let data = random_vec(40960);
     let mut cx = Graph::new();
     let a = cx.tensor((1, 10, 4096)).set(data.clone());
-    let mut b = a.mean_reduce(2).retrieve();
-    let mut c = a.mean_reduce(1).retrieve();
-    let mut d = a.mean_reduce(0).retrieve();
+    let mut b = a.mean(2).retrieve();
+    let mut c = a.mean(1).retrieve();
+    let mut d = a.mean(0).retrieve();
 
     cx.compile(MetalCompiler::<f16>::default(), (&mut b, &mut c, &mut d));
     cx.execute();

--- a/crates/luminal_metal/src/tests/fp32.rs
+++ b/crates/luminal_metal/src/tests/fp32.rs
@@ -9,10 +9,10 @@ luminal::test_imports!();
 
 unary_test!(|a| a.sin(), |a| a.sin(), test_sin, f32);
 unary_test!(|a| a.sqrt(), |a| a.sqrt(), test_sqrt, f32);
-unary_test!(|a| a.reciprocal(), |a| a.reciprocal(), test_reciprocal, f32);
+unary_test!(|a| a.reciprocal(), |a| a.recip(), test_reciprocal, f32);
 unary_test!(|a| a * a, |a| a.clone() * a, test_square, f32);
-unary_test!(|a| a.log(), |a| a.log(), test_log, f32);
-unary_test!(|a| a.log2(), |a| a.log() / 2_f32.ln(), test_log2, f32);
+unary_test!(|a| a.log(), |a| a.ln(), test_log, f32);
+unary_test!(|a| a.log2(), |a| a.ln() / 2_f32.ln(), test_log2, f32);
 unary_test!(|a| a.exp2(), |a| (a * 2_f32.ln()).exp(), test_exp2, f32);
 unary_test!(
     |a| a.softmax(0),
@@ -37,8 +37,8 @@ binary_test!(
     test_mod,
     f32
 );
-binary_test!(|a, b| a.min(b), |a, b| a.minimum(b), test_min, f32);
-binary_test!(|a, b| a.max(b), |a, b| a.maximum(b), test_max, f32);
+binary_test!(|a, b| a.minimum(b), |a, b| a.minimum(b), test_min, f32);
+binary_test!(|a, b| a.maximum(b), |a, b| a.maximum(b), test_max, f32);
 
 #[test]
 fn test_contiguous() {

--- a/crates/luminal_metal/src/tests/fp32.rs
+++ b/crates/luminal_metal/src/tests/fp32.rs
@@ -9,10 +9,10 @@ luminal::test_imports!();
 
 unary_test!(|a| a.sin(), |a| a.sin(), test_sin, f32);
 unary_test!(|a| a.sqrt(), |a| a.sqrt(), test_sqrt, f32);
-unary_test!(|a| a.recip(), |a| a.recip(), test_recip, f32);
+unary_test!(|a| a.reciprocal(), |a| a.reciprocal(), test_reciprocal, f32);
 unary_test!(|a| a * a, |a| a.clone() * a, test_square, f32);
-unary_test!(|a| a.ln(), |a| a.ln(), test_ln, f32);
-unary_test!(|a| a.log2(), |a| a.ln() / 2_f32.ln(), test_log2, f32);
+unary_test!(|a| a.log(), |a| a.log(), test_log, f32);
+unary_test!(|a| a.log2(), |a| a.log() / 2_f32.ln(), test_log2, f32);
 unary_test!(|a| a.exp2(), |a| (a * 2_f32.ln()).exp(), test_exp2, f32);
 unary_test!(
     |a| a.softmax(0),
@@ -59,14 +59,14 @@ fn test_contiguous() {
 // Reduction op tests
 
 #[test]
-fn test_sum_reduce() {
+fn test_sum() {
     let mut cx = Graph::new();
     let data = random_vec(4 * 4096);
     let a = cx.tensor((1, 4, 4096));
     a.set(data.clone());
-    let mut b = a.sum_reduce(1).retrieve();
-    let mut c = a.sum_reduce(0).retrieve();
-    let mut d = a.sum_reduce(2).retrieve();
+    let mut b = a.sum(1).retrieve();
+    let mut c = a.sum(0).retrieve();
+    let mut d = a.sum(2).retrieve();
 
     cx.compile(MetalCompiler::<f32>::default(), (&mut b, &mut c, &mut d));
     cx.execute();
@@ -83,14 +83,14 @@ fn test_sum_reduce() {
 }
 
 #[test]
-fn test_max_reduce() {
+fn test_max() {
     let mut cx = Graph::new();
     let data = random_vec(12);
     let a = cx.tensor((2, 2, 3));
     a.set(data.clone());
-    let mut b = a.max_reduce(1).retrieve();
-    let mut c = a.max_reduce(0).retrieve();
-    let mut d = a.max_reduce(2).retrieve();
+    let mut b = a.max(1).retrieve();
+    let mut c = a.max(0).retrieve();
+    let mut d = a.max(2).retrieve();
 
     cx.compile(MetalCompiler::<f32>::default(), (&mut b, &mut c, &mut d));
     cx.execute();
@@ -107,11 +107,11 @@ fn test_max_reduce() {
 }
 
 #[test]
-fn test_mean_reduce() {
+fn test_mean() {
     let data = random_vec(40960);
     let mut cx = Graph::new();
     let a = cx.tensor((1, 10, 4096)).set(data.clone());
-    let mut b = a.mean_reduce(2).retrieve();
+    let mut b = a.mean(2).retrieve();
 
     cx.compile(MetalCompiler::<f32>::default(), &mut b);
     cx.execute();

--- a/crates/luminal_nn/src/pooling.rs
+++ b/crates/luminal_nn/src/pooling.rs
@@ -41,7 +41,7 @@ impl AvgPool2D {
                 self.kernel.0 * self.kernel.1,
                 dimx_out * dimy_out,
             ))
-            .mean_reduce(2) // Average over the kernel dimension
+            .mean(2) // Average over the kernel dimension
             .reshape((batch, ch_in, dimx_out, dimy_out));
 
         if expanded {
@@ -93,7 +93,7 @@ impl AdaptiveAvgPool2D {
             .pool_last_dim(kernel_h, stride_h, 1)
             .permute((0, 1, 5, 3, 4, 2))
             .reshape((batch, ch, kernel_h * kernel_w, h_out * w_out))
-            .mean_reduce(2)
+            .mean(2)
             .reshape((batch, ch, h_out, w_out));
 
         // Remove batch dim if it was originally absent

--- a/crates/luminal_training/src/autograd.rs
+++ b/crates/luminal_training/src/autograd.rs
@@ -140,7 +140,7 @@ impl Compiler for Autograd {
                         .shape
                         .expand(op.0, inps[0].shape.dims[inps[0].shape.indexes[op.0]]);
                     let reduced = GraphTensor::from_id(fwd_node, prev_grad.shape, graph_ref);
-                    let grad = inps[0].equals(reduced) * prev_grad;
+                    let grad = inps[0].eq(reduced) * prev_grad;
                     add_grad(grad, inps[0], graph, &mut grads);
                 }
             } else if op == TypeId::of::<Contiguous>() {
@@ -250,7 +250,7 @@ mod tests {
     fn test_autograd_max_reduce() {
         let mut cx = Graph::new();
         let a = cx.named_tensor("Input", 2).set([10., 5.]);
-        let b = a.max_reduce(0);
+        let b = a.max(0);
 
         let grads = cx.compile(Autograd::new(a, b), ());
         cx.keep_tensors(&grads);
@@ -269,7 +269,7 @@ mod tests {
         let mut cx = Graph::new();
         let a = cx.named_tensor("A", (2, 2)).set([[2., 4.], [3., 1.]]);
         let input = cx.named_tensor("Input", 2).set([10., 5.]);
-        let output = (input.matmul(a)).sum_reduce(0);
+        let output = (input.matmul(a)).sum(0);
 
         let grads = cx.compile(Autograd::new(a, output), ());
         cx.keep_tensors(&grads);
@@ -295,7 +295,7 @@ mod tests {
         model.0.weight.set([[2., 4.], [3., 1.]]);
         model.2.weight.set([[6.], [5.]]);
         let input = cx.named_tensor("Input", 2).set([10., 5.]);
-        let output = model.forward(input).sum_reduce(0);
+        let output = model.forward(input).sum(0);
 
         let mut grads = cx.compile(Autograd::new(params(model), output), ());
         cx.keep_tensors(&grads);
@@ -328,7 +328,7 @@ mod tests {
     fn test_autograd_layer_norm() {
         let mut cx = Graph::new();
         let a = cx.tensor(3).set([-1., 2., 3.]);
-        let mut b = a.layer_norm(0, 1e-5).max_reduce(0).retrieve();
+        let mut b = a.layer_norm(0, 1e-5).max(0).retrieve();
 
         let grads = cx.compile(Autograd::new(a, b), &mut b);
         cx.keep_tensors(&grads);
@@ -347,7 +347,7 @@ mod tests {
     fn test_autograd_softmax() {
         let mut cx = Graph::new();
         let a = cx.tensor(3).set([-1., 2., 3.]);
-        let mut b = a.softmax(0).max_reduce(0).retrieve();
+        let mut b = a.softmax(0).max(0).retrieve();
 
         let mut grads = cx.compile(Autograd::new(a, b), &mut b);
         cx.keep_tensors(&grads);

--- a/crates/luminal_training/src/loss.rs
+++ b/crates/luminal_training/src/loss.rs
@@ -6,7 +6,7 @@ use luminal::prelude::*;
 pub fn mse_loss(prediction: GraphTensor, target: GraphTensor) -> GraphTensor {
     (prediction - target)
         .square()
-        .mean_reduce(prediction.shape.all_axes())
+        .mean(prediction.shape.all_axes())
 }
 
 /// [Root Mean square error](https://en.wikipedia.org/wiki/Root-mean-square_deviation).
@@ -22,7 +22,7 @@ pub fn rmse_loss(prediction: GraphTensor, target: GraphTensor) -> GraphTensor {
 pub fn mae_loss(prediction: GraphTensor, target: GraphTensor) -> GraphTensor {
     (prediction - target)
         .abs()
-        .mean_reduce(prediction.shape.all_axes())
+        .mean(prediction.shape.all_axes())
 }
 
 /// [Huber Loss](https://en.wikipedia.org/wiki/Huber_loss)
@@ -41,10 +41,10 @@ pub fn huber_loss(
     let abs_error = (prediction - target).abs();
     let delta_tensor = prediction.graph().constant(delta);
     let huber_error = (0.5 * (prediction - target).square())
-        * abs_error.less_than(delta_tensor.expand_to(abs_error.shape))
+        * abs_error.lt(delta_tensor.expand_to(abs_error.shape))
         + (delta * (abs_error - 0.5 * delta))
-            * abs_error.greater_than_equal(delta_tensor.expand_to(abs_error.shape));
-    huber_error.mean_reduce(huber_error.shape.all_axes())
+            * abs_error.ge(delta_tensor.expand_to(abs_error.shape));
+    huber_error.mean(huber_error.shape.all_axes())
 }
 
 /// Smooth l1 loss (closely related to [Huber Loss](https://en.wikipedia.org/wiki/Huber_loss))
@@ -81,7 +81,7 @@ pub fn cross_entropy_with_logits_loss(
             .graph()
             .constant(*logits.shape.dims().last().unwrap());
     let probs = logits.log_softmax(logits.shape.last_axis());
-    (-(probs * target_probabilities).mean_reduce(target_probabilities.shape.all_axes()))
+    (-(probs * target_probabilities).mean(target_probabilities.shape.all_axes()))
         / inv_last_axis_numel
 }
 
@@ -104,8 +104,8 @@ pub fn kl_div_with_logits_loss(
             .graph()
             .constant(*logits.shape.dims().last().unwrap());
     let probs = logits.log_softmax(logits.shape.last_axis());
-    (-((probs - target_probabilities.ln()) * target_probabilities)
-        .mean_reduce(target_probabilities.shape.all_axes()))
+    (-((probs - target_probabilities.log()) * target_probabilities)
+        .mean(target_probabilities.shape.all_axes()))
         / inv_last_axis_numel
 }
 
@@ -122,6 +122,6 @@ pub fn binary_cross_entropy_with_logits_loss(
     logits: GraphTensor,
     target_probabilities: GraphTensor,
 ) -> GraphTensor {
-    let bce = (1.0 - target_probabilities) * logits + (1.0 + (-logits).exp()).ln();
-    bce.mean_reduce(bce.shape.all_axes())
+    let bce = (1.0 - target_probabilities) * logits + (1.0 + (-logits).exp()).log();
+    bce.mean(bce.shape.all_axes())
 }

--- a/examples/llama/src/model.rs
+++ b/examples/llama/src/model.rs
@@ -54,7 +54,7 @@ fn apply_rotary_embeddings_ggml(input: GraphTensor, prev_seq: Expression) -> Gra
     let (batch, n_heads, seq, head_dim) = input.dims4();
     // Get freqs
     let freqs = (input.graph().arange(head_dim / 2) * 2.0) / (head_dim.to_usize().unwrap() as f32);
-    let inv_freqs = 500_000_f32.pow(freqs).recip();
+    let inv_freqs = 500_000_f32.pow(freqs).reciprocal();
     let pos = input.graph().arange(seq) + prev_seq;
     let emb = pos.expand(1, 1).matmul(inv_freqs.expand(0, 1));
 

--- a/examples/llama_server/src/llama/model.rs
+++ b/examples/llama_server/src/llama/model.rs
@@ -54,7 +54,7 @@ fn apply_rotary_embeddings_ggml(input: GraphTensor, prev_seq: Expression) -> Gra
     let (batch, n_heads, seq, head_dim) = input.dims4();
     // Get freqs
     let freqs = (input.graph().arange(head_dim / 2) * 2.0) / (head_dim.to_usize().unwrap() as f32);
-    let inv_freqs = 500_000_f32.pow(freqs).recip();
+    let inv_freqs = 500_000_f32.pow(freqs).reciprocal();
     let pos = input.graph().arange(seq) + prev_seq;
     let emb = pos.expand(1, 1).matmul(inv_freqs.expand(0, 1));
 

--- a/examples/phi/src/model.rs
+++ b/examples/phi/src/model.rs
@@ -52,7 +52,7 @@ fn apply_rotary_embeddings_ggml(input: GraphTensor, prev_seq: Expression) -> Gra
     let (batch, n_heads, seq, head_dim) = input.dims4();
     // Get freqs
     let freqs = (input.graph().arange(head_dim / 2) * 2.0) / (head_dim.to_usize().unwrap() as f32);
-    let inv_freqs = 10_000_f32.pow(freqs).recip();
+    let inv_freqs = 10_000_f32.pow(freqs).reciprocal();
     let pos = input.graph().arange(seq) + prev_seq;
     let emb = pos.expand(1, 1).matmul(inv_freqs.expand(0, 1));
 

--- a/examples/qwen/src/model.rs
+++ b/examples/qwen/src/model.rs
@@ -54,7 +54,9 @@ fn apply_rotary_embeddings(input: GraphTensor, prev_seq: Expression) -> GraphTen
     let (b, h, s, d) = input.dims4();
 
     // Get freqs
-    let inv_freq = ROPE_THETA.pow(input.graph().arange(d / 2) * 2 / d).reciprocal(); // [d / 2]
+    let inv_freq = ROPE_THETA
+        .pow(input.graph().arange(d / 2) * 2 / d)
+        .reciprocal(); // [d / 2]
     let pos = input.graph().arange(s) + prev_seq; // [s]
     let freqs = pos.expand(1, 1).matmul(inv_freq.expand(0, 1)); // [s, d / 2]
     let freqs = freqs

--- a/examples/qwen/src/model.rs
+++ b/examples/qwen/src/model.rs
@@ -54,7 +54,7 @@ fn apply_rotary_embeddings(input: GraphTensor, prev_seq: Expression) -> GraphTen
     let (b, h, s, d) = input.dims4();
 
     // Get freqs
-    let inv_freq = ROPE_THETA.pow(input.graph().arange(d / 2) * 2 / d).recip(); // [d / 2]
+    let inv_freq = ROPE_THETA.pow(input.graph().arange(d / 2) * 2 / d).reciprocal(); // [d / 2]
     let pos = input.graph().arange(s) + prev_seq; // [s]
     let freqs = pos.expand(1, 1).matmul(inv_freq.expand(0, 1)); // [s, d / 2]
     let freqs = freqs

--- a/examples/yolo_v8/src/model.rs
+++ b/examples/yolo_v8/src/model.rs
@@ -214,7 +214,7 @@ impl Module<GraphTensor> for SPPF {
                 (self.k / 2, self.k / 2),
             ))
             .pool_last_dim(self.k, 1, 1)
-            .max_reduce(4);
+            .max(4);
         let xs3 = xs2
             .pad((
                 (0, 0),
@@ -223,7 +223,7 @@ impl Module<GraphTensor> for SPPF {
                 (self.k / 2, self.k / 2),
             ))
             .pool_last_dim(self.k, 1, 1)
-            .max_reduce(4);
+            .max(4);
         let xs4 = xs3
             .pad((
                 (0, 0),
@@ -232,7 +232,7 @@ impl Module<GraphTensor> for SPPF {
                 (self.k / 2, self.k / 2),
             ))
             .pool_last_dim(self.k, 1, 1)
-            .max_reduce(4);
+            .max(4);
         self.cv2.forward(
             xs.concat_along(xs2, 1)
                 .concat_along(xs3, 1)

--- a/src/hl_ops/binary.rs
+++ b/src/hl_ops/binary.rs
@@ -106,7 +106,7 @@ impl Div<GraphTensor> for GraphTensor {
     type Output = GraphTensor;
 
     fn div(self, rhs: GraphTensor) -> Self::Output {
-        self * rhs.recip()
+        self * rhs.reciprocal()
     }
 }
 
@@ -115,7 +115,7 @@ impl Div<GraphTensor> for f32 {
     type Output = GraphTensor;
 
     fn div(self, rhs: GraphTensor) -> Self::Output {
-        self * rhs.recip()
+        self * rhs.reciprocal()
     }
 }
 
@@ -229,7 +229,7 @@ impl<S: Into<Expression>> Rem<S> for GraphTensor {
 
 // Comparisons (based on https://github.com/tinygrad/tinygrad/blob/3e0c2d256fe9f4f5f85cd3e4d8733a51d7b4a984/tinygrad/tensor.py#L653)
 impl GraphTensor {
-    pub fn less_than(self, rhs: GraphTensor) -> GraphTensor {
+    pub fn lt(self, rhs: GraphTensor) -> GraphTensor {
         assert_eq!(self.dims(), rhs.dims(), "Dims must match to lt tensors.");
         let new_id = self
             .graph()
@@ -240,24 +240,24 @@ impl GraphTensor {
         GraphTensor::from_id(new_id, self.shape.contiguous(), self.graph_ref)
     }
 
-    pub fn greater_than(self, rhs: GraphTensor) -> GraphTensor {
-        rhs.less_than(self)
+    pub fn gt(self, rhs: GraphTensor) -> GraphTensor {
+        rhs.lt(self)
     }
 
-    pub fn less_than_equal(self, rhs: GraphTensor) -> GraphTensor {
-        -self.greater_than(rhs) + 1.0
+    pub fn le(self, rhs: GraphTensor) -> GraphTensor {
+        -self.gt(rhs) + 1.0
     }
 
-    pub fn greater_than_equal(self, rhs: GraphTensor) -> GraphTensor {
-        -self.less_than(rhs) + 1.0
+    pub fn ge(self, rhs: GraphTensor) -> GraphTensor {
+        -self.lt(rhs) + 1.0
     }
 
-    pub fn not_equals(self, rhs: GraphTensor) -> GraphTensor {
-        self.less_than(rhs) + self.greater_than(rhs)
+    pub fn ne(self, rhs: GraphTensor) -> GraphTensor {
+        self.lt(rhs) + self.gt(rhs)
     }
 
-    pub fn equals(self, rhs: GraphTensor) -> GraphTensor {
-        -self.not_equals(rhs) + 1.0
+    pub fn eq(self, rhs: GraphTensor) -> GraphTensor {
+        -self.ne(rhs) + 1.0
     }
 
     /// Raise the tensor to a power
@@ -266,35 +266,35 @@ impl GraphTensor {
         Self: Mul<T, Output = Self>,
     {
         // Approximate, see full impl here: https://github.com/tinygrad/tinygrad/blob/a32c67760140dd26b60d7932268f2e62e96a66e0/tinygrad/tensor.py#L568
-        self.abs().ln().mul(e).exp()
+        self.abs().log().mul(e).exp()
     }
 }
 
-// Clipping ops (min, max, clip)
+// Clipping ops (minimum, maximum, clip)
 impl GraphTensor {
     /// Take the elementwise maximum of two tensors
-    pub fn max(self, rhs: GraphTensor) -> GraphTensor {
-        (self.less_than(rhs) * rhs) + (rhs.less_than_equal(self) * self)
+    pub fn maximum(self, rhs: GraphTensor) -> GraphTensor {
+        (self.lt(rhs) * rhs) + (rhs.le(self) * self)
     }
 
     /// Take the elementwise maximum of a tensor and a float
-    pub fn max_f32(self, rhs: f32) -> GraphTensor {
-        self.max(self.graph().constant(rhs).expand_to(self.shape))
+    pub fn maximum_f32(self, rhs: f32) -> GraphTensor {
+        self.maximum(self.graph().constant(rhs).expand_to(self.shape))
     }
 
     /// Take the elementwise minimum of two tensors
-    pub fn min(self, rhs: GraphTensor) -> GraphTensor {
-        -(-self).max(-rhs)
+    pub fn minimum(self, rhs: GraphTensor) -> GraphTensor {
+        -(-self).maximum(-rhs)
     }
 
     /// Take the elementwise minimum of a tensor and a float
-    pub fn min_f32(self, rhs: f32) -> GraphTensor {
-        -(-self).max_f32(-rhs)
+    pub fn minimum_f32(self, rhs: f32) -> GraphTensor {
+        -(-self).maximum_f32(-rhs)
     }
 
     /// Clip (clamp) a tensor into the range [`min`, `max`]
     pub fn clip(self, min: f32, max: f32) -> GraphTensor {
-        self.max_f32(min).min_f32(max)
+        self.maximum_f32(min).minimum_f32(max)
     }
 }
 

--- a/src/hl_ops/matmul.rs
+++ b/src/hl_ops/matmul.rs
@@ -13,7 +13,7 @@ impl GraphTensor {
             let mul = self.expand(1, n) * rhs.permute((1, 0)).expand(0, m);
 
             // Sum Reduce
-            let mut ret = mul.sum_reduce(2);
+            let mut ret = mul.sum(2);
             if vec {
                 ret = ret.reshape(ret.dims().last().unwrap());
             }
@@ -30,7 +30,7 @@ impl GraphTensor {
                 let mul = self.expand(2, d) * w.expand(0, a).expand(1, b);
 
                 // Sum Reduce
-                mul.sum_reduce(3)
+                mul.sum(3)
             } else if rhs.shape.len() == 3 {
                 // Reshape
                 let w = rhs.permute((0, 2, 1));
@@ -39,7 +39,7 @@ impl GraphTensor {
                 let mul = self.expand(2, d) * w.expand(1, b);
 
                 // Sum Reduce
-                mul.sum_reduce(3)
+                mul.sum(3)
             } else {
                 panic!(
                     "Can't matmul lhs {:?} and rhs {:?}",
@@ -58,7 +58,7 @@ impl GraphTensor {
                 let mul = self.expand(3, e) * rhs.expand(0, a).expand(1, b).expand(2, c);
 
                 // Sum Reduce
-                mul.sum_reduce(4)
+                mul.sum(4)
             } else if rhs.shape.len() == 4 {
                 // ABCDxABDE -> ABCE
                 let (_, _, _, e) = rhs.dims4();
@@ -69,7 +69,7 @@ impl GraphTensor {
                 let mul = self.expand(3, e) * rhs.expand(2, c);
 
                 // Sum Reduce
-                mul.sum_reduce(4)
+                mul.sum(4)
             } else {
                 panic!(
                     "Can't matmul lhs {:?} and rhs {:?}",
@@ -89,7 +89,7 @@ impl GraphTensor {
             let mul = s.expand(2, f) * w.expand(1, d);
 
             // Sum Reduce
-            mul.sum_reduce(3).reshape((a, b, c, d, f))
+            mul.sum(3).reshape((a, b, c, d, f))
         } else {
             panic!(
                 "Can't matmul lhs {:?} and rhs {:?}",
@@ -101,7 +101,7 @@ impl GraphTensor {
 
     /// Simple dot product of two vectors
     pub fn dot(self, rhs: GraphTensor) -> GraphTensor {
-        (self * rhs).sum_reduce(0)
+        (self * rhs).sum(0)
     }
 }
 

--- a/src/hl_ops/other.rs
+++ b/src/hl_ops/other.rs
@@ -57,7 +57,7 @@ impl GraphTensor {
 
     /// Cumulative product last dimension
     pub fn cumprod_last_dim(self) -> Self {
-        self.ln().cumsum_last_dim().exp()
+        self.log().cumsum_last_dim().exp()
     }
 }
 
@@ -109,7 +109,7 @@ impl Graph {
         let horizontal = self.arange(size).expand(0, size);
         let vertical = self.arange(size).expand(1, size);
 
-        (horizontal - (diagonal as f32 + 1.)).less_than(vertical)
+        (horizontal - (diagonal as f32 + 1.)).lt(vertical)
     }
 
     /// Upper right-hand triangle of 1s
@@ -120,7 +120,7 @@ impl Graph {
         let horizontal = self.arange(size).expand(0, size);
         let vertical = self.arange(size).expand(1, size);
 
-        (horizontal - (diagonal as f32 - 1.)).greater_than(vertical)
+        (horizontal - (diagonal as f32 - 1.)).gt(vertical)
     }
 }
 
@@ -133,8 +133,8 @@ impl GraphTensor {
             .graph()
             .arange(vocab)
             .expand(0, batch)
-            .equals(indexes.expand(1, vocab));
-        (one_hot.expand(2, dim) * self.expand(0, batch)).sum_reduce(1)
+            .eq(indexes.expand(1, vocab));
+        (one_hot.expand(2, dim) * self.expand(0, batch)).sum(1)
     }
 
     /// Print the value of this tensor when the graph is ran

--- a/src/hl_ops/reduction.rs
+++ b/src/hl_ops/reduction.rs
@@ -5,7 +5,7 @@ use crate::{
 
 impl GraphTensor {
     /// Reduce a dimension of the tensor by summing all elements along that axis.
-    pub fn sum_reduce(self, axes: impl ToAxes) -> GraphTensor {
+    pub fn sum(self, axes: impl ToAxes) -> GraphTensor {
         let (mut shape, mut id) = (self.shape, self.id);
         // Sum reduce each dimension
         for dim in axes.to_axes().into_iter().rev() {
@@ -20,7 +20,7 @@ impl GraphTensor {
     }
 
     /// Reduce a dimension of the tensor by taking the maximum of all elements along that axis.
-    pub fn max_reduce(self, axes: impl ToAxes) -> GraphTensor {
+    pub fn max(self, axes: impl ToAxes) -> GraphTensor {
         let (mut shape, mut id) = (self.shape, self.id);
         // Max reduce each dimension
         for dim in axes.to_axes().into_iter().rev() {
@@ -35,18 +35,18 @@ impl GraphTensor {
     }
 
     /// Reduce a dimension of the tensor by taking the mean of all elements along that axis.
-    pub fn mean_reduce(self, axes: impl ToAxes) -> GraphTensor {
+    pub fn mean(self, axes: impl ToAxes) -> GraphTensor {
         let reduced_elements = axes
             .to_axes()
             .into_iter()
             .map(|i| self.dims()[i])
             .product::<Expression>();
-        self.sum_reduce(axes) / reduced_elements
+        self.sum(axes) / reduced_elements
     }
 
     /// Reduce a dimension of the tensor by multiplying all elements along that axis.
-    pub fn prod_reduce(self, axes: impl ToAxes) -> GraphTensor {
-        self.ln().sum_reduce(axes).exp()
+    pub fn prod(self, axes: impl ToAxes) -> GraphTensor {
+        self.log().sum(axes).exp()
     }
 }
 
@@ -55,11 +55,11 @@ mod tests {
     crate::test_imports!();
 
     #[test]
-    fn test_sum_reduce() {
+    fn test_sum() {
         let mut cx = Graph::new();
         let a_data = random_vec(6);
         let a = cx.tensor((2, 3)).set(a_data.clone());
-        let b = a.sum_reduce(1).retrieve();
+        let b = a.sum(1).retrieve();
 
         cx.execute();
 
@@ -71,11 +71,11 @@ mod tests {
     }
 
     #[test]
-    fn test_max_reduce() {
+    fn test_max() {
         let mut cx = Graph::new();
         let a_data = random_vec(6);
         let a = cx.tensor((2, 3)).set(a_data.clone());
-        let b = a.max_reduce(1).retrieve();
+        let b = a.max(1).retrieve();
 
         cx.execute();
 
@@ -87,11 +87,11 @@ mod tests {
     }
 
     #[test]
-    fn test_mean_reduce() {
+    fn test_mean() {
         let mut cx = Graph::new();
         let a_data = random_vec(6);
         let a = cx.tensor((2, 3)).set(a_data.clone());
-        let b = a.mean_reduce(1).retrieve();
+        let b = a.mean(1).retrieve();
 
         cx.execute();
 

--- a/src/tests/test_prim.rs
+++ b/src/tests/test_prim.rs
@@ -97,10 +97,10 @@ fn test_exp2() {
 }
 
 #[test]
-fn test_recip() {
+fn test_reciprocal() {
     let mut cx = Graph::new();
     let a = cx.tensor(3).set([1., 2., 3.]);
-    let b = a.recip().retrieve();
+    let b = a.reciprocal().retrieve();
     cx.execute();
 
     let d_dev = Cpu::default();
@@ -227,7 +227,7 @@ fn test_max() {
     let mut cx = Graph::new();
     let a = cx.tensor(3).set([1., 0., 3.]);
     let b = cx.tensor(3).set([1., 2., -2.]);
-    let c = a.max(b).retrieve();
+    let c = a.maximum(b).retrieve();
     cx.execute();
 
     let d_dev = Cpu::default();
@@ -261,14 +261,14 @@ fn test_mod() {
 // Reduction op tests
 
 #[test]
-fn test_sum_reduce() {
+fn test_sum() {
     let mut cx = Graph::new();
     let a = cx
         .tensor((2, 2, 3))
         .set([[[1., 2., 3.], [1., 2., 3.]], [[1., 2., 3.], [1., 2., 3.]]]);
-    let b = a.sum_reduce(1).retrieve();
-    let c = a.sum_reduce(0).retrieve();
-    let d = a.sum_reduce(2).retrieve();
+    let b = a.sum(1).retrieve();
+    let c = a.sum(0).retrieve();
+    let d = a.sum(2).retrieve();
     cx.execute();
 
     let d_dev = Cpu::default();
@@ -283,13 +283,13 @@ fn test_sum_reduce() {
 }
 
 #[test]
-fn test_sum_reduce2() {
+fn test_sum2() {
     let mut cx = Graph::new();
     let a = cx.tensor((1, 2, 2, 3)).set([[
         [[34.4, -96.0, 144.0], [43.0, 560.0, 180.0]],
         [[39.6, -120.0, 180.0], [49.5, 700.0, 225.0]],
     ]]);
-    let b = a.sum_reduce(3).retrieve();
+    let b = a.sum(3).retrieve();
     cx.execute();
 
     let d_dev = Cpu::default();
@@ -308,9 +308,9 @@ fn test_max_reduce() {
     let a = cx
         .tensor((2, 2, 3))
         .set([[[1., 2., 3.], [1., 2., 3.]], [[1., 2., 3.], [1., 2., 3.]]]);
-    let b = a.max_reduce(1).retrieve();
-    let c = a.max_reduce(0).retrieve();
-    let d = a.max_reduce(2).retrieve();
+    let b = a.max(1).retrieve();
+    let c = a.max(0).retrieve();
+    let d = a.max(2).retrieve();
     cx.execute();
 
     let d_dev = Cpu::default();


### PR DESCRIPTION
## Summary
- switch remaining `.recip()` calls to `.reciprocal()` in examples and Metal tests
- adjust test name collision and update elementwise max call

## Testing
- `cargo check --workspace --quiet`
- `cargo test --workspace --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68487c5737388325a4c853c046d6148a