### PR TITLE
Add benchmarking metrics to llama example

### DIFF
--- a/examples/llama/src/main.rs
+++ b/examples/llama/src/main.rs
@@ -11,7 +11,7 @@ use luminal_cuda::{
 };
 use model::*;
 use rustc_hash::*;
-use std::{fs::File, io::Write, time::Duration};
+use std::{fs::File, io::Write, time::Duration, time::Instant};
 use tokenizers::Tokenizer;
 use tracing::{span, Level};
 use tracing_appender::non_blocking;
@@ -88,6 +88,11 @@ fn main() {
 
     let mut timings = vec![];
     let mut prev_seq = 0;
+    let mut ttft = None;
+    let mut decode_durations = Vec::with_capacity(gen_tokens.saturating_sub(1));
+    let start_generation = Instant::now();
+    let mut total_flops = 0u64;
+    let mut total_bytes = 0u64;
     for i in 0..gen_tokens {
         let span = if i == 0 {
             span!(Level::INFO, "prefill")
@@ -117,6 +122,10 @@ fn main() {
             runtime.allocate_intermediate_buffers(&cx.dyn_map);
         }
 
+        let iter_start = Instant::now();
+        let (iter_flops, iter_bytes) = estimate_flops_and_bytes(seq_len, prev_seq);
+        total_flops += iter_flops;
+        total_bytes += iter_bytes;
         timings.extend(runtime.execute(&cx.dyn_map));
         let logits_data = runtime.get_f32(logits.id);
 
@@ -126,8 +135,65 @@ fn main() {
         prev_seq += seq_len;
         print!("{}", tokenizer.decode(&sentence, true).unwrap());
         std::io::stdout().flush().unwrap();
+        let iter_duration = iter_start.elapsed();
+        if i == 0 {
+            ttft = Some(iter_duration);
+        } else {
+            decode_durations.push(iter_duration);
+        }
     }
     println!();
+
+    let total_elapsed = start_generation.elapsed();
+    let decode_total = decode_durations
+        .iter()
+        .fold(Duration::ZERO, |acc, value| acc + *value);
+    let tpot = if decode_durations.is_empty() {
+        None
+    } else {
+        Some(decode_total / decode_durations.len() as u32)
+    };
+    let achieved_tflops = total_flops as f64 / total_elapsed.as_secs_f64() / 1e12;
+    let achieved_gbps = total_bytes as f64 / total_elapsed.as_secs_f64() / 1e9;
+    let peak_tflops = std::env::var("LUMINAL_PEAK_TFLOPS")
+        .ok()
+        .and_then(|value| value.parse::<f64>().ok())
+        .unwrap_or(0.0);
+    let peak_gbps = std::env::var("LUMINAL_PEAK_BW_GBPS")
+        .ok()
+        .and_then(|value| value.parse::<f64>().ok())
+        .unwrap_or(0.0);
+    let mfu = if peak_tflops > 0.0 {
+        Some(achieved_tflops / peak_tflops)
+    } else {
+        None
+    };
+    let mbu = if peak_gbps > 0.0 {
+        Some(achieved_gbps / peak_gbps)
+    } else {
+        None
+    };
+    println!("Benchmark results:");
+    if let Some(ttft) = ttft {
+        println!("  TTFT: {:.2} ms", ttft.as_secs_f64() * 1e3);
+    }
+    if let Some(tpot) = tpot {
+        println!("  TPOT: {:.2} ms", tpot.as_secs_f64() * 1e3);
+    }
+    println!(
+        "  Achieved: {:.2} TFLOP/s, {:.2} GB/s",
+        achieved_tflops, achieved_gbps
+    );
+    if let Some(mfu) = mfu {
+        println!("  MFU (est): {:.1}%", mfu * 100.0);
+    } else {
+        println!("  MFU (est): N/A (set LUMINAL_PEAK_TFLOPS)");
+    }
+    if let Some(mbu) = mbu {
+        println!("  MBU (est): {:.1}%", mbu * 100.0);
+    } else {
+        println!("  MBU (est): N/A (set LUMINAL_PEAK_BW_GBPS)");
+    }
 
     layer_handle
         .flush(Duration::from_secs(5), Duration::from_secs(5))
@@ -139,6 +205,45 @@ fn main() {
         &<luminal_cuda::block::Ops as IntoBlockOp>::into_vec(),
         "trace.pftrace",
     );
+}
+
+fn estimate_flops_and_bytes(seq_len: usize, prev_seq: usize) -> (u64, u64) {
+    let total_seq = seq_len + prev_seq;
+    let hidden = HIDDEN as u64;
+    let intermediate = INTERMEDIATE as u64;
+    let seq = seq_len as u64;
+    let total_seq = total_seq as u64;
+    let head_dim = HEAD_DIM as u64;
+    let n_heads = hidden / head_dim;
+    let kv_hidden = (HIDDEN / KV_GROUPS) as u64;
+    let vocab = VOCAB_SIZE as u64;
+    let bytes_per = std::mem::size_of::<f32>() as u64;
+
+    let q_proj_flops = 2 * seq * hidden * hidden;
+    let k_proj_flops = 2 * seq * hidden * kv_hidden;
+    let v_proj_flops = 2 * seq * hidden * kv_hidden;
+    let o_proj_flops = 2 * seq * hidden * hidden;
+    let mlp_flops = 6 * seq * hidden * intermediate;
+    let attn_flops = 4 * seq * total_seq * head_dim * n_heads;
+    let lm_head_flops = 2 * seq * hidden * vocab;
+
+    let per_layer_flops =
+        q_proj_flops + k_proj_flops + v_proj_flops + o_proj_flops + mlp_flops + attn_flops;
+    let total_flops = per_layer_flops * LAYERS as u64 + lm_head_flops;
+
+    let q_bytes = bytes_per * (seq * hidden + hidden * hidden + seq * hidden);
+    let k_bytes = bytes_per * (seq * hidden + hidden * kv_hidden + seq * kv_hidden);
+    let v_bytes = bytes_per * (seq * hidden + hidden * kv_hidden + seq * kv_hidden);
+    let o_bytes = bytes_per * (seq * hidden + hidden * hidden + seq * hidden);
+    let mlp_bytes = bytes_per * (seq * hidden + hidden * intermediate + seq * intermediate) * 2
+        + bytes_per * (seq * intermediate + intermediate * hidden + seq * hidden);
+    let attn_bytes = bytes_per * (seq * hidden + total_seq * kv_hidden * 2 + seq * hidden);
+    let lm_head_bytes = bytes_per * (seq * hidden + hidden * vocab + seq * vocab);
+
+    let per_layer_bytes = q_bytes + k_bytes + v_bytes + o_bytes + mlp_bytes + attn_bytes;
+    let total_bytes = per_layer_bytes * LAYERS as u64 + lm_head_bytes;
+
+    (total_flops, total_bytes)
 }
 
 #[tracing::instrument(skip_all)]


### PR DESCRIPTION
### Motivation
- Provide built-in benchmarking in the llama example to measure generation performance metrics like TTFT and TPOT.
- Estimate compute and memory work per iteration so the example can report achieved TFLOP/s and GB/s.
- Offer simple hardware utilization estimates (MFU/MBU) derived from configurable peak values for quick profiling sanity checks.

### Description
- Added timing capture around the generation loop using `Instant` to compute `TTFT`, per-token decode durations, and `TPOT` in `examples/llama/src/main.rs`.
- Implemented `estimate_flops_and_bytes` to approximate per-iteration FLOPs and memory bytes and accumulated totals to compute achieved TFLOP/s and GB/s.
- Added optional MFU/MBU estimates read from `LUMINAL_PEAK_TFLOPS` and `LUMINAL_PEAK_BW_GBPS` environment variables and printed a concise benchmark summary at the end of the run.
- Integrated the new measurements with the existing execution flow and preserved the existing tracing/recording behavior and `record_exec_timings_to_file` call.

### Testing
- Ran `cargo fmt` on the repository and the formatting pass completed successfully.
- No automated unit tests or `cargo test` runs were executed as part of this change in the example.
- The change was limited to `examples/llama/src/main.rs` and formatted before committing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6955c77a754c8325830b38314111a912)