### PR TITLE
Add ~47 reduction and shape/movement op translations to PT2 backend

### DIFF
--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -5,6 +5,7 @@ use crate::pt2_schema::*;
 use crate::pt2_util::*;
 
 use super::Translator;
+use super::reduction::concrete_numel;
 
 impl<'a> Translator<'a> {
     pub(crate) fn translate_node(&mut self, node: &Node) -> Result<()> {
@@ -393,6 +394,70 @@ impl<'a> Translator<'a> {
             }
             "torch.ops.aten.amin.default" => self.translate_reduction(node, ReductionOp::Min)?,
 
+            // Single-output reduction ops
+            "torch.ops.aten.argmax.default" => self.translate_argmax(node)?,
+            "torch.ops.aten.argmin.default" => self.translate_argmin(node)?,
+            "torch.ops.aten.prod.default" | "torch.ops.aten.prod.dim_int" => {
+                self.translate_prod(node)?
+            }
+            "torch.ops.aten.argsort.default" | "torch.ops.aten.argsort.stable" => {
+                self.translate_argsort_op(node)?
+            }
+            "torch.ops.aten.log_softmax.int" | "torch.ops.aten._log_softmax.default" => {
+                self.translate_log_softmax(node)?
+            }
+            "torch.ops.aten.all.default" | "torch.ops.aten.all.dim" => {
+                self.translate_all(node)?
+            }
+            "torch.ops.aten.any.default" | "torch.ops.aten.any.dim" => {
+                self.translate_any(node)?
+            }
+            "torch.ops.aten.count_nonzero.default"
+            | "torch.ops.aten.count_nonzero.dim_IntList" => self.translate_count_nonzero(node)?,
+            "torch.ops.aten.nansum.default" => self.translate_nansum(node)?,
+            "torch.ops.aten.nanmean.default" => self.translate_nanmean(node)?,
+            "torch.ops.aten.logsumexp.default" => self.translate_logsumexp(node)?,
+            "torch.ops.aten.sum_to_size.default" => self.translate_sum_to_size(node)?,
+            "torch.ops.aten.std.correction" | "torch.ops.aten.std.default" => {
+                self.translate_std_op(node)?
+            }
+            "torch.ops.aten.var.correction" | "torch.ops.aten.var.default" => {
+                self.translate_var_op(node)?
+            }
+            "torch.ops.aten.median.default" | "torch.ops.aten.median.dim" => {
+                self.translate_median(node)?
+            }
+            "torch.ops.aten.msort.default" => {
+                let a = self.get_input_tensor(node, 0)?;
+                a.sort(0, false)
+            }
+
+            // Multi-output reduction ops
+            "torch.ops.aten.sort.default" | "torch.ops.aten.sort.stable" => {
+                self.translate_sort_op(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.max.dim" | "torch.ops.aten.min.dim" => {
+                self.translate_max_min_dim(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.std_mean.correction" | "torch.ops.aten.std_mean.default" => {
+                self.translate_std_mean(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.var_mean.correction" | "torch.ops.aten.var_mean.default" => {
+                self.translate_var_mean(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.aminmax.default" => {
+                self.translate_aminmax(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.kthvalue.default" => {
+                self.translate_kthvalue(node)?;
+                return Ok(());
+            }
+
             // Gather (axis-aware)
             "torch.ops.aten.gather.default" => self.translate_gather(node)?,
 
@@ -411,8 +476,35 @@ impl<'a> Translator<'a> {
             }
 
             // Split
-            "torch.ops.aten.split.Tensor" | "torch.ops.aten.split_with_sizes.default" => {
-                self.translate_split(node)?
+            "torch.ops.aten.split.Tensor"
+            | "torch.ops.aten.split_with_sizes.default"
+            | "torch.ops.aten.unsafe_split.Tensor"
+            | "torch.ops.aten.split_with_sizes_copy.default" => self.translate_split(node)?,
+
+            // Chunk
+            "torch.ops.aten.chunk.default" | "torch.ops.aten.unsafe_chunk.default" => {
+                self.translate_chunk(node)?;
+                return Ok(());
+            }
+
+            // Unbind
+            "torch.ops.aten.unbind.int" | "torch.ops.aten.unbind_copy.int" => {
+                self.translate_unbind(node)?;
+                return Ok(());
+            }
+
+            // Directional splits
+            "torch.ops.aten.dsplit.int" | "torch.ops.aten.dsplit.array" => {
+                self.translate_dsplit(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.hsplit.int" => {
+                self.translate_hsplit(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.vsplit.int" => {
+                self.translate_vsplit(node)?;
+                return Ok(());
             }
 
             // One-hot
@@ -432,6 +524,65 @@ impl<'a> Translator<'a> {
                 a % b
             }
 
+            // Shape / View / Movement ops
+            "torch.ops.aten.flatten.using_ints" => self.translate_flatten(node)?,
+            "torch.ops.aten.unflatten.int" => self.translate_unflatten(node)?,
+            "torch.ops.aten.ravel.default" => {
+                let a = self.get_input_tensor(node, 0)?;
+                a.flatten()
+            }
+            "torch.ops.aten.view_as.default" | "torch.ops.aten.reshape_as.default" => {
+                self.translate_reshape_as(node)?
+            }
+            "torch.ops.aten.movedim.intlist" | "torch.ops.aten.movedim.int" => {
+                self.translate_movedim(node)?
+            }
+            "torch.ops.aten.atleast_1d.default" => {
+                let a = self.get_input_tensor(node, 0)?;
+                if a.shape.len() == 0 {
+                    a.unsqueeze(0)
+                } else {
+                    a
+                }
+            }
+            "torch.ops.aten.atleast_2d.default" => {
+                let a = self.get_input_tensor(node, 0)?;
+                match a.shape.len() {
+                    0 => a.unsqueeze(0).unsqueeze(0),
+                    1 => a.unsqueeze(0),
+                    _ => a,
+                }
+            }
+            "torch.ops.aten.atleast_3d.default" => {
+                let a = self.get_input_tensor(node, 0)?;
+                match a.shape.len() {
+                    0 => a.unsqueeze(0).unsqueeze(0).unsqueeze(0),
+                    1 => a.unsqueeze(0).unsqueeze(2),
+                    2 => a.unsqueeze(2),
+                    _ => a,
+                }
+            }
+            "torch.ops.aten.narrow.default"
+            | "torch.ops.aten.narrow_copy.default"
+            | "torch.ops.aten.narrow.Tensor" => self.translate_narrow(node)?,
+            "torch.ops.aten.constant_pad_nd.default" => self.translate_constant_pad_nd(node)?,
+            "torch.ops.aten.repeat.default" | "torch.ops.aten.tile.default" => {
+                self.translate_repeat(node)?
+            }
+            "torch.ops.aten.fill.Scalar" | "torch.ops.aten.fill.Tensor" => {
+                self.translate_fill(node)?
+            }
+            "torch.ops.aten.broadcast_to.default" => self.translate_broadcast_to(node)?,
+            "torch.ops.aten.broadcast_tensors.default" => {
+                self.translate_broadcast_tensors(node)?;
+                return Ok(());
+            }
+            "torch.ops.aten.mT.default" => {
+                let a = self.get_input_tensor(node, 0)?;
+                let n = a.shape.len();
+                a.transpose(n - 2, n - 1)
+            }
+
             other => {
                 bail!("Unsupported ATen op: {other}");
             }
@@ -442,15 +593,6 @@ impl<'a> Translator<'a> {
         }
         Ok(())
     }
-}
-
-/// Compute total element count, returning an error if any dimension is symbolic.
-fn concrete_numel(a: &GraphTensor) -> Result<usize> {
-    a.dims().iter().try_fold(1usize, |acc, d| {
-        d.to_usize().map(|v| acc * v).ok_or_else(|| {
-            anyhow::anyhow!("Full reduction requires concrete dimensions, got symbolic dim")
-        })
-    })
 }
 
 impl<'a> Translator<'a> {

--- a/crates/luminal_python/rust/src/translator/movement.rs
+++ b/crates/luminal_python/rust/src/translator/movement.rs
@@ -432,7 +432,10 @@ impl<'a> Translator<'a> {
 
     pub(crate) fn translate_split(&mut self, node: &Node) -> Result<GraphTensor> {
         let a = self.get_input_tensor(node, 0)?;
-        let split_size = self.get_int_arg(node, 1)? as usize;
+
+        // Check if arg 1 is a list of sizes (split_with_sizes) or a single int (split)
+        let is_sizes_list = node.inputs[1].arg.as_ints().is_some();
+
         let dim = if node.inputs.len() > 2 {
             self.get_int_arg(node, 2).unwrap_or(0)
         } else {
@@ -455,20 +458,336 @@ impl<'a> Translator<'a> {
                         .collect()
                 });
 
-            // Store each chunk under its output name
-            for (i, out_name) in output_names.iter().enumerate() {
-                let start = i * split_size;
-                let end = ((i + 1) * split_size).min(total);
-                if start < total {
-                    let chunk = a.slice_along(start..end, dim);
-                    self.tensors.insert(out_name.clone(), chunk);
+            if is_sizes_list {
+                // split_with_sizes: arg 1 is a list of sizes
+                let sizes = self.get_ints_arg(node, 1)?;
+                let mut start = 0usize;
+                for (i, out_name) in output_names.iter().enumerate() {
+                    let chunk_size = sizes[i] as usize;
+                    let end = start + chunk_size;
+                    if start < total && chunk_size > 0 {
+                        let chunk = a.slice_along(start..end, dim);
+                        self.tensors.insert(out_name.clone(), chunk);
+                    }
+                    start = end;
                 }
+                Ok(a.slice_along(0..(sizes[0] as usize).min(total), dim))
+            } else {
+                // split: arg 1 is a single chunk size
+                let split_size = self.get_int_arg(node, 1)? as usize;
+                for (i, out_name) in output_names.iter().enumerate() {
+                    let start = i * split_size;
+                    let end = ((i + 1) * split_size).min(total);
+                    if start < total {
+                        let chunk = a.slice_along(start..end, dim);
+                        self.tensors.insert(out_name.clone(), chunk);
+                    }
+                }
+                Ok(a.slice_along(0..split_size.min(total), dim))
             }
-
-            // Return the first chunk
-            Ok(a.slice_along(0..split_size.min(total), dim))
         } else {
+            let split_size = self.get_int_arg(node, 1)? as usize;
             Ok(a.slice_along(0..split_size, dim))
         }
+    }
+
+    // --- Shape / View / Movement ops ---
+
+    pub(crate) fn translate_flatten(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let start = self.get_int_arg(node, 1).unwrap_or(0);
+        let end = self.get_int_arg(node, 2).unwrap_or(-1);
+        let ndim = a.shape.len();
+        let start = normalize_dim(start, ndim);
+        let end = normalize_dim(end, ndim);
+        let dims = a.dims();
+        let mut new_shape: Vec<Expression> = dims[..start].to_vec();
+        let flat_size = dims[start..=end]
+            .iter()
+            .fold(Expression::from(1usize), |acc, d| acc * *d);
+        new_shape.push(flat_size);
+        new_shape.extend_from_slice(&dims[end + 1..]);
+        Ok(reshape_tensor(a, new_shape))
+    }
+
+    pub(crate) fn translate_unflatten(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let dim = self.get_int_arg(node, 1)?;
+        let dim = normalize_dim(dim, a.shape.len());
+        let sizes = self.get_ints_arg(node, 2)?;
+        let dims = a.dims();
+        let mut new_shape: Vec<Expression> = dims[..dim].to_vec();
+        // Resolve -1 in unflatten sizes
+        let neg1_idx = sizes.iter().position(|&s| s == -1);
+        if let Some(idx) = neg1_idx {
+            let dim_val = dims[dim];
+            let known_product: i64 = sizes
+                .iter()
+                .filter(|&&s| s != -1)
+                .product();
+            for (i, &s) in sizes.iter().enumerate() {
+                if i == idx {
+                    new_shape.push(dim_val / Expression::from(known_product as usize));
+                } else {
+                    new_shape.push(Expression::from(s as usize));
+                }
+            }
+        } else {
+            for &s in &sizes {
+                new_shape.push(Expression::from(s as usize));
+            }
+        }
+        new_shape.extend_from_slice(&dims[dim + 1..]);
+        Ok(reshape_tensor(a, new_shape))
+    }
+
+    pub(crate) fn translate_reshape_as(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let other = self.get_input_tensor(node, 1)?;
+        let target_shape = other.dims().to_vec();
+        Ok(reshape_tensor(a, target_shape))
+    }
+
+    pub(crate) fn translate_movedim(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let ndim = a.shape.len();
+
+        // Can be single int or list of ints
+        let source: Vec<usize> = if let Ok(s) = self.get_int_arg(node, 1) {
+            vec![normalize_dim(s, ndim)]
+        } else {
+            self.get_ints_arg(node, 1)?
+                .iter()
+                .map(|&d| normalize_dim(d, ndim))
+                .collect()
+        };
+        let dest: Vec<usize> = if let Ok(d) = self.get_int_arg(node, 2) {
+            vec![normalize_dim(d, ndim)]
+        } else {
+            self.get_ints_arg(node, 2)?
+                .iter()
+                .map(|&d| normalize_dim(d, ndim))
+                .collect()
+        };
+
+        // Build permutation
+        let mut perm: Vec<usize> = Vec::with_capacity(ndim);
+        // Start with dims not in source, then insert source dims at dest positions
+        let mut order: Vec<Option<usize>> = vec![None; ndim];
+        for (&s, &d) in source.iter().zip(dest.iter()) {
+            order[d] = Some(s);
+        }
+        let remaining: Vec<usize> = (0..ndim)
+            .filter(|i| !source.contains(i))
+            .collect();
+        let mut rem_idx = 0;
+        for i in 0..ndim {
+            if let Some(s) = order[i] {
+                perm.push(s);
+            } else {
+                perm.push(remaining[rem_idx]);
+                rem_idx += 1;
+            }
+        }
+        Ok(a.permute(perm))
+    }
+
+    pub(crate) fn translate_narrow(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let dim = self.get_int_arg(node, 1)?;
+        let dim = normalize_dim(dim, a.shape.len());
+        let start = self.get_int_arg(node, 2)? as usize;
+        let length = self.get_int_arg(node, 3)? as usize;
+        Ok(a.slice_along(start..start + length, dim))
+    }
+
+    pub(crate) fn translate_chunk(&mut self, node: &Node) -> Result<()> {
+        let a = self.get_input_tensor(node, 0)?;
+        let chunks = self.get_int_arg(node, 1)? as usize;
+        let dim = self.get_int_arg(node, 2).unwrap_or(0);
+        let dim = normalize_dim(dim, a.shape.len());
+        let dim_size = a.dims()[dim]
+            .to_usize()
+            .ok_or_else(|| anyhow::anyhow!("chunk requires concrete dim size"))?;
+        let chunk_size = (dim_size + chunks - 1) / chunks;
+
+        if let Some(tensors) = node.outputs[0].as_tensors.as_ref() {
+            let mut start = 0;
+            for t in tensors.iter() {
+                let end = (start + chunk_size).min(dim_size);
+                if start < dim_size {
+                    let chunk = a.slice_along(start..end, dim);
+                    self.tensors.insert(t.name.clone(), chunk);
+                }
+                start = end;
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn translate_unbind(&mut self, node: &Node) -> Result<()> {
+        let a = self.get_input_tensor(node, 0)?;
+        let dim = self.get_int_arg(node, 1).unwrap_or(0);
+        let dim = normalize_dim(dim, a.shape.len());
+
+        if let Some(tensors) = node.outputs[0].as_tensors.as_ref() {
+            for (i, t) in tensors.iter().enumerate() {
+                let sliced = a.slice_along(i..i + 1, dim).squeeze(dim);
+                self.tensors.insert(t.name.clone(), sliced);
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn translate_constant_pad_nd(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let pad_list = self.get_ints_arg(node, 1)?;
+        let value = self.get_float_arg(node, 2).unwrap_or(0.0) as f32;
+        let ndim = a.shape.len();
+        let mut result = a;
+        for i in 0..pad_list.len() / 2 {
+            let dim = ndim - 1 - i;
+            let left = pad_list[i * 2] as usize;
+            let right = pad_list[i * 2 + 1] as usize;
+            if left > 0 || right > 0 {
+                result = result.pad_along(left, right, dim, value);
+            }
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn translate_repeat(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let repeats = self.get_ints_arg(node, 1)?;
+        let repeats_usize: Vec<usize> = repeats.iter().map(|&r| r as usize).collect();
+        Ok(a.repeat(repeats_usize))
+    }
+
+    pub(crate) fn translate_fill(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let val = self.get_float_arg(node, 1)? as f32;
+        Ok(self.graph.constant_float(val).expand_rhs(a.shape))
+    }
+
+    pub(crate) fn translate_broadcast_to(&mut self, node: &Node) -> Result<GraphTensor> {
+        let mut a = self.get_input_tensor(node, 0)?;
+        let target = self.get_ints_arg(node, 1)?;
+        let target_exprs: Vec<Expression> = target
+            .iter()
+            .enumerate()
+            .map(|(i, &s)| {
+                if s == -1 {
+                    a.shape.dims[i]
+                } else {
+                    Expression::from(s as usize)
+                }
+            })
+            .collect();
+        // Unsqueeze leading dims if needed
+        while a.shape.len() < target_exprs.len() {
+            a = a.unsqueeze(0);
+        }
+        a.shape.expand(target_exprs);
+        Ok(a)
+    }
+
+    pub(crate) fn translate_broadcast_tensors(&mut self, node: &Node) -> Result<()> {
+        // Collect all input tensors
+        let tensors: Vec<GraphTensor> =
+            if let Some(names) = node.inputs[0].arg.as_tensors() {
+                names
+                    .iter()
+                    .map(|n| self.get_tensor(&n.name))
+                    .collect::<Result<_>>()?
+            } else {
+                let mut ts = Vec::new();
+                for input in &node.inputs {
+                    if let Some(name) = input.arg.as_tensor_name() {
+                        if let Ok(t) = self.get_tensor(name) {
+                            ts.push(t);
+                        }
+                    }
+                }
+                ts
+            };
+
+        if tensors.is_empty() {
+            anyhow::bail!("broadcast_tensors: no tensor inputs found");
+        }
+
+        // Find max ndim
+        let max_ndim = tensors.iter().map(|t| t.shape.len()).max().unwrap();
+        // Compute broadcast shape
+        let mut broadcast_shape: Vec<Expression> = vec![Expression::from(1usize); max_ndim];
+        for t in &tensors {
+            let offset = max_ndim - t.shape.len();
+            for (i, d) in t.dims().iter().enumerate() {
+                let bi = offset + i;
+                if broadcast_shape[bi].to_usize() == Some(1) {
+                    broadcast_shape[bi] = *d;
+                }
+            }
+        }
+
+        // Broadcast each tensor and store
+        if let Some(out_tensors) = node.outputs[0].as_tensors.as_ref() {
+            for (i, t) in tensors.into_iter().enumerate() {
+                let mut expanded = t;
+                while expanded.shape.len() < max_ndim {
+                    expanded = expanded.unsqueeze(0);
+                }
+                expanded.shape.expand(broadcast_shape.clone());
+                if i < out_tensors.len() {
+                    self.tensors
+                        .insert(out_tensors[i].name.clone(), expanded);
+                }
+            }
+        }
+        Ok(())
+    }
+
+    pub(crate) fn translate_hsplit(&mut self, node: &Node) -> Result<()> {
+        let a = self.get_input_tensor(node, 0)?;
+        let sections = self.get_int_arg(node, 1)? as usize;
+        let dim = if a.shape.len() == 1 { 0 } else { 1 };
+        self.split_equal_sections(a, sections, dim, node)
+    }
+
+    pub(crate) fn translate_vsplit(&mut self, node: &Node) -> Result<()> {
+        let a = self.get_input_tensor(node, 0)?;
+        let sections = self.get_int_arg(node, 1)? as usize;
+        self.split_equal_sections(a, sections, 0, node)
+    }
+
+    pub(crate) fn translate_dsplit(&mut self, node: &Node) -> Result<()> {
+        let a = self.get_input_tensor(node, 0)?;
+        let sections = self.get_int_arg(node, 1)? as usize;
+        self.split_equal_sections(a, sections, 2, node)
+    }
+
+    fn split_equal_sections(
+        &mut self,
+        a: GraphTensor,
+        sections: usize,
+        dim: usize,
+        node: &Node,
+    ) -> Result<()> {
+        let dim_size = a.dims()[dim]
+            .to_usize()
+            .ok_or_else(|| anyhow::anyhow!("split requires concrete dim size"))?;
+        let chunk_size = dim_size / sections;
+        if let Some(tensors) = node.outputs[0].as_tensors.as_ref() {
+            for (i, t) in tensors.iter().enumerate() {
+                let start = i * chunk_size;
+                let end = if i == sections - 1 {
+                    dim_size
+                } else {
+                    start + chunk_size
+                };
+                let chunk = a.slice_along(start..end, dim);
+                self.tensors.insert(t.name.clone(), chunk);
+            }
+        }
+        Ok(())
     }
 }

--- a/crates/luminal_python/rust/src/translator/reduction.rs
+++ b/crates/luminal_python/rust/src/translator/reduction.rs
@@ -6,6 +6,16 @@ use crate::pt2_util::*;
 
 use super::Translator;
 
+/// Re-insert reduced axes as size-1 dims (keepdim behavior).
+fn keepdim_unsqueeze(mut t: GraphTensor, axes: &[usize]) -> GraphTensor {
+    let mut sorted = axes.to_vec();
+    sorted.sort();
+    for &ax in &sorted {
+        t = t.unsqueeze(ax);
+    }
+    t
+}
+
 impl<'a> Translator<'a> {
     pub(crate) fn translate_reduction(
         &mut self,
@@ -31,13 +41,437 @@ impl<'a> Translator<'a> {
         };
 
         if keepdim {
-            let mut sorted_axes = axes.clone();
-            sorted_axes.sort();
-            for &ax in &sorted_axes {
-                result = result.unsqueeze(ax);
-            }
+            result = keepdim_unsqueeze(result, &axes);
         }
 
         Ok(result)
     }
+
+    // --- Single-output reduction ops ---
+
+    pub(crate) fn translate_argmax(&mut self, node: &Node) -> Result<GraphTensor> {
+        self.translate_argmax_min(node, true)
+    }
+
+    pub(crate) fn translate_argmin(&mut self, node: &Node) -> Result<GraphTensor> {
+        self.translate_argmax_min(node, false)
+    }
+
+    fn translate_argmax_min(&mut self, node: &Node, is_max: bool) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        if node.inputs.len() > 1 && node.inputs[1].arg.as_int().is_some() {
+            let dim = self.get_int_arg(node, 1)?;
+            let dim = normalize_dim(dim, a.shape.len());
+            let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+            let mut result = if is_max { a.argmax(dim) } else { a.argmin(dim) };
+            if keepdim {
+                result = result.unsqueeze(dim);
+            }
+            Ok(result)
+        } else {
+            let total = concrete_numel(&a)?;
+            let mut flat = a;
+            flat.shape = ShapeTracker::new(vec![1, total]);
+            Ok(if is_max { flat.argmax(1) } else { flat.argmin(1) })
+        }
+    }
+
+    pub(crate) fn translate_prod(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        if node.inputs.len() > 1 && node.inputs[1].arg.as_int().is_some() {
+            let dim = self.get_int_arg(node, 1)?;
+            let dim = normalize_dim(dim, a.shape.len());
+            let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+            let mut result = a.prod(vec![dim]);
+            if keepdim {
+                result = result.unsqueeze(dim);
+            }
+            Ok(result)
+        } else {
+            let total = concrete_numel(&a)?;
+            let mut flat = a;
+            flat.shape = ShapeTracker::new(vec![1, total]);
+            Ok(flat.prod(vec![1]))
+        }
+    }
+
+    pub(crate) fn translate_argsort_op(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let dim = self.get_int_arg(node, 1).unwrap_or(-1);
+        let dim = normalize_dim(dim, a.shape.len());
+        let descending = self.get_bool_arg(node, 2).unwrap_or(false);
+        Ok(a.argsort(dim, descending))
+    }
+
+    pub(crate) fn translate_log_softmax(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let dim = self.get_int_arg(node, 1)?;
+        let dim = normalize_dim(dim, a.shape.len());
+        Ok(a.log_softmax(dim))
+    }
+
+    pub(crate) fn translate_all(&mut self, node: &Node) -> Result<GraphTensor> {
+        self.translate_all_any(node, true)
+    }
+
+    pub(crate) fn translate_any(&mut self, node: &Node) -> Result<GraphTensor> {
+        self.translate_all_any(node, false)
+    }
+
+    /// Shared impl for `all` (use_min=true) and `any` (use_min=false).
+    fn translate_all_any(&mut self, node: &Node, use_min: bool) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let zero = self
+            .graph
+            .constant_float(0.0)
+            .cast(a.dtype)
+            .expand_rhs(a.shape);
+        let nonzero = a.cast(DType::F32).ne(zero.cast(DType::F32)).cast(DType::F32);
+        let reduce = |t: GraphTensor, axes: Vec<usize>| {
+            if use_min { t.min(axes) } else { t.max(axes) }
+        };
+        if node.inputs.len() > 1 && node.inputs[1].arg.as_int().is_some() {
+            let dim = self.get_int_arg(node, 1)?;
+            let dim = normalize_dim(dim, a.shape.len());
+            let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+            let mut result = reduce(nonzero, vec![dim]);
+            if keepdim {
+                result = result.unsqueeze(dim);
+            }
+            Ok(result.cast(DType::Bool))
+        } else {
+            let total = concrete_numel(&nonzero)?;
+            let mut flat = nonzero;
+            flat.shape = ShapeTracker::new(vec![1, total]);
+            Ok(reduce(flat, vec![1]).cast(DType::Bool))
+        }
+    }
+
+    pub(crate) fn translate_count_nonzero(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let zero = self
+            .graph
+            .constant_float(0.0)
+            .cast(a.dtype)
+            .expand_rhs(a.shape);
+        let nonzero = a.cast(DType::F32).ne(zero.cast(DType::F32)).cast(DType::F32);
+        if node.inputs.len() > 1 && node.inputs[1].arg.as_int().is_some() {
+            let dim = self.get_int_arg(node, 1)?;
+            let dim = normalize_dim(dim, a.shape.len());
+            Ok(nonzero.sum(vec![dim]).cast(DType::Int))
+        } else if node.inputs.len() > 1 && node.inputs[1].arg.as_ints().is_some() {
+            let dims = self.get_ints_arg(node, 1)?;
+            let ndim = a.shape.len();
+            let axes: Vec<usize> = dims.iter().map(|&d| normalize_dim(d, ndim)).collect();
+            Ok(nonzero.sum(axes).cast(DType::Int))
+        } else {
+            let total = concrete_numel(&nonzero)?;
+            let mut flat = nonzero;
+            flat.shape = ShapeTracker::new(vec![1, total]);
+            Ok(flat.sum(vec![1]).cast(DType::Int))
+        }
+    }
+
+    pub(crate) fn translate_nansum(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let clean = self.nan_to_zero(a);
+        if node.inputs.len() > 1 && node.inputs[1].arg.as_ints().is_some() {
+            let dims = self.get_ints_arg(node, 1)?;
+            let ndim = a.shape.len();
+            let axes: Vec<usize> = dims.iter().map(|&d| normalize_dim(d, ndim)).collect();
+            let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+            let mut result = clean.sum(axes.clone());
+            if keepdim {
+                result = keepdim_unsqueeze(result, &axes);
+            }
+            Ok(result)
+        } else {
+            let total = concrete_numel(&clean)?;
+            let mut flat = clean;
+            flat.shape = ShapeTracker::new(vec![1, total]);
+            Ok(flat.sum(vec![1]))
+        }
+    }
+
+    pub(crate) fn translate_nanmean(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let is_nan = a.ne(a).cast(DType::F32);
+        let one = self.graph.constant_float(1.0).expand_rhs(a.shape);
+        let clean = a * (one - is_nan);
+        let count = one - is_nan;
+        if node.inputs.len() > 1 && node.inputs[1].arg.as_ints().is_some() {
+            let dims = self.get_ints_arg(node, 1)?;
+            let ndim = a.shape.len();
+            let axes: Vec<usize> = dims.iter().map(|&d| normalize_dim(d, ndim)).collect();
+            let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+            let mut result = clean.sum(axes.clone()) / count.sum(axes.clone());
+            if keepdim {
+                result = keepdim_unsqueeze(result, &axes);
+            }
+            Ok(result)
+        } else {
+            let total = concrete_numel(&clean)?;
+            let mut flat_clean = clean;
+            flat_clean.shape = ShapeTracker::new(vec![1, total]);
+            let mut flat_count = count;
+            flat_count.shape = ShapeTracker::new(vec![1, total]);
+            Ok(flat_clean.sum(vec![1]) / flat_count.sum(vec![1]))
+        }
+    }
+
+    pub(crate) fn translate_logsumexp(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let dims = self.get_ints_arg(node, 1)?;
+        let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+        let ndim = a.shape.len();
+        let axes: Vec<usize> = dims.iter().map(|&d| normalize_dim(d, ndim)).collect();
+
+        // Numerically stable: max + log(sum(exp(x - max)))
+        let m = a.max(axes.clone());
+        let m_expanded = keepdim_unsqueeze(m, &axes);
+        let (a_bc, m_bc) = broadcast_binary(a, m_expanded);
+        let shifted = a_bc - m_bc;
+        let mut result = shifted.exp().sum(axes.clone()).log() + m;
+        if keepdim {
+            result = keepdim_unsqueeze(result, &axes);
+        }
+        Ok(result)
+    }
+
+    pub(crate) fn translate_sum_to_size(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let target = self.get_ints_arg(node, 1)?;
+        let mut axes = Vec::new();
+        for (i, &t) in target.iter().enumerate() {
+            if t == 1 {
+                if let Some(s) = a.shape.dims[i].to_usize() {
+                    if s > 1 {
+                        axes.push(i);
+                    }
+                }
+            }
+        }
+        if axes.is_empty() {
+            Ok(a)
+        } else {
+            let result = a.sum(axes.clone());
+            Ok(keepdim_unsqueeze(result, &axes))
+        }
+    }
+
+    pub(crate) fn translate_std_op(&mut self, node: &Node) -> Result<GraphTensor> {
+        self.translate_std_or_var(node, true)
+    }
+
+    pub(crate) fn translate_var_op(&mut self, node: &Node) -> Result<GraphTensor> {
+        self.translate_std_or_var(node, false)
+    }
+
+    /// Shared impl for `std` (is_std=true) and `var` (is_std=false).
+    fn translate_std_or_var(&mut self, node: &Node, is_std: bool) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        let compute = |t: GraphTensor, axes: Vec<usize>, correction: usize| {
+            if is_std {
+                t.std_options(axes, correction)
+            } else {
+                t.var_options(axes, correction)
+            }
+        };
+        if node.inputs.len() > 1 && node.inputs[1].arg.as_ints().is_some() {
+            let dims = self.get_ints_arg(node, 1)?;
+            let ndim = a.shape.len();
+            let axes: Vec<usize> = dims.iter().map(|&d| normalize_dim(d, ndim)).collect();
+            let correction = self.get_int_arg(node, 2).unwrap_or(1) as usize;
+            let keepdim = self.get_bool_arg(node, 3).unwrap_or(false);
+            let mut result = compute(a, axes.clone(), correction);
+            if keepdim {
+                result = keepdim_unsqueeze(result, &axes);
+            }
+            Ok(result)
+        } else {
+            let total = concrete_numel(&a)?;
+            let mut flat = a;
+            flat.shape = ShapeTracker::new(vec![1, total]);
+            Ok(compute(flat, vec![1], 1))
+        }
+    }
+
+    // --- Multi-output reduction ops ---
+
+    pub(crate) fn translate_sort_op(&mut self, node: &Node) -> Result<()> {
+        let a = self.get_input_tensor(node, 0)?;
+        let dim = self.get_int_arg(node, 1).unwrap_or(-1);
+        let dim = normalize_dim(dim, a.shape.len());
+        let descending = self.get_bool_arg(node, 2).unwrap_or(false);
+
+        let values = a.sort(dim, descending);
+        let indices = a.argsort(dim, descending);
+        self.store_multi_outputs(node, values, indices);
+        Ok(())
+    }
+
+    pub(crate) fn translate_max_min_dim(&mut self, node: &Node) -> Result<()> {
+        let a = self.get_input_tensor(node, 0)?;
+        let dim = self.get_int_arg(node, 1)?;
+        let dim = normalize_dim(dim, a.shape.len());
+        let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+
+        let is_max = node.target.contains("max");
+        let mut values = if is_max { a.max(vec![dim]) } else { a.min(vec![dim]) };
+        let mut indices = if is_max { a.argmax(dim) } else { a.argmin(dim) };
+
+        if keepdim {
+            values = values.unsqueeze(dim);
+            indices = indices.unsqueeze(dim);
+        }
+
+        self.store_multi_outputs(node, values, indices);
+        Ok(())
+    }
+
+    pub(crate) fn translate_std_mean(&mut self, node: &Node) -> Result<()> {
+        self.translate_stat_mean(node, true)
+    }
+
+    pub(crate) fn translate_var_mean(&mut self, node: &Node) -> Result<()> {
+        self.translate_stat_mean(node, false)
+    }
+
+    /// Shared impl for `std_mean` (is_std=true) and `var_mean` (is_std=false).
+    fn translate_stat_mean(&mut self, node: &Node, is_std: bool) -> Result<()> {
+        let a = self.get_input_tensor(node, 0)?;
+        let (axes, correction, keepdim) = self.parse_reduction_with_correction(node, &a)?;
+
+        let mean_val = a.mean(axes.clone());
+        let stat_val = if is_std {
+            a.std_options(axes.clone(), correction)
+        } else {
+            a.var_options(axes.clone(), correction)
+        };
+
+        let (mut stat_out, mut mean_out) = (stat_val, mean_val);
+        if keepdim {
+            stat_out = keepdim_unsqueeze(stat_out, &axes);
+            mean_out = keepdim_unsqueeze(mean_out, &axes);
+        }
+
+        self.store_multi_outputs(node, stat_out, mean_out);
+        Ok(())
+    }
+
+    pub(crate) fn translate_aminmax(&mut self, node: &Node) -> Result<()> {
+        let a = self.get_input_tensor(node, 0)?;
+        if node.inputs.len() > 1 && node.inputs[1].arg.as_int().is_some() {
+            let dim = self.get_int_arg(node, 1)?;
+            let dim = normalize_dim(dim, a.shape.len());
+            let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+            let mut min_val = a.min(vec![dim]);
+            let mut max_val = a.max(vec![dim]);
+            if keepdim {
+                min_val = min_val.unsqueeze(dim);
+                max_val = max_val.unsqueeze(dim);
+            }
+            self.store_multi_outputs(node, min_val, max_val);
+        } else {
+            let total = concrete_numel(&a)?;
+            let mut flat = a;
+            flat.shape = ShapeTracker::new(vec![1, total]);
+            self.store_multi_outputs(node, flat.min(vec![1]), flat.max(vec![1]));
+        }
+        Ok(())
+    }
+
+    pub(crate) fn translate_kthvalue(&mut self, node: &Node) -> Result<()> {
+        let a = self.get_input_tensor(node, 0)?;
+        let k = self.get_int_arg(node, 1)? as usize;
+        let dim = self.get_int_arg(node, 2).unwrap_or(-1);
+        let dim = normalize_dim(dim, a.shape.len());
+        let keepdim = self.get_bool_arg(node, 3).unwrap_or(false);
+
+        let sorted = a.sort(dim, false);
+        let indices = a.argsort(dim, false);
+        let mut value = sorted.slice_along((k - 1)..k, dim);
+        let mut index = indices.slice_along((k - 1)..k, dim);
+        if !keepdim {
+            value = value.squeeze(dim);
+            index = index.squeeze(dim);
+        }
+
+        self.store_multi_outputs(node, value, index);
+        Ok(())
+    }
+
+    pub(crate) fn translate_median(&mut self, node: &Node) -> Result<GraphTensor> {
+        let a = self.get_input_tensor(node, 0)?;
+        if node.inputs.len() > 1 && node.inputs[1].arg.as_int().is_some() {
+            let dim = self.get_int_arg(node, 1)?;
+            let dim = normalize_dim(dim, a.shape.len());
+            let keepdim = self.get_bool_arg(node, 2).unwrap_or(false);
+            let dim_size = a.dims()[dim]
+                .to_usize()
+                .ok_or_else(|| anyhow::anyhow!("median requires concrete dim size"))?;
+            let mid = dim_size / 2;
+            let sorted = a.sort(dim, false);
+            let mut result = sorted.slice_along(mid..mid + 1, dim);
+            if !keepdim {
+                result = result.squeeze(dim);
+            }
+            Ok(result)
+        } else {
+            let total = concrete_numel(&a)?;
+            let mut flat = a;
+            flat.shape = ShapeTracker::new(vec![1, total]);
+            let sorted = flat.sort(1, false);
+            let mid = total / 2;
+            Ok(sorted.slice_along(mid..mid + 1, 1).squeeze(1))
+        }
+    }
+
+    // --- Helpers ---
+
+    /// Replace NaN values with 0.0.
+    fn nan_to_zero(&mut self, a: GraphTensor) -> GraphTensor {
+        let is_nan = a.ne(a).cast(DType::F32);
+        let one = self.graph.constant_float(1.0).expand_rhs(a.shape);
+        a * (one - is_nan)
+    }
+
+    /// Parse axes, correction, and keepdim for std_mean/var_mean.
+    fn parse_reduction_with_correction(
+        &self,
+        node: &Node,
+        a: &GraphTensor,
+    ) -> Result<(Vec<usize>, usize, bool)> {
+        let ndim = a.shape.len();
+        if node.inputs.len() > 1 && node.inputs[1].arg.as_ints().is_some() {
+            let dims = self.get_ints_arg(node, 1)?;
+            let axes: Vec<usize> = dims.iter().map(|&d| normalize_dim(d, ndim)).collect();
+            let correction = self.get_int_arg(node, 2).unwrap_or(1) as usize;
+            let keepdim = self.get_bool_arg(node, 3).unwrap_or(false);
+            Ok((axes, correction, keepdim))
+        } else {
+            let axes: Vec<usize> = (0..ndim).collect();
+            let correction = self.get_int_arg(node, 1).unwrap_or(1) as usize;
+            Ok((axes, correction, false))
+        }
+    }
+
+    /// Store two outputs for multi-output ops.
+    fn store_multi_outputs(&mut self, node: &Node, first: GraphTensor, second: GraphTensor) {
+        if let Some(tensors) = node.outputs[0].as_tensors.as_ref() {
+            if tensors.len() >= 2 {
+                self.tensors.insert(tensors[0].name.clone(), first);
+                self.tensors.insert(tensors[1].name.clone(), second);
+            }
+        }
+    }
+}
+
+/// Compute total element count, returning an error if any dimension is symbolic.
+pub(crate) fn concrete_numel(a: &GraphTensor) -> Result<usize> {
+    a.dims().iter().try_fold(1usize, |acc, d| {
+        d.to_usize().map(|v| acc * v).ok_or_else(|| {
+            anyhow::anyhow!("Full reduction requires concrete dimensions, got symbolic dim")
+        })
+    })
 }

--- a/crates/luminal_python/tests/pytorch_compat/test_ops_correctness.py
+++ b/crates/luminal_python/tests/pytorch_compat/test_ops_correctness.py
@@ -1,0 +1,302 @@
+"""Tests for PT2 backend reduction and shape/movement ops."""
+
+import os
+import pytest
+import torch
+import torch._dynamo
+
+# Force PT2 export mode
+os.environ["LUMINAL_EXPORT_MODE"] = "pt2"
+
+torch.set_float32_matmul_precision("highest")
+
+
+@pytest.fixture(autouse=True, scope="function")
+def reset_dynamo():
+    torch._dynamo.config.cache_size_limit = 1
+    torch._dynamo.config.suppress_errors = False
+    yield
+    torch._dynamo.reset()
+
+
+def _get_backend():
+    import luminal_python
+
+    return luminal_python.luminal_backend
+
+
+def _run_model(model_fn, *inputs, atol=1e-4, rtol=1e-4):
+    """Compile model_fn with luminal and compare against eager PyTorch."""
+    torch._dynamo.reset()
+    eager_out = model_fn(*inputs)
+    compiled = torch.compile(model_fn, backend=_get_backend())
+    luminal_out = compiled(*inputs)
+    if isinstance(eager_out, torch.Tensor):
+        torch.testing.assert_close(luminal_out, eager_out, atol=atol, rtol=rtol)
+    elif isinstance(eager_out, (tuple, list)):
+        for a, b in zip(luminal_out, eager_out):
+            torch.testing.assert_close(a, b, atol=atol, rtol=rtol)
+    return luminal_out
+
+
+# ===== Reduction Ops =====
+
+
+def test_argmax():
+    x = torch.randn(3, 5)
+
+    def f(x):
+        return x.argmax(dim=1)
+
+    _run_model(f, x)
+
+
+def test_argmax_keepdim():
+    x = torch.randn(3, 5)
+
+    def f(x):
+        return x.argmax(dim=1, keepdim=True)
+
+    _run_model(f, x)
+
+
+def test_argmin():
+    x = torch.randn(3, 5)
+
+    def f(x):
+        return x.argmin(dim=1)
+
+    _run_model(f, x)
+
+
+def test_prod():
+    x = torch.randn(3, 4).abs() + 0.1  # positive to avoid sign issues
+
+    def f(x):
+        return x.prod(dim=1)
+
+    _run_model(f, x, atol=1e-3, rtol=1e-3)
+
+
+def test_prod_keepdim():
+    x = torch.randn(3, 4).abs() + 0.1
+
+    def f(x):
+        return x.prod(dim=0, keepdim=True)
+
+    _run_model(f, x, atol=1e-3, rtol=1e-3)
+
+
+def test_argsort():
+    x = torch.randn(4, 5)
+
+    def f(x):
+        return x.argsort(dim=1)
+
+    _run_model(f, x)
+
+
+def test_log_softmax():
+    x = torch.randn(3, 5)
+
+    def f(x):
+        return torch.nn.functional.log_softmax(x, dim=1)
+
+    _run_model(f, x, atol=1e-3, rtol=1e-3)
+
+
+def test_std_unbiased():
+    x = torch.randn(4, 8)
+
+    def f(x):
+        return x.std(dim=1)
+
+    _run_model(f, x, atol=1e-3, rtol=1e-3)
+
+
+def test_var_unbiased():
+    x = torch.randn(4, 8)
+
+    def f(x):
+        return x.var(dim=1)
+
+    _run_model(f, x, atol=1e-3, rtol=1e-3)
+
+
+def test_sort():
+    x = torch.randn(3, 5)
+
+    def f(x):
+        vals, inds = x.sort(dim=1)
+        return vals, inds
+
+    _run_model(f, x)
+
+
+def test_max_reduction_with_dim():
+    x = torch.randn(3, 5)
+
+    def f(x):
+        vals, inds = x.max(dim=1)
+        return vals, inds
+
+    _run_model(f, x)
+
+
+def test_min_reduction_with_dim():
+    x = torch.randn(3, 5)
+
+    def f(x):
+        vals, inds = x.min(dim=1)
+        return vals, inds
+
+    _run_model(f, x)
+
+
+def test_msort():
+    x = torch.randn(5, 3)
+
+    def f(x):
+        return torch.msort(x)
+
+    _run_model(f, x)
+
+
+def test_logsumexp():
+    x = torch.randn(3, 5)
+
+    def f(x):
+        return torch.logsumexp(x, dim=1)
+
+    _run_model(f, x, atol=1e-3, rtol=1e-3)
+
+
+def test_median():
+    x = torch.randn(5, 7)
+
+    def f(x):
+        return x.median(dim=1).values
+
+    _run_model(f, x)
+
+
+# ===== Shape / View / Movement Ops =====
+
+
+def test_flatten():
+    x = torch.randn(2, 3, 4)
+
+    def f(x):
+        return x.flatten(1, 2)
+
+    _run_model(f, x)
+
+
+def test_unflatten():
+    x = torch.randn(2, 12)
+
+    def f(x):
+        return x.unflatten(1, (3, 4))
+
+    _run_model(f, x)
+
+
+def test_ravel():
+    x = torch.randn(2, 3, 4)
+
+    def f(x):
+        return x.ravel()
+
+    _run_model(f, x)
+
+
+def test_narrow():
+    x = torch.randn(4, 6)
+
+    def f(x):
+        return x.narrow(1, 1, 3)
+
+    _run_model(f, x)
+
+
+def test_chunk():
+    x = torch.randn(6, 4)
+
+    def f(x):
+        chunks = x.chunk(3, dim=0)
+        return chunks[0] + chunks[1] + chunks[2]
+
+    _run_model(f, x)
+
+
+def test_unbind():
+    x = torch.randn(3, 4)
+
+    def f(x):
+        parts = x.unbind(dim=0)
+        return parts[0] + parts[1] + parts[2]
+
+    _run_model(f, x)
+
+
+def test_constant_pad_nd():
+    x = torch.randn(2, 3)
+
+    def f(x):
+        return torch.nn.functional.pad(x, (1, 2, 0, 1), value=0.0)
+
+    _run_model(f, x)
+
+
+def test_repeat():
+    x = torch.randn(2, 3)
+
+    def f(x):
+        return x.repeat(2, 3)
+
+    _run_model(f, x)
+
+
+def test_tile():
+    x = torch.randn(2, 3)
+
+    def f(x):
+        return x.tile(2, 3)
+
+    _run_model(f, x)
+
+
+def test_fill():
+    x = torch.randn(3, 4)
+
+    def f(x):
+        return x.fill(42.0)
+
+    _run_model(f, x)
+
+
+def test_broadcast_to():
+    x = torch.randn(1, 3)
+
+    def f(x):
+        return x.broadcast_to(4, 3)
+
+    _run_model(f, x)
+
+
+def test_mT():
+    x = torch.randn(2, 3, 4)
+
+    def f(x):
+        return x.mT
+
+    _run_model(f, x)
+
+
+def test_movedim():
+    x = torch.randn(2, 3, 4)
+
+    def f(x):
+        return x.movedim(0, 2)
+
+    _run_model(f, x)


### PR DESCRIPTION
## Summary
- Add 22 reduction op translations: argmax, argmin, prod, argsort, log_softmax, all, any, count_nonzero, nansum, nanmean, logsumexp, sum_to_size, std, var, median, msort, sort, max.dim/min.dim, std_mean, var_mean, aminmax, kthvalue
- Add 25 shape/movement op translations: flatten, unflatten, ravel, reshape_as/view_as, movedim, atleast_{1,2,3}d, narrow, chunk, unbind, hsplit/vsplit/dsplit, constant_pad_nd, repeat, tile, fill, broadcast_to, broadcast_tensors, mT
- Improve translate_split to handle split_with_sizes (list of sizes) and add unsafe_split/split_with_sizes_copy variants
- Extract helpers (keepdim_unsqueeze, store_multi_outputs, nan_to_zero) to reduce duplication
- Add test file for correctness validation

## Test plan
- [x] `cargo check -p luminal_python` passes with no warnings
- [x] `cargo test -p luminal` passes (91 tests)
- [ ] `LUMINAL_EXPORT_MODE=pt2 uv run pytest tests/pytorch_compat/test_ops_correctness.py -v`
- [ ] `LUMINAL_EXPORT_MODE=pt2 uv run pytest tests/test_hlir_ops.py tests/test_unary.py -v` (regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)