### PR TITLE
CUDA Context Fix 

### DIFF
--- a/crates/luminal_2/src/extract.rs
+++ b/crates/luminal_2/src/extract.rs
@@ -366,7 +366,7 @@ pub fn search(
     #[cfg(feature = "metal")]
     let device = MTLCreateSystemDefaultDevice().unwrap();
     #[cfg(feature = "cuda")]
-    let device = CudaContext::new(0).unwrap();
+    let device = crate::run::shared_cuda_context();
     let inputs = inputs
         .into_iter()
         .map(|(n, init)| {

--- a/crates/luminal_2/src/lib.rs
+++ b/crates/luminal_2/src/lib.rs
@@ -42,6 +42,8 @@ pub enum GPUArch {
 }
 
 impl GPUArch {
+    // Maybe derive here the architecture of the CUDA device to avoid any weird bugs
+
     fn metal_buffer_type(&self, var: usize) -> &'static str {
         match self {
             Self::Metal(m) => m.get(&var).copied().unwrap_or(""),
@@ -123,7 +125,7 @@ impl Operator for CompatKernel {
         use cudarc::driver::{LaunchConfig, PushKernelArg};
         use luminal_cuda::CudaData;
         let dyn_vars = &unsafe { self.1.as_ref().unwrap() }.dyn_map;
-        let ctx = cudarc::driver::CudaContext::new(0).unwrap();
+        let ctx = crate::run::shared_cuda_context();
         let stream = ctx.default_stream();
 
         let ptx = cudarc::nvrtc::compile_ptx(&self.0.code).unwrap();
@@ -207,7 +209,7 @@ pub struct Diff {
 impl Operator for Diff {
     fn process(&mut self, inp: Vec<(InputTensor, ShapeTracker)>) -> Vec<Tensor> {
         // Dump
-        let ctx = cudarc::driver::CudaContext::new(0).unwrap();
+        let ctx = crate::run::shared_cuda_context();
         let stream = ctx.default_stream();
         let buffer = inp[0].0.borrowed().downcast_ref::<CudaData<f32>>().unwrap();
         let data: Vec<f32> = stream.memcpy_dtov(&buffer.0).unwrap();

--- a/crates/luminal_2/src/run.rs
+++ b/crates/luminal_2/src/run.rs
@@ -2,6 +2,8 @@ use itertools::Itertools;
 
 #[cfg(feature = "cuda")]
 use cudarc::{driver::*, nvrtc::CompileOptions};
+#[cfg(feature = "cuda")]
+use std::sync::OnceLock;
 
 use luminal::{
     prelude::{
@@ -50,7 +52,7 @@ pub fn assign_buffers(
         let k = &graph[node];
         if k.code == "Inputs" {
             continue; // user-provided; ignore
-        }
+        } // Can replace with look ups in the use_count -> if there, then not an Input
 
         // Allocate exact-size buffers for this node's outputs
         let mut outs = vec![];
@@ -72,7 +74,7 @@ pub fn assign_buffers(
             let src = e.source();
             if graph[src].code == "Inputs" {
                 continue;
-            }
+            }  // Can replace with look ups in the use_count -> if there, then not an Input
             let (src_out_idx, _) = *e.weight();
             if let Some(c) = use_count.get_mut(&(src, src_out_idx)) {
                 *c -= 1;
@@ -94,7 +96,7 @@ pub fn assign_buffers(
 pub fn compile_kernels(
     kernels: &StableGraph<Kernel, (usize, usize)>,
 ) -> FxHashMap<String, CudaFunction> {
-    let ctx = cudarc::driver::CudaContext::new(0).unwrap();
+    let ctx = shared_cuda_context();
     let mut compiled = FxHashMap::default();
 
     for kernel in kernels.node_weights() {
@@ -153,11 +155,11 @@ pub fn run_graph(
     inputs: &mut FxHashMap<usize, (&CudaSlice<f32>, bool)>,
     kernels: &StableGraph<Kernel, (usize, usize)>,
     dyn_vars: &FxHashMap<char, usize>,
-    compiled_kernels: &FxHashMap<String, CudaFunction>,
+    compiled_kernels: &FxHashMap<String, CudaFunction>, // wonder how this impacts performance inserting a string of kernel code vs inserting an object (e.g. struct with code as string)
     intermediate_buffers: &mut Vec<Buffer>,
     intermediate_buffer_map: &FxHashMap<NodeIndex, Vec<usize>>,
 ) -> (Vec<Vec<f32>>, u128) {
-    let ctx = cudarc::driver::CudaContext::new(0).unwrap();
+    let ctx = shared_cuda_context();
     let stream = ctx.default_stream();
     let start = std::time::Instant::now();
 
@@ -558,7 +560,13 @@ pub fn new_buffer(size: usize) -> Buffer {
 
 #[cfg(feature = "cuda")]
 pub fn new_buffer(size: usize) -> Buffer {
-    let ctx = cudarc::driver::CudaContext::new(0).unwrap();
+    let ctx = shared_cuda_context();
     let stream = ctx.default_stream();
     stream.alloc_zeros::<f32>(size / size_of::<f32>()).unwrap()
+}
+
+#[cfg(feature = "cuda")]
+pub fn shared_cuda_context() -> std::sync::Arc<CudaContext> {
+    static CTX: OnceLock<std::sync::Arc<CudaContext>> = OnceLock::new();
+    CTX.get_or_init(|| CudaContext::new(0).unwrap()).clone()
 }

--- a/crates/luminal_2/src/translate.rs
+++ b/crates/luminal_2/src/translate.rs
@@ -7,7 +7,7 @@ use luminal::prelude::{
     petgraph::{Directed, algo::toposort, prelude::StableGraph},
     *,
 };
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use std::collections::HashSet;
 
 #[derive(Debug, Clone)]
@@ -25,12 +25,12 @@ pub type OptimalGraphNodeIndex = NodeIndex;
 pub type SubGraph = StableGraph<GraphTerm, (), Directed>;
 pub type MetaGraph = StableGraph<SubGraph, CrossSubGraphTensorIndexes, Directed>;
 
-fn collect_ancestors(graph: &Graph, n: NodeIndex) -> HashSet<NodeIndex> {
-    let mut seen = HashSet::new();
+fn collect_ancestors(graph: &Graph, n: NodeIndex) -> FxHashSet<NodeIndex> {
+    let mut seen: FxHashSet<NodeIndex> = FxHashSet::default(); // faster non-cryptographic hash
     let mut stack = vec![n];
     while let Some(cur) = stack.pop() {
         for (src, _out, _shape) in graph.get_sources(cur) {
-            if seen.insert(src) {
+            if seen.insert(src) { // success iff src is not in seen (note for myself)
                 stack.push(src);
             }
         }

--- a/crates/luminal_cuda/src/binary.rs
+++ b/crates/luminal_cuda/src/binary.rs
@@ -94,7 +94,7 @@ pub struct SubtractionCompiler<T: CudaFloat>(PhantomData<T>);
 impl<T: CudaFloat> Compiler for SubtractionCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, _: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         let (lhs, rhs) = (node(), node());
         let mul = binary::<CudaMul<T>>(rhs.clone(), constant::<T>(-1.));
         let add = binary::<CudaAdd<T>>(lhs.clone(), mul.clone());
@@ -225,7 +225,7 @@ pub struct EqualCompiler<T: CudaFloat>(PhantomData<T>);
 impl<T: CudaFloat> Compiler for EqualCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, _: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         let one = constant::<T>(1.);
         let (lhs, rhs) = (node(), node());
         let lt1 = binary::<CudaLessThan<T>>(lhs.clone(), rhs.clone());
@@ -349,7 +349,7 @@ pub struct GatherCompiler<T: CudaFloat>(PhantomData<T>);
 impl<T: CudaFloat> Compiler for GatherCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, _: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         let indexes = node();
         let ind_copy = unary::<CudaCopyToDevice<T>>(indexes.clone());
         let equal = binary::<CudaEqual<T>>(op::<CudaARange<T>>(), ind_copy.clone());

--- a/crates/luminal_cuda/src/elementwise_fusion.rs
+++ b/crates/luminal_cuda/src/elementwise_fusion.rs
@@ -66,7 +66,7 @@ fn is_more_than_one_view(
 impl<T: CudaFloat> Compiler for ElementwiseFusionCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, mut ids: To) {
-        let device = CudaContext::new(0).unwrap();
+        let device = crate::shared_cuda_context(0);
         // Track fused ops to compile later
         let mut fused_ops = FxHashSet::default();
 

--- a/crates/luminal_cuda/src/lib.rs
+++ b/crates/luminal_cuda/src/lib.rs
@@ -25,7 +25,12 @@ use itertools::Itertools;
 use prim::CudaConstant;
 use rustc_hash::FxHashMap;
 
-use std::{collections::hash_map::DefaultHasher, fmt::Write, hash::Hasher, sync::Arc};
+use std::{
+    collections::hash_map::DefaultHasher,
+    fmt::Write,
+    hash::Hasher,
+    sync::{Arc, OnceLock},
+};
 
 use luminal::{op::InputTensor, prelude::*};
 
@@ -217,6 +222,16 @@ fn hash<T: std::hash::Hash>(obj: T) -> u64 {
     let mut hasher = DefaultHasher::new();
     obj.hash(&mut hasher);
     hasher.finish()
+}
+
+/// Returns a shared CUDA context for the given device index.
+/// All CUDA compiler passes and ops should acquire the context via this function
+/// to ensure a single context is used across the entire graph execution.
+pub fn shared_cuda_context(device_index: u32) -> Arc<CudaContext> {
+    static CUDA_CTX: OnceLock<Arc<CudaContext>> = OnceLock::new();
+    CUDA_CTX
+        .get_or_init(|| CudaContext::new(device_index as usize).unwrap())
+        .clone()
 }
 
 fn get_buffer_from_tensor<'a, T: CudaFloat>(tensor: &'a InputTensor) -> &'a CudaSlice<T> {

--- a/crates/luminal_cuda/src/matmul.rs
+++ b/crates/luminal_cuda/src/matmul.rs
@@ -119,7 +119,7 @@ where
 {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, mut ids: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         // Look for the matmul pattern
         // Mul ([A, C(fake), B] | [A(fake), C, B]) -> SumReduce(2) -> [A, C]
         // Actually starts at [A,B] | [B, C]

--- a/crates/luminal_cuda/src/other.rs
+++ b/crates/luminal_cuda/src/other.rs
@@ -77,7 +77,7 @@ pub struct ARangeCompiler<T: CudaFloat>(PhantomData<T>);
 impl<T: CudaFloat> Compiler for ARangeCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, _: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         // TODO: Make sure this actually checks the shape transformations to ensure pooling happens
         let contig_one = constant::<T>(1.);
         let contig1 = unary::<CudaContiguous<T>>(contig_one.clone());

--- a/crates/luminal_cuda/src/prim.rs
+++ b/crates/luminal_cuda/src/prim.rs
@@ -681,7 +681,7 @@ pub struct PrimitiveCompiler<T>(PhantomData<T>);
 impl<T: CudaFloat> Compiler for PrimitiveCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, mut ids: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         // Go through the graph and insert copy ops
         // Copy function output to device and input from device
         for function_node in graph

--- a/crates/luminal_cuda/src/quantized.rs
+++ b/crates/luminal_cuda/src/quantized.rs
@@ -244,7 +244,7 @@ impl<T> CudaQuantizedCompiler<T> {
 impl<T: CudaFloat + Default> Compiler for CudaQuantizedCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, _: To) {
-        let device = CudaContext::new(0).unwrap();
+        let device = crate::shared_cuda_context(0);
         let weight_ids = self.0.clone();
         // Modify ops directly downstream of weights
         for weight in downstream(&weight_ids, graph) {

--- a/crates/luminal_cuda/src/unary.rs
+++ b/crates/luminal_cuda/src/unary.rs
@@ -127,7 +127,7 @@ pub struct MeanReduceCompiler<T>(PhantomData<T>);
 impl<T: CudaFloat> Compiler for MeanReduceCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, mut ids: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         // Look for the mean-reduce pattern
         // mul(recip(fake_sum_reduce(const_ones)), sum_reduce(x))
         let fake_sum_reduce = op::<CudaConstant<T>>();
@@ -308,7 +308,7 @@ pub struct StdNormCompiler<T>(PhantomData<T>);
 impl<T: CudaFloat> Compiler for StdNormCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, mut ids: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         // Look for the RMSNorm pattern
         // mul(recip(sqrt(add(mean_reduce(mul(x, x)), 1e-6))), x)
 
@@ -400,7 +400,7 @@ pub struct CudaExpCompiler<T: CudaFloat>(PhantomData<T>);
 impl<T: CudaFloat> Compiler for CudaExpCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, mut ids: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         // Look for the exp pattern
         // exp2(mul(x, const))
 
@@ -448,7 +448,7 @@ pub struct CudaCosCompiler<T>(PhantomData<T>);
 impl<T: CudaFloat> Compiler for CudaCosCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, mut ids: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         // Look for the cos pattern
         // sin(add(mul(const_neg_one, x), const_pi_over_2))
 
@@ -599,7 +599,7 @@ pub struct SoftmaxCompiler<T>(PhantomData<T>);
 impl<T: CudaFloat> Compiler for SoftmaxCompiler<T> {
     type Output = ();
     fn compile<To: ToIdsMut>(&self, graph: &mut Graph, mut ids: To) {
-        let dev = CudaContext::new(0).unwrap();
+        let dev = crate::shared_cuda_context(0);
         // Look for the mean-reduce pattern
         // mul(recip(fake_sum_reduce(const_ones)), sum_reduce(x))
 

--- a/demos/matmul/src/main.rs
+++ b/demos/matmul/src/main.rs
@@ -128,7 +128,7 @@ fn main() {
         #[cfg(feature = "metal")]
         let device = &MTLCreateSystemDefaultDevice().unwrap();
         #[cfg(feature = "cuda")]
-        let device = &CudaContext::new(0).unwrap();
+        let device = &luminal_2::run::shared_cuda_context();
 
         let mut inputs = FxHashMap::default();
         let mut rng = rng();


### PR DESCRIPTION
- Added shared CUDA context (`OnceLock`) and use it across luminal_cud and luminal_2
- Replaced all `CudaContext::new(0)` with shared context; fix u32→usize cast

Still need to check the correctness. Was going to do it yesterday, but Lambda node got closed when I was about to continue working on it

TODO: Verify the statement above, remove the comments (my thoughts on some elements in the code)