### PR TITLE
Fix autograd gradient normalization for permuted and broadcast tensors

### DIFF
--- a/crates/luminal_training/src/autograd.rs
+++ b/crates/luminal_training/src/autograd.rs
@@ -189,6 +189,34 @@ fn normalize_grad_for_input(
     graph: &mut Graph,
 ) -> GraphTensor {
 
+    // If grad has fewer logical axes than fwd (common when forward used expand/broadcast),
+    // insert broadcasted axes into grad at the logical positions where fwd is fake.
+    // Do this before undoing permutes so indexes line up.
+    if grad.shape.len() < fwd.shape.len() {
+        let _need = fwd.shape.len() - grad.shape.len();
+        // insert fake positions from highest -> lowest so indices remain valid
+        let mut fake_positions: Vec<usize> =
+            (0..fwd.shape.len()).filter(|&i| fwd.shape.fake[i]).collect();
+        fake_positions.sort_unstable_by(|a, b| b.cmp(a));
+        for &pos in &fake_positions {
+            if grad.shape.len() >= fwd.shape.len() {
+                break;
+            }
+            // Insert a logical axis with the forward logical size (broadcast view).
+            let size = fwd.shape.dims[fwd.shape.indexes[pos]];
+            grad.shape.expand_dim(pos, size);
+            // Rewrap so the updated shape is used downstream.
+            grad = GraphTensor::from_id(grad.id, grad.shape, graph as *mut Graph);
+        }
+        // Defensive: if we still didn't reach target rank (e.g., malformed fake flags), pad at end.
+        while grad.shape.len() < fwd.shape.len() {
+            let pos = grad.shape.len();
+            let size = fwd.shape.dims[fwd.shape.indexes[pos]];
+            grad.shape.expand_dim(pos, size);
+            grad = GraphTensor::from_id(grad.id, grad.shape, graph as *mut Graph);
+        }
+    }
+
     // Undo permutes
     let mut new_indexes = ArrayVec::new();
     new_indexes.resize(fwd.shape.len(), 0);

--- a/crates/luminal_training/src/autograd.rs
+++ b/crates/luminal_training/src/autograd.rs
@@ -242,313 +242,734 @@ mod tests {
     use luminal::prelude::Module as LModule;
     luminal::test_imports!();
 
+    // Helper utilities used by tests
     fn get_vec(grad: (NodeIndex, ShapeTracker), cx: &mut Graph) -> Vec<f32> {
         GraphTensor::from_id(grad.0, grad.1, cx).data()
     }
 
-    #[test]
-    fn test_autograd_max_reduce() {
-        let mut cx = Graph::new();
-        let a = cx.named_tensor("Input", 2).set([10., 5.]);
-        let b = a.max(0);
+    // --- 1. Core Autograd Tests ---
+    mod core_autograd {
+        use super::*;
 
-        let grads = cx.compile(Autograd::new(a, b), ());
-        cx.keep_tensors(&grads);
-        cx.execute();
+        #[test]
+        fn test_autograd_max_reduce() {
+            let mut cx = Graph::new();
+            let a = cx.named_tensor("Input", 2).set([10., 5.]);
+            let b = a.max(0);
 
-        let dev = dfdx::prelude::Cpu::default();
-        let d_a = dev.tensor([10., 5.]);
-        let d_b = d_a.trace(Gradients::leaky()).max();
-        let d_grads = d_b.backward();
+            let grads = cx.compile(Autograd::new(a, b), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
 
-        assert_exact(&get_vec(grads[0], &mut cx), &d_grads.get(&d_a).as_vec());
+            let dev = dfdx::prelude::Cpu::default();
+            let d_a = dev.tensor([10., 5.]);
+            let d_b = d_a.trace(Gradients::leaky()).max();
+            let d_grads = d_b.backward();
+
+            assert_exact(&get_vec(grads[0], &mut cx), &d_grads.get(&d_a).as_vec());
+        }
+
+        #[test]
+        fn test_autograd_matmul() {
+            let mut cx = Graph::new();
+            let a = cx.named_tensor("A", (2, 2)).set([[2., 4.], [3., 1.]]);
+            let input = cx.named_tensor("Input", 2).set([10., 5.]);
+            let output = (input.matmul(a)).sum(0);
+
+            let grads = cx.compile(Autograd::new(a, output), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            let dev = dfdx::prelude::Cpu::default();
+            let w1 = dev.tensor([[2., 4.], [3., 1.]]);
+            let inp = dev.tensor([10., 5.]);
+            let out = inp.trace(Gradients::leaky()).matmul(w1.clone()).sum();
+            let d_grads = out.backward();
+
+            assert_exact(&get_vec(grads[0], &mut cx), &d_grads.get(&w1).as_vec());
+        }
+
+        #[test]
+        fn test_autograd_mlp() {
+            let mut cx = Graph::new();
+            let model = (
+                luminal_nn::Linear::new(2, 2, false, &mut cx),
+                luminal_nn::ReLU,
+                luminal_nn::Linear::new(2, 1, false, &mut cx),
+            );
+            model.0.weight.set([[2., 4.], [3., 1.]]);
+            model.2.weight.set([[6.], [5.]]);
+            let input = cx.named_tensor("Input", 2).set([10., 5.]);
+            let output = model.forward(input).sum(0);
+
+            let mut grads = cx.compile(Autograd::new(params(model), output), ());
+            cx.keep_tensors(&grads);
+            cx.compile(GenericCompiler::default(), &mut grads);
+            cx.execute();
+
+            let dev = dfdx::prelude::Cpu::default();
+            let mut d_model = dev.build_module::<(
+                dfdx::nn::builders::UnbiasedLinear<2, 2>,
+                dfdx::nn::builders::ReLU,
+                dfdx::nn::builders::UnbiasedLinear<2, 1>,
+            ), f32>();
+            d_model.0.weight = dev.tensor([[2., 4.], [3., 1.]]).permute();
+            d_model.2.weight = dev.tensor([[6.], [5.]]).permute();
+            let inp = dev.tensor([10., 5.]);
+            let out = d_model.forward(inp.trace(Gradients::leaky())).sum();
+            let d_grads = out.backward();
+
+            assert_exact(
+                &get_vec(grads[0], &mut cx),
+                &d_grads.get(&d_model.0.weight).permute().as_vec(),
+            );
+            assert_exact(
+                &get_vec(grads[1], &mut cx),
+                &d_grads.get(&d_model.2.weight).as_vec(),
+            );
+        }
+
+        #[test]
+        fn test_autograd_layer_norm() {
+            let mut cx = Graph::new();
+            let a = cx.tensor(3).set([-1., 2., 3.]);
+            let mut b = a.layer_norm(0, 1e-5).max(0).retrieve();
+
+            let grads = cx.compile(Autograd::new(a, b), &mut b);
+            cx.keep_tensors(&grads);
+            cx.compile(GenericCompiler::default(), &mut b);
+            cx.execute();
+
+            let d_dev = Cpu::default();
+            let d_a = d_dev.tensor([-1., 2., 3.]);
+            let d_b = d_a.trace(Gradients::leaky()).normalize(1e-5).max();
+            assert_close(&b.data(), &d_b.as_vec());
+            let d_grads = d_b.backward();
+            assert_close(&get_vec(grads[0], &mut cx), &d_grads.get(&d_a).as_vec());
+        }
+
+        #[test]
+        fn test_autograd_softmax() {
+            let mut cx = Graph::new();
+            let a = cx.tensor(3).set([-1., 2., 3.]);
+            let mut b = a.softmax(0).max(0).retrieve();
+
+            let mut grads = cx.compile(Autograd::new(a, b), &mut b);
+            cx.keep_tensors(&grads);
+            cx.compile(GenericCompiler::default(), (&mut grads, &mut b));
+            cx.execute();
+
+            let d_dev = Cpu::default();
+            let d_a = d_dev.tensor([-1., 2., 3.]);
+            let d_b = d_a.trace(Gradients::leaky()).softmax().max();
+            assert_close(&b.data(), &d_b.as_vec());
+            let d_grads = d_b.backward();
+            assert_close(&get_vec(grads[0], &mut cx), &d_grads.get(&d_a).as_vec());
+        }
+
+        #[test]
+        fn test_autograd_transformer() {
+            let mut cx = Graph::new();
+            let model = luminal_nn::TransformerEncoderBlock::new(3, 4, 1, &mut cx);
+            model
+                .attention
+                .w_k
+                .weight
+                .set(vec![1., 22., 3., 1., 2., 3., 1., 2., 3.]);
+            model
+                .attention
+                .w_q
+                .weight
+                .set(vec![3., 2., 3., 1.3, 2., 3., 3., 2., 3.]);
+            model
+                .attention
+                .w_v
+                .weight
+                .set(vec![-1., 12., 3., -1., 2., -3., 11., 2., 3.]);
+            model
+                .attention
+                .w_o
+                .weight
+                .set(vec![1., 22., 3., 1., 2., 3., 1., 2., 3.]);
+            model
+                .ff
+                .0
+                .weight
+                .set(vec![-1., 12., 3., -1., 2., -3., 11., 2., 3., 11., 2., 3.]);
+            model
+                .ff
+                .2
+                .weight
+                .set(vec![-1., 12., 3., -1., 2., -3., 11., 2., 3., 3., -1., 2.]);
+
+            let a = cx.tensor((2, 3)).set([[-1., 2., 3.], [3., 3., -1.]]);
+            let target = cx.tensor((2, 3)).set([[0., 1., 0.], [0., 0., 1.]]);
+            let out = model.forward(a);
+            let mut loss = crate::cross_entropy_with_logits_loss(out, target).retrieve();
+
+            let mut model_params = params(&model);
+            let mut grads = cx.compile(
+                Autograd::new((&model_params, a), loss),
+                (&mut model_params, &mut loss),
+            );
+            cx.keep_tensors(&grads);
+            cx.compile(
+                GenericCompiler::default(),
+                (&mut model_params, &mut grads, &mut loss),
+            );
+            cx.execute();
+
+            let d_dev = Cpu::default();
+            let mut d_model = d_dev
+                .build_module::<dfdx::nn::modules::builders::TransformerEncoderBlock<3, 1, 4>, f32>();
+            d_model.self_attn.w_k.bias.copy_from(&[0.0, 0.0, 0.0]);
+            d_model.self_attn.w_v.bias.copy_from(&[0.0, 0.0, 0.0]);
+            d_model.self_attn.w_q.bias.copy_from(&[0.0, 0.0, 0.0]);
+            d_model.self_attn.w_o.bias.copy_from(&[0., 0., 0.]);
+            d_model.self_attn.w_o.weight = d_dev
+                .tensor_from_vec(
+                    vec![1., 22., 3., 1., 2., 3., 1., 2., 3.],
+                    (DConst::<3>, DConst::<3>),
+                )
+                .permute();
+            d_model.self_attn.w_k.weight = d_dev
+                .tensor_from_vec(
+                    vec![1., 22., 3., 1., 2., 3., 1., 2., 3.],
+                    (DConst::<3>, DConst::<3>),
+                )
+                .permute();
+            d_model.self_attn.w_q.weight = d_dev
+                .tensor_from_vec(
+                    vec![3., 2., 3., 1.3, 2., 3., 3., 2., 3.],
+                    (DConst::<3>, DConst::<3>),
+                )
+                .permute();
+            d_model.self_attn.w_v.weight = d_dev
+                .tensor_from_vec(
+                    vec![-1., 12., 3., -1., 2., -3., 11., 2., 3.],
+                    (DConst::<3>, DConst::<3>),
+                )
+                .permute();
+            d_model.ff.0 .0.weight = d_dev
+                .tensor_from_vec(
+                    vec![-1., 12., 3., -1., 2., -3., 11., 2., 3., 11., 2., 3.],
+                    (DConst::<3>, DConst::<4>),
+                )
+                .permute();
+            d_model.ff.0 .0.bias = d_dev.tensor_from_vec(vec![0., 0., 0., 0.], (DConst::<4>,));
+            d_model.ff.0 .2.weight = d_dev
+                .tensor_from_vec(
+                    vec![-1., 12., 3., -1., 2., -3., 11., 2., 3., 3., -1., 2.],
+                    (DConst::<4>, DConst::<3>),
+                )
+                .permute();
+            d_model.ff.0 .2.bias = d_dev.tensor_from_vec(vec![0., 0., 0.], (DConst::<3>,));
+            d_model.norm1.gamma = d_dev.tensor_from_vec(vec![1., 1., 1.], (DConst::<3>,));
+            d_model.norm2.gamma = d_dev.tensor_from_vec(vec![1., 1., 1.], (DConst::<3>,));
+            d_model.norm1.epsilon = 1e-5;
+            d_model.norm2.beta = d_dev.tensor_from_vec(vec![0., 0., 0.], (DConst::<3>,));
+            d_model.norm1.beta = d_dev.tensor_from_vec(vec![0., 0., 0.], (DConst::<3>,));
+            d_model.norm2.epsilon = 1e-5;
+            let d_a = d_dev.tensor_from_vec(vec![-1., 2., 3., 3., 3., -1.], (DConst::<2>, DConst::<3>));
+            let d_target =
+                d_dev.tensor_from_vec(vec![0., 1., 0., 0., 0., 1.], (DConst::<2>, DConst::<3>));
+            let d_b = d_model.forward(d_a.trace(Gradients::leaky()));
+            let d_loss = dfdx::prelude::cross_entropy_with_logits_loss(d_b, d_target);
+
+            assert_close(&loss.data(), &d_loss.as_vec());
+
+            let d_grads = d_loss.backward();
+            assert_close(
+                &get_vec(*grads.last().unwrap(), &mut cx),
+                &d_grads.get(&d_a).as_vec(),
+            );
+            assert_close(
+                &get_vec(
+                    grads[model_params
+                        .iter()
+                        .position(|i| *i == model.ff.2.weight.id)
+                        .unwrap()],
+                    &mut cx,
+                ),
+                &d_grads.get(&d_model.ff.0 .2.weight).permute().as_vec(),
+            );
+            assert_close(
+                &get_vec(
+                    grads[model_params
+                        .iter()
+                        .position(|i| *i == model.ff.0.weight.id)
+                        .unwrap()],
+                    &mut cx,
+                ),
+                &d_grads.get(&d_model.ff.0 .0.weight).permute().as_vec(),
+            );
+            assert_close(
+                &get_vec(
+                    grads[model_params
+                        .iter()
+                        .position(|i| *i == model.attention.w_o.weight.id)
+                        .unwrap()],
+                    &mut cx,
+                ),
+                &d_grads
+                    .get(&d_model.self_attn.w_o.weight)
+                    .permute()
+                    .as_vec(),
+            );
+            assert_close(
+                &get_vec(
+                    grads[model_params
+                        .iter()
+                        .position(|i| *i == model.attention.w_q.weight.id)
+                        .unwrap()],
+                    &mut cx,
+                ),
+                &d_grads
+                    .get(&d_model.self_attn.w_q.weight)
+                    .permute()
+                    .as_vec(),
+            );
+            assert_close(
+                &get_vec(
+                    grads[model_params
+                        .iter()
+                        .position(|i| *i == model.attention.w_k.weight.id)
+                        .unwrap()],
+                    &mut cx,
+                ),
+                &d_grads
+                    .get(&d_model.self_attn.w_k.weight)
+                    .permute()
+                    .as_vec(),
+            );
+            assert_close(
+                &get_vec(
+                    grads[model_params
+                        .iter()
+                        .position(|i| *i == model.attention.w_v.weight.id)
+                        .unwrap()],
+                    &mut cx,
+                ),
+                &d_grads
+                    .get(&d_model.self_attn.w_v.weight)
+                    .permute()
+                    .as_vec(),
+            );
+        }
     }
 
-    #[test]
-    fn test_autograd_matmul() {
-        let mut cx = Graph::new();
-        let a = cx.named_tensor("A", (2, 2)).set([[2., 4.], [3., 1.]]);
-        let input = cx.named_tensor("Input", 2).set([10., 5.]);
-        let output = (input.matmul(a)).sum(0);
+    // --- 2. Broadcasting, Permute, and Fake Dim Handling ---
+    mod broadcast_permute {
+        use super::*;
 
-        let grads = cx.compile(Autograd::new(a, output), ());
-        cx.keep_tensors(&grads);
-        cx.execute();
+        #[test]
+        fn test_add_grad_decreasing_idx_r1() {
+            let mut cx = Graph::new();
+            // Create a tensor, expand to add fake dims and permute to produce
+            // a non-monotonic indexes mapping. This mirrors the original intent
+            // without relying on compile-time shape generics.
+            let a = cx.tensor(2);
+            let a = a.expand((1, 1, 2));
+            let a = a.permute((2, 1, 0));
 
-        let dev = dfdx::prelude::Cpu::default();
-        let w1 = dev.tensor([[2., 4.], [3., 1.]]);
-        let inp = dev.tensor([10., 5.]);
-        let out = inp.trace(Gradients::leaky()).matmul(w1.clone()).sum();
-        let d_grads = out.backward();
+            // has multiple fake dimensions
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert!(fake_count >= 2);
+            // indexes should not be strictly increasing
+            let not_strict = a.shape.indexes.windows(2).any(|w| w[0] >= w[1]);
+            assert!(not_strict);
 
-        assert_exact(&get_vec(grads[0], &mut cx), &d_grads.get(&w1).as_vec());
-    }
+            // reduce to scalar and ensure autograd compiles
+            let loss = a.sum((0, 1, 2));
+            let _grads = cx.compile(Autograd::new(vec![a.id], loss), ());
+        }
 
-    #[test]
-    fn test_autograd_mlp() {
-        let mut cx = Graph::new();
-        let model = (
-            luminal_nn::Linear::new(2, 2, false, &mut cx),
-            luminal_nn::ReLU,
-            luminal_nn::Linear::new(2, 1, false, &mut cx),
-        );
-        model.0.weight.set([[2., 4.], [3., 1.]]);
-        model.2.weight.set([[6.], [5.]]);
-        let input = cx.named_tensor("Input", 2).set([10., 5.]);
-        let output = model.forward(input).sum(0);
+        #[test]
+        fn test_add_grad_decreasing_idx_r2() {
+            let mut cx = Graph::new();
+            // Start with a 2x3 tensor, expand to add fake dims, then permute to
+            // create a non-monotonic indexes mapping.
+            let a = cx.tensor((2, 3));
+            let a = a.expand((2, 1, 1, 1, 3));
+            let a = a.permute((4, 1, 0, 3, 2));
 
-        let mut grads = cx.compile(Autograd::new(params(model), output), ());
-        cx.keep_tensors(&grads);
-        cx.compile(GenericCompiler::default(), &mut grads);
-        cx.execute();
+            // has multiple fake dimensions
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert!(fake_count >= 3);
+            // indexes should not be strictly increasing
+            let not_strict = a.shape.indexes.windows(2).any(|w| w[0] >= w[1]);
+            assert!(not_strict);
 
-        let dev = dfdx::prelude::Cpu::default();
-        let mut d_model = dev.build_module::<(
-            dfdx::nn::builders::UnbiasedLinear<2, 2>,
-            dfdx::nn::builders::ReLU,
-            dfdx::nn::builders::UnbiasedLinear<2, 1>,
-        ), f32>();
-        d_model.0.weight = dev.tensor([[2., 4.], [3., 1.]]).permute();
-        d_model.2.weight = dev.tensor([[6.], [5.]]).permute();
-        let inp = dev.tensor([10., 5.]);
-        let out = d_model.forward(inp.trace(Gradients::leaky())).sum();
-        let d_grads = out.backward();
+            let loss = a.sum((0, 1, 2, 3, 4));
+            let _grads = cx.compile(Autograd::new(vec![a.id], loss), ());
+        }
 
-        assert_exact(
-            &get_vec(grads[0], &mut cx),
-            &d_grads.get(&d_model.0.weight).permute().as_vec(),
-        );
-        assert_exact(
-            &get_vec(grads[1], &mut cx),
-            &d_grads.get(&d_model.2.weight).as_vec(),
-        );
-    }
+        #[test]
+        fn test_add_grad_with_values_r1() {
+            let mut cx = Graph::new();
+            let a = cx.tensor(3).set([1.0, 2.0, 3.0]);
+            let orig_a_id = a.id;
+            // Expand and permute to create fake dims with non-monotonic indexes
+            let a = a.expand((1, 3, 1));
+            let a = a.permute((1, 2, 0));
 
-    #[test]
-    fn test_autograd_layer_norm() {
-        let mut cx = Graph::new();
-        let a = cx.tensor(3).set([-1., 2., 3.]);
-        let mut b = a.layer_norm(0, 1e-5).max(0).retrieve();
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert!(fake_count >= 2);
+            let not_strict = a.shape.indexes.windows(2).any(|w| w[0] >= w[1]);
+            assert!(not_strict);
 
-        let grads = cx.compile(Autograd::new(a, b), &mut b);
-        cx.keep_tensors(&grads);
-        cx.compile(GenericCompiler::default(), &mut b);
-        cx.execute();
+            let loss = a.sum((0, 1, 2));
 
-        let d_dev = Cpu::default();
-        let d_a = d_dev.tensor([-1., 2., 3.]);
-        let d_b = d_a.trace(Gradients::leaky()).normalize(1e-5).max();
-        assert_close(&b.data(), &d_b.as_vec());
-        let d_grads = d_b.backward();
-        assert_close(&get_vec(grads[0], &mut cx), &d_grads.get(&d_a).as_vec());
-    }
+            let grads = cx.compile(Autograd::new(orig_a_id, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
 
-    #[test]
-    fn test_autograd_softmax() {
-        let mut cx = Graph::new();
-        let a = cx.tensor(3).set([-1., 2., 3.]);
-        let mut b = a.softmax(0).max(0).retrieve();
+            // Gradient of sum is all ones
+            assert_exact(&get_vec(grads[0], &mut cx), &vec![1.0, 1.0, 1.0]);
+        }
 
-        let mut grads = cx.compile(Autograd::new(a, b), &mut b);
-        cx.keep_tensors(&grads);
-        cx.compile(GenericCompiler::default(), (&mut grads, &mut b));
-        cx.execute();
+        #[test]
+        fn test_add_grad_with_values_r2() {
+            let mut cx = Graph::new();
+            let a = cx.tensor((2, 3)).set([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+            let orig_a_id = a.id;
+            // Expand and permute to create fake dims with non-monotonic indexes
+            let a = a.expand((2, 1, 3, 1));
+            let a = a.permute((2, 3, 0, 1));
 
-        let d_dev = Cpu::default();
-        let d_a = d_dev.tensor([-1., 2., 3.]);
-        let d_b = d_a.trace(Gradients::leaky()).softmax().max();
-        assert_close(&b.data(), &d_b.as_vec());
-        let d_grads = d_b.backward();
-        assert_close(&get_vec(grads[0], &mut cx), &d_grads.get(&d_a).as_vec());
-    }
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert!(fake_count >= 2);
 
-    #[test]
-    fn test_autograd_transformer() {
-        let mut cx = Graph::new();
-        let model = luminal_nn::TransformerEncoderBlock::new(3, 4, 1, &mut cx);
-        model
-            .attention
-            .w_k
-            .weight
-            .set(vec![1., 22., 3., 1., 2., 3., 1., 2., 3.]);
-        model
-            .attention
-            .w_q
-            .weight
-            .set(vec![3., 2., 3., 1.3, 2., 3., 3., 2., 3.]);
-        model
-            .attention
-            .w_v
-            .weight
-            .set(vec![-1., 12., 3., -1., 2., -3., 11., 2., 3.]);
-        model
-            .attention
-            .w_o
-            .weight
-            .set(vec![1., 22., 3., 1., 2., 3., 1., 2., 3.]);
-        model
-            .ff
-            .0
-            .weight
-            .set(vec![-1., 12., 3., -1., 2., -3., 11., 2., 3., 11., 2., 3.]);
-        model
-            .ff
-            .2
-            .weight
-            .set(vec![-1., 12., 3., -1., 2., -3., 11., 2., 3., 3., -1., 2.]);
+            let loss = a.sum((0, 1, 2, 3));
 
-        let a = cx.tensor((2, 3)).set([[-1., 2., 3.], [3., 3., -1.]]);
-        let target = cx.tensor((2, 3)).set([[0., 1., 0.], [0., 0., 1.]]);
-        let out = model.forward(a);
-        let mut loss = crate::cross_entropy_with_logits_loss(out, target).retrieve();
+            let grads = cx.compile(Autograd::new(orig_a_id, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
 
-        let mut model_params = params(&model);
-        let mut grads = cx.compile(
-            Autograd::new((&model_params, a), loss),
-            (&mut model_params, &mut loss),
-        );
-        cx.keep_tensors(&grads);
-        cx.compile(
-            GenericCompiler::default(),
-            (&mut model_params, &mut grads, &mut loss),
-        );
-        cx.execute();
+            // Gradient of sum is all ones
+            assert_exact(
+                &get_vec(grads[0], &mut cx),
+                &vec![1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+            );
+        }
 
-        let d_dev = Cpu::default();
-        let mut d_model = d_dev
-            .build_module::<dfdx::nn::modules::builders::TransformerEncoderBlock<3, 1, 4>, f32>();
-        d_model.self_attn.w_k.bias.copy_from(&[0.0, 0.0, 0.0]);
-        d_model.self_attn.w_v.bias.copy_from(&[0.0, 0.0, 0.0]);
-        d_model.self_attn.w_q.bias.copy_from(&[0.0, 0.0, 0.0]);
-        d_model.self_attn.w_o.bias.copy_from(&[0., 0., 0.]);
-        d_model.self_attn.w_o.weight = d_dev
-            .tensor_from_vec(
-                vec![1., 22., 3., 1., 2., 3., 1., 2., 3.],
-                (DConst::<3>, DConst::<3>),
-            )
-            .permute();
-        d_model.self_attn.w_k.weight = d_dev
-            .tensor_from_vec(
-                vec![1., 22., 3., 1., 2., 3., 1., 2., 3.],
-                (DConst::<3>, DConst::<3>),
-            )
-            .permute();
-        d_model.self_attn.w_q.weight = d_dev
-            .tensor_from_vec(
-                vec![3., 2., 3., 1.3, 2., 3., 3., 2., 3.],
-                (DConst::<3>, DConst::<3>),
-            )
-            .permute();
-        d_model.self_attn.w_v.weight = d_dev
-            .tensor_from_vec(
-                vec![-1., 12., 3., -1., 2., -3., 11., 2., 3.],
-                (DConst::<3>, DConst::<3>),
-            )
-            .permute();
-        d_model.ff.0 .0.weight = d_dev
-            .tensor_from_vec(
-                vec![-1., 12., 3., -1., 2., -3., 11., 2., 3., 11., 2., 3.],
-                (DConst::<3>, DConst::<4>),
-            )
-            .permute();
-        d_model.ff.0 .0.bias = d_dev.tensor_from_vec(vec![0., 0., 0., 0.], (DConst::<4>,));
-        d_model.ff.0 .2.weight = d_dev
-            .tensor_from_vec(
-                vec![-1., 12., 3., -1., 2., -3., 11., 2., 3., 3., -1., 2.],
-                (DConst::<4>, DConst::<3>),
-            )
-            .permute();
-        d_model.ff.0 .2.bias = d_dev.tensor_from_vec(vec![0., 0., 0.], (DConst::<3>,));
-        d_model.norm1.gamma = d_dev.tensor_from_vec(vec![1., 1., 1.], (DConst::<3>,));
-        d_model.norm2.gamma = d_dev.tensor_from_vec(vec![1., 1., 1.], (DConst::<3>,));
-        d_model.norm1.epsilon = 1e-5;
-        d_model.norm2.beta = d_dev.tensor_from_vec(vec![0., 0., 0.], (DConst::<3>,));
-        d_model.norm1.beta = d_dev.tensor_from_vec(vec![0., 0., 0.], (DConst::<3>,));
-        d_model.norm2.epsilon = 1e-5;
-        let d_a = d_dev.tensor_from_vec(vec![-1., 2., 3., 3., 3., -1.], (DConst::<2>, DConst::<3>));
-        let d_target =
-            d_dev.tensor_from_vec(vec![0., 1., 0., 0., 0., 1.], (DConst::<2>, DConst::<3>));
-        let d_b = d_model.forward(d_a.trace(Gradients::leaky()));
-        let d_loss = dfdx::prelude::cross_entropy_with_logits_loss(d_b, d_target);
+        #[test]
+        fn test_add_grad_multiply_with_permute() {
+            let mut cx = Graph::new();
+            let a = cx.tensor(3).set([2.0, 3.0, 4.0]);
+            let orig_a_id = a.id;
+            // Expand and permute to create fake dims with non-monotonic indexes
+            let a = a.expand((1, 1, 3));
+            let a = a.permute((2, 1, 0));
 
-        assert_close(&loss.data(), &d_loss.as_vec());
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert!(fake_count >= 2);
 
-        let d_grads = d_loss.backward();
-        assert_close(
-            &get_vec(*grads.last().unwrap(), &mut cx),
-            &d_grads.get(&d_a).as_vec(),
-        );
-        assert_close(
-            &get_vec(
-                grads[model_params
-                    .iter()
-                    .position(|i| *i == model.ff.2.weight.id)
-                    .unwrap()],
-                &mut cx,
-            ),
-            &d_grads.get(&d_model.ff.0 .2.weight).permute().as_vec(),
-        );
-        assert_close(
-            &get_vec(
-                grads[model_params
-                    .iter()
-                    .position(|i| *i == model.ff.0.weight.id)
-                    .unwrap()],
-                &mut cx,
-            ),
-            &d_grads.get(&d_model.ff.0 .0.weight).permute().as_vec(),
-        );
-        assert_close(
-            &get_vec(
-                grads[model_params
-                    .iter()
-                    .position(|i| *i == model.attention.w_o.weight.id)
-                    .unwrap()],
-                &mut cx,
-            ),
-            &d_grads
-                .get(&d_model.self_attn.w_o.weight)
-                .permute()
-                .as_vec(),
-        );
-        assert_close(
-            &get_vec(
-                grads[model_params
-                    .iter()
-                    .position(|i| *i == model.attention.w_q.weight.id)
-                    .unwrap()],
-                &mut cx,
-            ),
-            &d_grads
-                .get(&d_model.self_attn.w_q.weight)
-                .permute()
-                .as_vec(),
-        );
-        assert_close(
-            &get_vec(
-                grads[model_params
-                    .iter()
-                    .position(|i| *i == model.attention.w_k.weight.id)
-                    .unwrap()],
-                &mut cx,
-            ),
-            &d_grads
-                .get(&d_model.self_attn.w_k.weight)
-                .permute()
-                .as_vec(),
-        );
-        assert_close(
-            &get_vec(
-                grads[model_params
-                    .iter()
-                    .position(|i| *i == model.attention.w_v.weight.id)
-                    .unwrap()],
-                &mut cx,
-            ),
-            &d_grads
-                .get(&d_model.self_attn.w_v.weight)
-                .permute()
-                .as_vec(),
-        );
+            // Multiply by constant, then sum
+            let b = a * 2.0;
+            let loss = b.sum((0, 1, 2));
+
+            let grads = cx.compile(Autograd::new(orig_a_id, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            // Gradient should be 2.0 for each element (derivative of 2*x)
+            assert_exact(&get_vec(grads[0], &mut cx), &vec![2.0, 2.0, 2.0]);
+        }
+
+        #[test]
+        fn test_add_grad_complex_permute() {
+            let mut cx = Graph::new();
+            let a = cx.tensor((2, 2)).set([[1.0, 2.0], [3.0, 4.0]]);
+            let orig_a_id = a.id;
+            // Create a complex permutation with multiple fake dims
+            let a = a.expand((1, 2, 1, 2, 1));
+            let a = a.permute((3, 4, 1, 0, 2));
+
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert!(fake_count >= 3);
+
+            let loss = a.sum((0, 1, 2, 3, 4));
+
+            let grads = cx.compile(Autograd::new(orig_a_id, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            // Gradient of sum is all ones
+            assert_exact(&get_vec(grads[0], &mut cx), &vec![1.0, 1.0, 1.0, 1.0]);
+        }
+
+        #[test]
+        fn test_add_grad_first_last_fake() {
+            let mut cx = Graph::new();
+            let a = cx.tensor(3).set([1.0, 2.0, 3.0]);
+            let orig_a_id = a.id;
+            // Add fake dims at the beginning and end, then permute
+            let a = a.expand((1, 3, 1));
+            let a = a.permute((2, 0, 1));
+
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert_eq!(fake_count, 2);
+
+            let loss = a.sum((0, 1, 2));
+
+            let grads = cx.compile(Autograd::new(orig_a_id, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            assert_exact(&get_vec(grads[0], &mut cx), &vec![1.0, 1.0, 1.0]);
+        }
+
+        #[test]
+        fn test_add_grad_reverse_permute() {
+            let mut cx = Graph::new();
+            let a = cx.tensor((2, 3, 4));
+            let orig_a_id = a.id;
+            a.set(vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+                16.0, 17.0, 18.0, 19.0, 20.0, 21.0, 22.0, 23.0, 24.0,
+            ]);
+            // Expand and reverse permute
+            let a = a.expand((2, 1, 3, 1, 4));
+            let a = a.permute((4, 3, 2, 1, 0));
+
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert!(fake_count >= 2);
+            // Check that indexes are non-monotonic (not strictly increasing)
+            let not_increasing = a.shape.indexes.windows(2).any(|w| w[0] >= w[1]);
+            assert!(not_increasing);
+
+            let loss = a.sum((0, 1, 2, 3, 4));
+
+            let grads = cx.compile(Autograd::new(orig_a_id, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            // Should have 2*3*4 = 24 elements, all with gradient 1.0
+            let grad_vec = get_vec(grads[0], &mut cx);
+            assert_eq!(grad_vec.len(), 24);
+            assert!(grad_vec.iter().all(|&v| (v - 1.0).abs() < 1e-6));
+        }
+
+        #[test]
+        fn test_add_grad_with_addition() {
+            let mut cx = Graph::new();
+            let a = cx.tensor(3).set([1.0, 2.0, 3.0]);
+            let b = cx.tensor(3).set([4.0, 5.0, 6.0]);
+            let orig_a_id = a.id;
+            let orig_b_id = b.id;
+
+            // Expand and permute a to create fake dims with non-monotonic indexes
+            let a = a.expand((1, 3, 1));
+            let a = a.permute((1, 2, 0));
+
+            // Also transform b
+            let b = b.expand((1, 3, 1));
+            let b = b.permute((1, 2, 0));
+
+            let c = a + b;
+            let loss = c.sum((0, 1, 2));
+
+            let grads = cx.compile(Autograd::new(vec![orig_a_id, orig_b_id], loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            // Gradients for both should be all ones
+            assert_exact(&get_vec(grads[0], &mut cx), &vec![1.0, 1.0, 1.0]);
+            assert_exact(&get_vec(grads[1], &mut cx), &vec![1.0, 1.0, 1.0]);
+        }
+
+        #[test]
+        fn test_add_grad_high_rank() {
+            let mut cx = Graph::new();
+            let a = cx.tensor((2, 2, 2, 2));
+            let orig_a_id = a.id;
+            a.set(vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0, 13.0, 14.0, 15.0,
+                16.0,
+            ]);
+
+            // Add fake dims and permute
+            let a = a.expand((2, 1, 2, 2, 1, 2));
+            let a = a.permute((5, 4, 2, 3, 1, 0));
+
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert!(fake_count >= 2);
+
+            let loss = a.sum((0, 1, 2, 3, 4, 5));
+
+            let grads = cx.compile(Autograd::new(orig_a_id, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            let grad_vec = get_vec(grads[0], &mut cx);
+            assert_eq!(grad_vec.len(), 16);
+            assert!(grad_vec.iter().all(|&v| (v - 1.0).abs() < 1e-6));
+        }
+
+        #[test]
+        fn test_add_grad_partial_fake() {
+            let mut cx = Graph::new();
+            let a = cx.tensor((3, 4)).set(vec![
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+            ]);
+            let orig_a_id = a.id;
+
+            // Expand only in the middle, creating just one fake dim
+            let a = a.expand((3, 1, 4));
+            let a = a.permute((2, 0, 1));
+
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert_eq!(fake_count, 1);
+
+            let loss = a.sum((0, 1, 2));
+
+            let grads = cx.compile(Autograd::new(orig_a_id, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            let grad_vec = get_vec(grads[0], &mut cx);
+            assert_eq!(grad_vec.len(), 12);
+            assert!(grad_vec.iter().all(|&v| (v - 1.0).abs() < 1e-6));
+        }
+
+        #[test]
+        fn test_add_grad_with_elementwise_ops() {
+            let mut cx = Graph::new();
+            let a = cx.tensor(4).set([1.0, 2.0, 3.0, 4.0]);
+            let orig_a_id = a.id;
+
+            // Expand and permute to create fake dims with non-monotonic indexes
+            let a = a.expand((1, 1, 4));
+            let a = a.permute((2, 1, 0));
+
+            // Apply element-wise operations
+            let b = a.sin();
+            let loss = b.sum((0, 1, 2));
+
+            let grads = cx.compile(Autograd::new(orig_a_id, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            // Gradient should be cos(a) for each element
+            let expected: Vec<f32> = vec![1.0_f32, 2.0, 3.0, 4.0]
+                .into_iter()
+                .map(|x| x.cos())
+                .collect();
+            assert_close(&get_vec(grads[0], &mut cx), &expected);
+        }
+
+        #[test]
+        fn test_undo_permute_behavior() {
+            // Test that the undo-permute step correctly aligns gradient coordinates with forward tensor
+            let mut cx = Graph::new();
+
+            // Create a tensor and transform it like in the failing test
+            let a = cx.tensor((2, 3)).set([[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]);
+            let orig_a_id = a.id;
+
+            // Apply complex transformations that create non-monotonic indexes
+            let a = a.expand((2, 1, 1, 1, 3));
+            let a = a.permute((4, 1, 0, 3, 2));
+
+            // Verify the shape has the expected properties
+            assert_eq!(a.shape.len(), 5);
+            let fake_count = a.shape.fake.iter().filter(|&&b| b).count();
+            assert!(fake_count >= 3);
+
+            // Sum to scalar - this should work without out-of-bounds errors
+            let loss = a.sum((0, 1, 2, 3, 4));
+            let grads = cx.compile(Autograd::new(vec![orig_a_id], loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            // Verify the gradient is correct (all ones)
+            let grad_vec = get_vec(grads[0], &mut cx);
+            assert_eq!(grad_vec.len(), 6); // 2 * 3
+            assert!(grad_vec.iter().all(|&v| (v - 1.0).abs() < 1e-6));
+        }
+
+        #[test]
+        fn test_add_grad_requires_real_contiguous() {
+            let mut cx = Graph::new();
+
+            // Make a 2×3 tensor, broadcast & permute so it’s decidedly non-contiguous
+            let a = cx.tensor((2, 3)).set([[1., 2., 3.], [4., 5., 6.]]);
+            let orig = a.id;
+            let a = a.expand((1, 2, 3)).permute((2, 1, 0));
+
+            // Loss is a *second* sum-reduce: first autograd will insert its own,
+            // then this explicit one forces another op to read the result.
+            // If the fake “contiguous” flag is wrong, the second reduction sees
+            // bad strides and the numeric answer is off.
+            let loss = a.sum((0, 1, 2)).sum(());
+            let g = cx.compile(Autograd::new(orig, loss), ());
+            cx.keep_tensors(&g);
+            cx.execute();
+
+            // Expected gradient is still all ones (two sums in series)
+            assert_exact(&GraphTensor::from_id(g[0].0, g[0].1, &mut cx).data(),
+                        &vec![1., 1., 1., 1., 1., 1.]);
+        }
+        #[test]
+        fn test_add_grad_preserves_unfaked_dim() {
+            let mut cx = Graph::new();
+
+            // b is broadcast → fake for forward, but we turn it real with *a
+            let b = cx.tensor(1).set([2.]);          // shape [1] fake dim
+            let a = cx.tensor(3).set([1., 2., 3.]);  // shape [3]
+            let c = b.expand((3,)) * a;              // broadcast multiply
+            let loss = c.sum(0);                     // scalar
+
+            let grads = cx.compile(Autograd::new(b.id, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            // dloss/db = sum(a) = 6
+            assert_exact(&GraphTensor::from_id(grads[0].0, grads[0].1, &mut cx).data(),
+                        &vec![6.0]);
+        }
+
+        #[test]
+        fn test_add_grad_max_rank_broadcast() {
+            let mut cx = Graph::new();
+            // Test with maximum supported rank (6 dimensions) with many fake dims
+            // ShapeTracker uses ArrayVec with capacity 6, so this is the limit
+            let a = cx.tensor((2, 1, 3, 1, 1, 4));   // 6 dims, many fake
+            // Set some values - we need 2*3*4 = 24 values
+            a.set(vec![1.0; 24]);
+            let orig = a.id;
+            let loss = a.sum((0, 1, 2, 3, 4, 5));
+
+            let grads = cx.compile(Autograd::new(orig, loss), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            // Verify gradient is correct (all ones)
+            let grad_vec = get_vec(grads[0], &mut cx);
+            assert_eq!(grad_vec.len(), 2 * 3 * 4); // 24 elements
+            assert!(grad_vec.iter().all(|&v| (v - 1.0).abs() < 1e-6));
+        }
+
+        #[test]
+        fn test_add_grad_perm_weight_noncontig() {
+            let mut cx = Graph::new();
+            // Weight is 2×2 but permuted so strides are swapped
+            // This tests that autograd correctly handles non-contiguous tensors
+            let w = cx.tensor((2,2)).set([[1.,2.],[3.,4.]]).permute((1,0));
+            let x = cx.tensor(2).set([10., 5.]);
+            let out = x.matmul(w).sum(0);
+
+            // This should compile and execute without out-of-bounds errors
+            let grads = cx.compile(Autograd::new(w.id, out), ());
+            cx.keep_tensors(&grads);
+            cx.execute();
+
+            // Verify we got a gradient with the correct shape (2x2 = 4 elements)
+            let grad_vec = get_vec(grads[0], &mut cx);
+            assert_eq!(grad_vec.len(), 4);
+            // Verify gradient values are reasonable (not NaN or Inf)
+            assert!(grad_vec.iter().all(|&v| v.is_finite()));
+        }
     }
 }

--- a/crates/luminal_training/src/autograd.rs
+++ b/crates/luminal_training/src/autograd.rs
@@ -183,12 +183,11 @@ impl Compiler for Autograd {
     }
 }
 
-fn add_grad(
+fn normalize_grad_for_input(
     mut grad: GraphTensor,
-    fwd: GraphTensor,
+    fwd: &GraphTensor,
     graph: &mut Graph,
-    grad_map: &mut FxHashMap<NodeIndex, (NodeIndex, ShapeTracker)>,
-) {
+) -> GraphTensor {
     // Reshape gradient to match the shape of the input source (before the input was reshaped)
     // Undo permutes
     let mut new_indexes = ArrayVec::new();
@@ -224,6 +223,18 @@ fn add_grad(
             grad.shape = pre_fwd_shape.contiguous();
         }
     }
+    grad
+}
+
+fn add_grad(
+    mut grad: GraphTensor,
+    fwd: GraphTensor,
+    graph: &mut Graph,
+    grad_map: &mut FxHashMap<NodeIndex, (NodeIndex, ShapeTracker)>,
+) {
+
+    // Normalize/reshape incoming grad to match `fwd`'s semantics.
+    let grad = normalize_grad_for_input(grad, &fwd, graph);
 
     if let Some((existing_grad_node, existing_grad_shape)) = grad_map.get(&fwd.id).copied() {
         let grad = GraphTensor::from_id(grad.id, grad.shape, graph);
@@ -970,6 +981,87 @@ mod tests {
             assert_eq!(grad_vec.len(), 4);
             // Verify gradient values are reasonable (not NaN or Inf)
             assert!(grad_vec.iter().all(|&v| v.is_finite()));
+        }
+    }
+
+        // ---------------------------
+    // Unit tests for normalize_grad_for_input
+    // ---------------------------
+    mod normalize_tests {
+        use super::*;
+
+        // Helper to get materialized data from a GraphTensor
+        fn data_of(t: &GraphTensor, cx: &mut Graph) -> Vec<f32> {
+            GraphTensor::from_id(t.id, t.shape, cx as *mut Graph).data()
+        }
+
+        /// White-box unit test replicating `test_add_grad_decreasing.rs`.
+        /// It verifies that `normalize_grad_for_input` correctly handles a `fwd` tensor
+        /// with multiple fake dimensions and non-monotonic `indexes`.
+        #[test]
+        fn test_normalize_handles_non_monotonic_indexes_and_multi_fake_dims() {
+            let mut cx = Graph::new();
+            // 1. Construct `fwd` tensor state with non-monotonic indexes and multiple fake dims.
+            // Use a real tensor (constant reshaped) instead of an uninitialized placeholder
+            // so execution doesn't attempt to load an unset value for this node.
+            let fwd_base = cx.constant(0.0).reshape((2, 3));
+            let fwd_expanded = fwd_base.expand((2, 1, 3, 1));
+            // Sanity-check the expanded state before permuting
+            assert_eq!(fwd_expanded.shape.shape_usize(), vec![2, 1, 3, 1]);
+            assert_eq!(fwd_expanded.shape.indexes.as_slice(), &[0, 2, 1, 3]);
+            assert_eq!(fwd_expanded.shape.fake.as_slice(), &[false, false, true, true]);
+            let fwd = fwd_expanded.permute((2, 3, 0, 1));
+
+            // Sanity-check the forward tensor's shape properties.
+            assert_eq!(fwd.shape.shape_usize(), vec![3, 1, 2, 1]);
+            assert_eq!(fwd.shape.indexes.as_slice(), &[1, 3, 0, 2]);
+            assert_eq!(fwd.shape.fake.as_slice(), &[false, false, true, true]); 
+
+            // 2. Simulate upstream gradient of broadcasted `1.0`.
+            let grad: GraphTensor = cx.constant(1.0).expand((3, 1, 2, 1));
+
+            // 3. Call the function under test.
+            let out = super::normalize_grad_for_input(grad, &fwd, &mut cx);
+
+            // 4. White-box verification:
+            //    - The output should have had two SumReduce ops applied.
+            //    - We can verify this by checking the final shape, which should be [2, 3].
+            assert_eq!(out.shape.shape_usize(), vec![2, 3]);
+
+            // 5. Execute graph and verify final data.
+            //    The gradient of 1.0, reduced over two fake dims of size 1, should
+            //    result in a [2, 3] tensor of ones.
+            cx.keep_tensors(vec![(out.id, out.shape)]);
+            cx.execute();
+            let expected_data = vec![1.0; 6];
+            assert_exact(&data_of(&out, &mut cx), &expected_data);
+        }
+
+        /// Unit test to verify `normalize_grad_for_input` does nothing when no fake
+        /// dimensions or permutes are present.
+        #[test]
+        fn test_normalize_is_noop_for_simple_shapes() {
+            let mut cx = Graph::new();
+            // 1. `fwd` tensor is a simple, contiguous tensor.
+            let fwd = cx.tensor(3).set([1.0, 2.0, 3.0]);
+
+            // 2. Upstream grad is ones with the same shape.
+            let grad = cx.tensor(3).set([1.0, 1.0, 1.0]);
+            let original_grad_id = grad.id;
+
+            // 3. Call the function under test.
+            let out = super::normalize_grad_for_input(grad, &fwd, &mut cx);
+
+            // 4. White-box verification:
+            //    - No new ops should be added. The output ID should be the same as the input.
+            assert_eq!(out.id, original_grad_id, "No new nodes should be created");
+            //    - The output shape should be identical to the input shape.
+            assert_eq!(out.shape.shape_usize(), vec![3]);
+
+            // 5. Verify data.
+            cx.keep_tensors(vec![(out.id, out.shape)]);
+            cx.execute();
+            assert_exact(&data_of(&out, &mut cx), &vec![1.0, 1.0, 1.0]);
         }
     }
 }

--- a/crates/luminal_training/src/autograd.rs
+++ b/crates/luminal_training/src/autograd.rs
@@ -188,15 +188,15 @@ fn normalize_grad_for_input(
     fwd: &GraphTensor,
     graph: &mut Graph,
 ) -> GraphTensor {
-
     // If grad has fewer logical axes than fwd (common when forward used expand/broadcast),
     // insert broadcasted axes into grad at the logical positions where fwd is fake.
     // Do this before undoing permutes so indexes line up.
     if grad.shape.len() < fwd.shape.len() {
         let _need = fwd.shape.len() - grad.shape.len();
         // insert fake positions from highest -> lowest so indices remain valid
-        let mut fake_positions: Vec<usize> =
-            (0..fwd.shape.len()).filter(|&i| fwd.shape.fake[i]).collect();
+        let mut fake_positions: Vec<usize> = (0..fwd.shape.len())
+            .filter(|&i| fwd.shape.fake[i])
+            .collect();
         fake_positions.sort_unstable_by(|a, b| b.cmp(a));
         for &pos in &fake_positions {
             if grad.shape.len() >= fwd.shape.len() {
@@ -226,8 +226,9 @@ fn normalize_grad_for_input(
     grad.shape.indexes = new_indexes;
 
     // Undo expands (sum-reduce on every fake dimension)
-    let mut fake_dims: Vec<usize> =
-        (0..fwd.shape.len()).filter(|&idx| fwd.shape.fake[idx]).collect();
+    let mut fake_dims: Vec<usize> = (0..fwd.shape.len())
+        .filter(|&idx| fwd.shape.fake[idx])
+        .collect();
 
     // Remove highest indices first so later indices stay valid.
     fake_dims.sort_unstable_by(|a, b| b.cmp(a));
@@ -266,7 +267,6 @@ fn add_grad(
     graph: &mut Graph,
     grad_map: &mut FxHashMap<NodeIndex, (NodeIndex, ShapeTracker)>,
 ) {
-
     // Normalize/reshape incoming grad to match `fwd`'s semantics.
     let grad = normalize_grad_for_input(grad, &fwd, graph);
 
@@ -466,7 +466,8 @@ mod tests {
 
             let d_dev = Cpu::default();
             let mut d_model = d_dev
-                .build_module::<dfdx::nn::modules::builders::TransformerEncoderBlock<3, 1, 4>, f32>();
+                .build_module::<dfdx::nn::modules::builders::TransformerEncoderBlock<3, 1, 4>, f32>(
+                );
             d_model.self_attn.w_k.bias.copy_from(&[0.0, 0.0, 0.0]);
             d_model.self_attn.w_v.bias.copy_from(&[0.0, 0.0, 0.0]);
             d_model.self_attn.w_q.bias.copy_from(&[0.0, 0.0, 0.0]);
@@ -515,7 +516,8 @@ mod tests {
             d_model.norm2.beta = d_dev.tensor_from_vec(vec![0., 0., 0.], (DConst::<3>,));
             d_model.norm1.beta = d_dev.tensor_from_vec(vec![0., 0., 0.], (DConst::<3>,));
             d_model.norm2.epsilon = 1e-5;
-            let d_a = d_dev.tensor_from_vec(vec![-1., 2., 3., 3., 3., -1.], (DConst::<2>, DConst::<3>));
+            let d_a =
+                d_dev.tensor_from_vec(vec![-1., 2., 3., 3., 3., -1.], (DConst::<2>, DConst::<3>));
             let d_target =
                 d_dev.tensor_from_vec(vec![0., 1., 0., 0., 0., 1.], (DConst::<2>, DConst::<3>));
             let d_b = d_model.forward(d_a.trace(Gradients::leaky()));
@@ -953,26 +955,30 @@ mod tests {
             cx.execute();
 
             // Expected gradient is still all ones (two sums in series)
-            assert_exact(&GraphTensor::from_id(g[0].0, g[0].1, &mut cx).data(),
-                        &vec![1., 1., 1., 1., 1., 1.]);
+            assert_exact(
+                &GraphTensor::from_id(g[0].0, g[0].1, &mut cx).data(),
+                &vec![1., 1., 1., 1., 1., 1.],
+            );
         }
         #[test]
         fn test_add_grad_preserves_unfaked_dim() {
             let mut cx = Graph::new();
 
             // b is broadcast → fake for forward, but we turn it real with *a
-            let b = cx.tensor(1).set([2.]);          // shape [1] fake dim
-            let a = cx.tensor(3).set([1., 2., 3.]);  // shape [3]
-            let c = b.expand((3,)) * a;              // broadcast multiply
-            let loss = c.sum(0);                     // scalar
+            let b = cx.tensor(1).set([2.]); // shape [1] fake dim
+            let a = cx.tensor(3).set([1., 2., 3.]); // shape [3]
+            let c = b.expand((3,)) * a; // broadcast multiply
+            let loss = c.sum(0); // scalar
 
             let grads = cx.compile(Autograd::new(b.id, loss), ());
             cx.keep_tensors(&grads);
             cx.execute();
 
             // dloss/db = sum(a) = 6
-            assert_exact(&GraphTensor::from_id(grads[0].0, grads[0].1, &mut cx).data(),
-                        &vec![6.0]);
+            assert_exact(
+                &GraphTensor::from_id(grads[0].0, grads[0].1, &mut cx).data(),
+                &vec![6.0],
+            );
         }
 
         #[test]
@@ -980,8 +986,8 @@ mod tests {
             let mut cx = Graph::new();
             // Test with maximum supported rank (6 dimensions) with many fake dims
             // ShapeTracker uses ArrayVec with capacity 6, so this is the limit
-            let a = cx.tensor((2, 1, 3, 1, 1, 4));   // 6 dims, many fake
-            // Set some values - we need 2*3*4 = 24 values
+            let a = cx.tensor((2, 1, 3, 1, 1, 4)); // 6 dims, many fake
+                                                   // Set some values - we need 2*3*4 = 24 values
             a.set(vec![1.0; 24]);
             let orig = a.id;
             let loss = a.sum((0, 1, 2, 3, 4, 5));
@@ -1001,7 +1007,7 @@ mod tests {
             let mut cx = Graph::new();
             // Weight is 2×2 but permuted so strides are swapped
             // This tests that autograd correctly handles non-contiguous tensors
-            let w = cx.tensor((2,2)).set([[1.,2.],[3.,4.]]).permute((1,0));
+            let w = cx.tensor((2, 2)).set([[1., 2.], [3., 4.]]).permute((1, 0));
             let x = cx.tensor(2).set([10., 5.]);
             let out = x.matmul(w).sum(0);
 
@@ -1018,7 +1024,7 @@ mod tests {
         }
     }
 
-        // ---------------------------
+    // ---------------------------
     // Unit tests for normalize_grad_for_input
     // ---------------------------
     mod normalize_tests {
@@ -1043,13 +1049,16 @@ mod tests {
             // Sanity-check the expanded state before permuting
             assert_eq!(fwd_expanded.shape.shape_usize(), vec![2, 1, 3, 1]);
             assert_eq!(fwd_expanded.shape.indexes.as_slice(), &[0, 2, 1, 3]);
-            assert_eq!(fwd_expanded.shape.fake.as_slice(), &[false, false, true, true]);
+            assert_eq!(
+                fwd_expanded.shape.fake.as_slice(),
+                &[false, false, true, true]
+            );
             let fwd = fwd_expanded.permute((2, 3, 0, 1));
 
             // Sanity-check the forward tensor's shape properties.
             assert_eq!(fwd.shape.shape_usize(), vec![3, 1, 2, 1]);
             assert_eq!(fwd.shape.indexes.as_slice(), &[1, 3, 0, 2]);
-            assert_eq!(fwd.shape.fake.as_slice(), &[false, false, true, true]); 
+            assert_eq!(fwd.shape.fake.as_slice(), &[false, false, true, true]);
 
             // 2. Simulate upstream gradient of broadcasted `1.0`.
             let grad: GraphTensor = cx.constant(1.0).expand((3, 1, 2, 1));

--- a/crates/luminal_training/src/autograd.rs
+++ b/crates/luminal_training/src/autograd.rs
@@ -188,7 +188,7 @@ fn normalize_grad_for_input(
     fwd: &GraphTensor,
     graph: &mut Graph,
 ) -> GraphTensor {
-    // Reshape gradient to match the shape of the input source (before the input was reshaped)
+
     // Undo permutes
     let mut new_indexes = ArrayVec::new();
     new_indexes.resize(fwd.shape.len(), 0);
@@ -197,16 +197,21 @@ fn normalize_grad_for_input(
     }
     grad.shape.indexes = new_indexes;
 
-    // Undo expands (sum reduce)
-    for i in fwd.shape.indexes.into_iter().rev() {
-        if fwd.shape.fake[i] {
-            grad.id = graph
-                .add_op(SumReduce(i))
-                .input(grad.id, 0, grad.shape)
-                .finish();
-            grad.shape.remove_dim(i);
-            grad.shape = grad.shape.contiguous();
-        }
+    // Undo expands (sum-reduce on every fake dimension)
+    let mut fake_dims: Vec<usize> =
+        (0..fwd.shape.len()).filter(|&idx| fwd.shape.fake[idx]).collect();
+
+    // Remove highest indices first so later indices stay valid.
+    fake_dims.sort_unstable_by(|a, b| b.cmp(a));
+
+    for idx in fake_dims {
+        grad.id = graph
+            .add_op(SumReduce(idx))
+            .input(grad.id, 0, grad.shape)
+            .finish();
+
+        grad.shape.remove_dim(idx);
+        grad.shape = grad.shape.contiguous();
     }
 
     // Check to see if a reshape was done here. If so, we may need to assert grad shape is contiguous or insert a contiguous call
@@ -223,6 +228,7 @@ fn normalize_grad_for_input(
             grad.shape = pre_fwd_shape.contiguous();
         }
     }
+
     grad
 }
 


### PR DESCRIPTION
## Summary
Fixes #68 - resolves an index out-of-bounds panic in autograd's add_grad function that occurred when computing gradients for tensors with non-monotonic permute indices and fake (broadcasted) dimensions.

### Remarks
I do admit these fixes seem extremely hacky to me. Would appreciate review and even if they work, it might be evidence for the brittleness of ShapeTracker/autograd logic in its current state. 
I also came across another issue with `permute` logic during my debugging, but will make a separate issue for that.

## Commits
The fix is structured across 4 commits for easier cherrypicking:

### 1. Add tests for identifying bug in issue #68 (8c1b5a7)
Reorganized test module structure for better organization
Added comprehensive test cases that reproduce the issue, including:
test_add_grad_decreasing_idx: The original failing case from issue #68
test_add_grad_high_rank: Tests gradient computation with higher-rank tensors
test_add_grad_preserves_unfaked_dim: Tests preservation of non-broadcast dimensions

Status: All new tests fail at this commit (as expected)

### 2. Refactor gradient normalization logic (777d4b2)
Extracted gradient normalization into normalize_grad_for_input helper function
No behavioral changes, pure refactoring
Added unit tests specifically for the normalization logic
Makes the subsequent fixes clearer and more testable

Status: Tests still fail

### 3. Fix add_grad fake-dim removal (Partial fix) (6e898fd)
Core fix: Changed from using logical indices (fwd.shape.indexes) to physical indices when identifying and removing fake dimensions
Now correctly collects fake underlying indices: (0..fwd.shape.len()).filter(|&idx| fwd.shape.fake[idx])
Sorts indices in descending order before removal to prevent index shifting issues
Why this works: Eliminates the mixing of logical/physical index spaces that caused incorrect axis access

Status: Fixes the OOB panic from the original issue, but test_add_grad_preserves_unfaked_dim still fails because rank alignment isn't handled yet

### 4. Fix broadcasted axes in autograd gradient norm (Complete fix) (4057c7e)
Handles the case where incoming gradients have fewer axes than the forward tensor
Inserts missing axes at positions where the forward tensor has fake dimensions before performing undo-permute logic
Uses grad.expand() to ensure gradient shape aligns with forward tensor shape

Remarks: I think this is the hackiest part of the changes, but it does seem necessary to pass `test_add_grad_preserves_unfaked_dim` (which I verified separately is valid logic in pytorch). Unclear if there is a better way.

Status: All tests pass