### PR TITLE
Update cudarc to 0.16.6

### DIFF
--- a/crates/luminal_cuda/Cargo.toml
+++ b/crates/luminal_cuda/Cargo.toml
@@ -9,9 +9,9 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 luminal = { path = "../.." }
-cudarc = { version = "0.16.1", features = [
-	"f16",
-	"cuda-version-from-build-system",
+cudarc = { version = "0.16.6", features = [
+        "f16",
+        "cuda-version-from-build-system",
 ] }
 itertools = "0.12.1"
 rustc-hash = "2.1.1"


### PR DESCRIPTION
## Summary
- update `cudarc` in `luminal_cuda`

## Testing
- `cargo clippy --all-targets -- -D warnings`
- `cargo test --workspace`
- `cargo clippy --all-targets --manifest-path crates/luminal_cuda/Cargo.toml -- -D warnings` *(fails: `Failed to execute nvcc`)*

------
https://chatgpt.com/codex/tasks/task_e_6881236e90c08325bd78d78c76ba74c3