### PR TITLE
Refine egglog-based symbolic simplification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ serde = { version = "1.0.202", features = ["derive"] }
 thread_local = "1.1.8"
 generational-box = "0.5.6"
 serde_json = "1.0.140"
-egg = "0.9.5"
 egglog = "1.0.0"
 egglog-ast = "1.0.0"
 egraph-serialize = { version = "0.3.0", default-features = false, features = ["graphviz", "serde"]}


### PR DESCRIPTION
### Motivation
- Replace the previous `egg` equality-saturation flow with `egglog` while restoring the prior simplification behavior without runaway saturation. 
- Ensure expressions can be reconstructed from an `egglog` snapshot via the existing serialization path into `SerializedEGraph`.
- Normalize multiplicative/divisive constant patterns safely after extraction to avoid incorrect algebraic rewrites that depend on particular variables.

### Description
- Replace the `egg` path with an `egglog` flow and evaluator, adding imports for `egglog` and `egglog_ast`, parsing and running an `egglog` program and using `eval_expr` to retrieve a serialized egraph. 
- Implement `extract_shortest`, `build_expression`, and `extract_expression` to build `Expression` values from a `SerializedEGraph` trajectory. 
- Add a focused set of `egglog` rewrite rules (inserted into the program and schedule) and a small `ExprNode` helper plus `simplify_mul_div_constants` post-processing to recover previous reductions safely and avoid harmful rewrites on `z`-dependent terms. 
- Fix postfix operand ordering and other expression-tree handling issues and remove the unused `egg` dependency in `Cargo.toml`.

### Testing
- Ran `cargo fmt` to format sources successfully. 
- Ran the full test suite with `cargo test`, and all library and unit tests passed (final run: `58 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694efdb6f2d88325b45396d221c2257a)