### PR TITLE
luminal_python: register DynamicCache with pytree to enable use_cache=True

### DIFF
--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -17,6 +17,84 @@ from .luminal import process_pt2
 from .main import _collect_weight_pointers, _detect_factory_capsule, _load_cpu_weights
 
 # ---------------------------------------------------------------------------
+# DynamicCache <> pytree registration
+#
+# Without this, torch.export.export raises when handed an HF model that
+# returns CausalLMOutputWithPast(past_key_values=DynamicCache(...)), which
+# is every model with use_cache=True. The registration mirrors the one in
+# transformers.integrations.executorch.register_dynamic_cache_export_support
+# — same dict-based flatten (key_cache / value_cache lists), same replay via
+# cache.update(k, v, idx), and the matching torch.fx._pytree spec for FX
+# graphs. Done at module import so both entry points (pt2_backend via
+# torch.compile and the direct compile() call) get it for free.
+# ---------------------------------------------------------------------------
+
+
+def _get_cache_dict(cache):
+    """Flatten a DynamicCache to a dict of parallel key/value lists."""
+    return {
+        "key_cache": [layer.keys for layer in cache.layers if layer.keys is not None],
+        "value_cache": [
+            layer.values for layer in cache.layers if layer.values is not None
+        ],
+    }
+
+
+def _flatten_dynamic_cache(cache):
+    return torch.utils._pytree._dict_flatten(_get_cache_dict(cache))
+
+
+def _flatten_with_keys_dynamic_cache(cache):
+    return torch.utils._pytree._dict_flatten_with_keys(_get_cache_dict(cache))
+
+
+def _unflatten_dynamic_cache(values, context):
+    from transformers.cache_utils import DynamicCache
+
+    dictionary = torch.utils._pytree._dict_unflatten(values, context)
+    cache = DynamicCache()
+    key_list = dictionary.get("key_cache", [])
+    value_list = dictionary.get("value_cache", [])
+    for idx in range(max(len(key_list), len(value_list))):
+        k = key_list[idx] if idx < len(key_list) else None
+        v = value_list[idx] if idx < len(value_list) else None
+        cache.update(k, v, idx)
+    return cache
+
+
+def _register_cache_serialization():
+    """Register DynamicCache with both torch.utils._pytree and torch.fx._pytree.
+
+    Idempotent: a second call is a no-op. Silently skipped if transformers is
+    not installed.
+    """
+    try:
+        from transformers.cache_utils import DynamicCache
+    except ImportError:
+        return
+
+    if DynamicCache in torch.utils._pytree.SUPPORTED_NODES:
+        return
+
+    torch.utils._pytree.register_pytree_node(
+        DynamicCache,
+        _flatten_dynamic_cache,
+        _unflatten_dynamic_cache,
+        serialized_type_name=f"{DynamicCache.__module__}.{DynamicCache.__name__}",
+        flatten_with_keys_fn=_flatten_with_keys_dynamic_cache,
+    )
+    torch.fx._pytree.register_pytree_flatten_spec(
+        DynamicCache,
+        lambda cache, spec: torch.fx._pytree._dict_flatten_spec(
+            _get_cache_dict(cache), spec
+        ),
+    )
+
+
+_register_cache_serialization()
+
+
+# ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
 

--- a/crates/luminal_python/tests/test_kv_cache_comparison.py
+++ b/crates/luminal_python/tests/test_kv_cache_comparison.py
@@ -1,0 +1,94 @@
+"""KV Cache decode loop test.
+
+Compiles a tiny 1-layer Llama model with use_cache=True, then:
+  1. Prefill: model(input_ids) -> logits + K/V cache
+  2. Decode:  model(next_token, past_key_values=cache) -> logits + updated K/V
+
+Verifies correctness of both steps and writes DOT graphs for comparison.
+"""
+
+import os
+
+import torch
+
+from luminal import luminal_backend
+
+
+def _capturing_backend(captured):
+    """Wrap luminal_backend to capture CompiledModels for DOT extraction."""
+
+    def backend(gm, example_inputs):
+        compiled = luminal_backend(gm, example_inputs)
+        captured.append(compiled)
+        return compiled
+
+    return backend
+
+
+def test_kv_cache_decode_loop():
+    """Full prefill -> decode loop through luminal with KV cache."""
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    # Allow both prefill and decode compilations (conftest sets limit=1)
+    torch._dynamo.config.cache_size_limit = 2
+
+    config = LlamaConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_hidden_layers=1,
+        intermediate_size=128,
+        vocab_size=256,
+        max_position_embeddings=128,
+        use_cache=True,
+        attn_implementation="eager",
+    )
+    model = LlamaForCausalLM(config).eval()
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+
+    captured = []
+    compiled = torch.compile(model, backend=_capturing_backend(captured))
+
+    # --- Prefill step ---
+    with torch.no_grad():
+        ref_prefill = model(input_ids)
+        out_prefill = compiled(input_ids)
+
+    assert torch.allclose(out_prefill.logits, ref_prefill.logits, atol=1e-5)
+    assert out_prefill.past_key_values is not None, "Prefill should return KV cache"
+
+    # --- Decode step ---
+    next_token = ref_prefill.logits[0, -1, :].argmax().unsqueeze(0).unsqueeze(0)
+
+    with torch.no_grad():
+        ref_decode = model(next_token, past_key_values=ref_prefill.past_key_values)
+        out_decode = compiled(next_token, past_key_values=out_prefill.past_key_values)
+
+    assert torch.allclose(out_decode.logits, ref_decode.logits, atol=1e-5)
+
+    # --- DOT graph comparison ---
+    # captured[0] = prefill graph, captured[1] = decode graph (recompiled by dynamo)
+    assert len(captured) >= 2, (
+        f"Expected 2 compilations (prefill+decode), got {len(captured)}"
+    )
+
+    out_dir = "/tmp/luminal_kv_cache_comparison"
+    os.makedirs(out_dir, exist_ok=True)
+
+    prefill_dot = captured[0]._graph.to_dot()
+    decode_dot = captured[1]._graph.to_dot()
+
+    with open(os.path.join(out_dir, "prefill.dot"), "w") as f:
+        f.write(prefill_dot)
+    with open(os.path.join(out_dir, "decode.dot"), "w") as f:
+        f.write(decode_dot)
+
+    print(f"\n=== DOT files written to {out_dir} ===")
+    print(f"Prefill: {len(prefill_dot)} chars, inputs: {captured[0]._input_names}")
+    print(f"Decode:  {len(decode_dot)} chars, inputs: {captured[1]._input_names}")
+
+    # Decode graph should have more inputs (past K/V cache tensors)
+    assert len(captured[1]._input_names) > len(captured[0]._input_names), (
+        f"Decode should have more inputs than prefill: "
+        f"{len(captured[1]._input_names)} vs {len(captured[0]._input_names)}"
+    )

--- a/crates/luminal_python/tests/test_kv_cache_growing.py
+++ b/crates/luminal_python/tests/test_kv_cache_growing.py
@@ -1,0 +1,179 @@
+"""KV Cache growing decode loop test.
+
+Compiles a tiny 1-layer Llama model with use_cache=True, then runs a
+multi-step autoregressive decode loop:
+
+  1. Prefill:  model(input_ids) -> logits + initial KV cache
+  2. Decode x N: model(next_token, past_key_values=cache) -> logits + grown KV cache
+
+At each step, prints the KV cache tensor shapes so you can see the
+sequence dimension grow: (1, n_kv_heads, 4, head_dim) -> (1, n_kv_heads, 5, ...) -> ...
+
+Verifies luminal output matches PyTorch reference at every step.
+"""
+
+import pytest
+import torch
+import torch._dynamo
+
+from luminal import luminal_backend
+
+NUM_DECODE_STEPS = 5
+
+
+def test_kv_cache_growing():
+    """Multi-step prefill + decode loop showing KV cache growth."""
+    from transformers import LlamaConfig, LlamaForCausalLM
+
+    # We need 1 compilation for prefill + 1 per unique decode cache size
+    torch._dynamo.config.cache_size_limit = NUM_DECODE_STEPS + 2
+    # Disable automatic dynamic shapes — dynamo would otherwise try to use SymInt
+    # for the varying cache seq_len dimension, which torch.export doesn't support.
+    # Instead, we want a fresh recompilation for each new cache size.
+    torch._dynamo.config.automatic_dynamic_shapes = False
+
+    config = LlamaConfig(
+        hidden_size=64,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        num_hidden_layers=4,
+        intermediate_size=128,
+        vocab_size=256,
+        max_position_embeddings=128,
+        use_cache=True,
+        attn_implementation="eager",
+    )
+    model = LlamaForCausalLM(config).eval()
+    compiled = torch.compile(model, backend=luminal_backend)
+
+    input_ids = torch.tensor([[1, 2, 3, 4]])
+
+    # ---- Prefill ----
+    with torch.no_grad():
+        ref_out = model(input_ids)
+        lum_out = compiled(input_ids)
+
+    assert ref_out.past_key_values is not None, "Reference should return KV cache"
+    assert lum_out.past_key_values is not None, "Luminal should return KV cache"
+
+    assert torch.allclose(lum_out.logits, ref_out.logits, atol=1e-5), (
+        f"Prefill mismatch: max_diff="
+        f"{torch.max(torch.abs(lum_out.logits - ref_out.logits)).item():.2e}"
+    )
+
+    _print_cache_shapes("Prefill", ref_out.past_key_values, lum_out.past_key_values)
+
+    ref_cache = ref_out.past_key_values
+    lum_cache = lum_out.past_key_values
+
+    # ---- Decode loop ----
+    for step in range(NUM_DECODE_STEPS):
+        # Greedy next token from reference logits
+        next_token = ref_out.logits[0, -1, :].argmax().unsqueeze(0).unsqueeze(0)
+
+        with torch.no_grad():
+            ref_out = model(next_token, past_key_values=ref_cache)
+            lum_out = compiled(next_token, past_key_values=lum_cache)
+
+        assert torch.allclose(lum_out.logits, ref_out.logits, atol=1e-5), (
+            f"Decode step {step} mismatch: max_diff="
+            f"{torch.max(torch.abs(lum_out.logits - ref_out.logits)).item():.2e}"
+        )
+
+        ref_cache = ref_out.past_key_values
+        lum_cache = lum_out.past_key_values
+
+        _print_cache_shapes(f"Decode step {step}", ref_cache, lum_cache)
+
+    # Final sanity check: cache seq_len should equal prompt + decode steps
+    expected_seq = input_ids.shape[1] + NUM_DECODE_STEPS
+    final_k = ref_cache.layers[0].keys
+    assert final_k.shape[2] == expected_seq, (
+        f"Expected cache seq_len={expected_seq}, got {final_k.shape[2]}"
+    )
+    print(
+        f"\nAll {NUM_DECODE_STEPS} decode steps passed. "
+        f"Cache grew from seq_len={input_ids.shape[1]} to {expected_seq}."
+    )
+
+
+@pytest.mark.skipif(
+    not torch.cuda.is_available(),
+    reason="R1 full-width 1-layer is too memory-heavy for CPU native backend",
+)
+def test_kv_cache_growing_r1_mla(device: torch.device):
+    """Growing-cache decode loop on DeepSeek-R1 (MLA + decoupled RoPE), 1 layer.
+
+    Exercises MLA: q_lora / kv_lora low-rank projections, decoupled RoPE split
+    (qk_nope_head_dim + qk_rope_head_dim), and DynamicCache crossing the compile
+    boundary through the MLA update path (`cache_utils.py:102-121`).
+
+    Runs in fp32 — in bf16, MLA's empty-tensor-cat inside DynamicLayer.update
+    has a precision drift on the compiled path (logits ~3.7 on 1 layer) that
+    does not affect standard GQA (Llama in bf16 is bit-identical). Investigate
+    separately.
+    """
+    from transformers import AutoConfig, DeepseekV3ForCausalLM
+
+    torch._dynamo.config.cache_size_limit = NUM_DECODE_STEPS + 2
+    torch._dynamo.config.automatic_dynamic_shapes = False
+
+    config = AutoConfig.from_pretrained("deepseek-ai/DeepSeek-R1")
+    config.num_hidden_layers = 1
+    # first_k_dense_replace=3 (default) makes the 1 layer dense, so we avoid
+    # the 256-expert MoE path and the associated memory pressure.
+    config._attn_implementation = "eager"
+    config.torch_dtype = torch.float32
+    model = DeepseekV3ForCausalLM(config).eval().to(dtype=torch.float32, device=device)
+    compiled = torch.compile(model, backend=luminal_backend)
+
+    input_ids = torch.tensor([[1, 2, 3, 4]], device=device)
+
+    with torch.no_grad():
+        ref_out = model(input_ids)
+        lum_out = compiled(input_ids)
+
+    # fp32 MLA matches to ~1e-5 — see diagnose_dtype.py. Keep the tolerance
+    # tight here so regressions in the MLA cat/split path show up immediately.
+    assert torch.allclose(lum_out.logits, ref_out.logits, atol=1e-4), (
+        f"Prefill: max_diff={torch.max(torch.abs(lum_out.logits - ref_out.logits)).item():.2e}"
+    )
+
+    ref_cache = ref_out.past_key_values
+    lum_cache = lum_out.past_key_values
+
+    # Run a single decode step — enough to confirm the cache flows through as an
+    # explicit input on the second compile (the key signal from
+    # _test_kv_cache_comparison.py's "decode has more inputs than prefill"
+    # assertion). Full 5-step growth is covered by the Llama test above.
+    next_token = ref_out.logits[0, -1, :].argmax().view(1, 1).to(device)
+    with torch.no_grad():
+        ref_dec = model(next_token, past_key_values=ref_cache)
+        lum_dec = compiled(next_token, past_key_values=lum_cache)
+
+    assert torch.allclose(lum_dec.logits, ref_dec.logits, atol=1e-4), (
+        f"Decode: max_diff={torch.max(torch.abs(lum_dec.logits - ref_dec.logits)).item():.2e}"
+    )
+
+
+def _print_cache_shapes(label, ref_cache, lum_cache):
+    """Print KV cache shapes for both reference and luminal."""
+    print(f"\n--- {label} ---")
+    for layer_idx, ref_layer in enumerate(ref_cache.layers):
+        ref_k, ref_v = ref_layer.keys, ref_layer.values
+        lum_layer = lum_cache.layers[layer_idx]
+        lum_k, lum_v = lum_layer.keys, lum_layer.values
+        print(
+            f"  Layer {layer_idx}:  "
+            f"K ref={list(ref_k.shape)}  lum={list(lum_k.shape)}  |  "
+            f"V ref={list(ref_v.shape)}  lum={list(lum_v.shape)}"
+        )
+        # Verify cache tensors match
+        assert torch.allclose(lum_k, ref_k, atol=1e-5), (
+            f"{label} layer {layer_idx} K mismatch: "
+            f"max_diff={torch.max(torch.abs(lum_k - ref_k)).item():.2e}"
+        )
+        assert torch.allclose(lum_v, ref_v, atol=1e-5), (
+            f"{label} layer {layer_idx} V mismatch: "
+            f"max_diff={torch.max(torch.abs(lum_v - ref_v)).item():.2e}"
+        )


### PR DESCRIPTION
## Summary

- Adds `_register_cache_serialization()` at `luminal_python/src/luminal/pt2.py` import scope, registering `transformers.cache_utils.DynamicCache` with both `torch.utils._pytree` and `torch.fx._pytree` so HF models can compile through the luminal backend with `use_cache=True`.
- Adds two tests for the now-supported KV-cache pattern: `test_kv_cache_comparison.py` (Llama prefill + 1 decode, asserts decode graph gains explicit K/V tensor inputs) and `test_kv_cache_growing.py` (Llama prefill + 5 growing decode steps, plus a CUDA-only DeepSeek-R1 MLA variant at fp32).

## Background

Today every user of `luminal_backend` has to set `config.use_cache = False` to make `torch.compile` succeed on an HF causal LM. Without that override, `torch.export.export` raises a pytree error on `CausalLMOutputWithPast(past_key_values=DynamicCache(...))` — `DynamicCache` isn't registered as a pytree node, so the exporter can't flatten it. This rules out autoregressive decode and forces a non-standard config tweak on every model.

The fix mirrors `transformers.integrations.executorch.register_dynamic_cache_export_support` — same dict-based flatten (`key_cache` / `value_cache` lists), same replay via `cache.update(k, v, idx)` in the unflatten, and the matching `torch.fx._pytree.register_pytree_flatten_spec` leg for FX graphs. We do the registration ourselves rather than depending on transformers calling it for us, because the executorch helper isn't always invoked.

Notable details:
- Idempotent — guards on \`if DynamicCache in torch.utils._pytree.SUPPORTED_NODES: return\`.
- Silent no-op if \`transformers\` isn't installed (the registration is wrapped in a \`try/except ImportError\`).
- Both legs (pytree + fx._pytree) are needed: \`torch.export\` uses \`_pytree\`; FX graph passes inside the export pipeline use \`_fx_pytree\`.

## Test plan

- [x] \`LUMINAL_TEST_DEVICE=cuda uv run pytest tests/test_kv_cache_comparison.py -v\` — passes at \`atol=1e-5\`. Decode graph captures 3 inputs (input_ids, past_K, past_V) vs. prefill's 1 (input_ids only); \`len(captured[1]._input_names) > len(captured[0]._input_names)\` assertion holds.
- [x] \`LUMINAL_TEST_DEVICE=cuda uv run pytest tests/test_kv_cache_growing.py -v\` — Llama 5-step decode passes at \`atol=1e-5\`; cache grows \`[1, 2, 4, 16] → [1, 2, 9, 16]\` with bit-equal tensors at every layer/step.
- [x] R1-MLA variant (\`test_kv_cache_growing_r1_mla\`) — passes at \`atol=1e-4\` in fp32 on CUDA, validating the cache plumbing also works for MLA + decoupled-RoPE attention. Marked \`pytest.mark.skipif(not torch.cuda.is_available())\`.
- [x] Full Python regression suite — 225 passed / 4 xfailed (the 4 xfailed are pre-existing bf16-precision tests). One intermittent failure in \`test_llama_transformer_block\` was reproduced and confirmed to also occur on \`main\` without this change (passes in isolation; matches the documented 2026-04-26 loop-rolling-stage register pattern).

## Notes for reviewers

- Both new test files set \`torch._dynamo.config.automatic_dynamic_shapes = False\` and bump \`cache_size_limit\` to fit prefill + N decode compiles. This is the same recipe used by HF's ExecuTorch integration — \`torch.export\` doesn't accept \`SymInt\` for the varying cache \`seq_len\`, so each unique cache size triggers a separate compile.
- The R1 MLA test loads \`AutoConfig.from_pretrained("deepseek-ai/DeepSeek-R1")\` and overrides \`num_hidden_layers=1\` to keep the random-weight model under 1 GB. Network access is required at test time; this matches the pattern of the existing \`test_hf_llama3_real_config_1layer\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)