### PR TITLE
luminal_python: translate F.scaled_dot_product_attention as one fused op

### DIFF
--- a/crates/luminal_python/rust/src/translator/attention.rs
+++ b/crates/luminal_python/rust/src/translator/attention.rs
@@ -1,0 +1,195 @@
+use anyhow::{Context, Result};
+use luminal::prelude::*;
+
+use crate::pt2_schema::*;
+use crate::pt2_util::*;
+
+use super::Translator;
+
+/// Which SDPA variant we're translating. Governs argument positions and
+/// which output slots are consumed downstream.
+#[derive(Clone, Copy, Debug)]
+pub enum SdpaVariant {
+    /// `aten._scaled_dot_product_efficient_attention.default(q, k, v, attn_bias,
+    ///     compute_log_sumexp, dropout_p=0., is_causal=False, *, scale=None)
+    ///     -> (output, log_sumexp, philox_seed, philox_offset)`
+    Efficient,
+    /// `aten._scaled_dot_product_flash_attention.default(q, k, v, dropout_p=0.,
+    ///     is_causal=False, return_debug_mask=False, *, scale=None)
+    ///     -> (output, logsumexp, cum_seq_q, cum_seq_k, max_q, max_k,
+    ///         rng_state, unused, debug_attn_mask)`
+    Flash,
+    /// `aten._scaled_dot_product_flash_attention_for_cpu.default(q, k, v,
+    ///     dropout_p=0., is_causal=False, *, attn_mask=None, scale=None)
+    ///     -> (output, logsumexp)`
+    FlashForCpu,
+    /// `aten._scaled_dot_product_cudnn_attention.default(q, k, v, attn_bias,
+    ///     compute_log_sumexp, dropout_p=0., is_causal=False,
+    ///     return_debug_mask=False, *, scale=None)
+    ///     -> (output, logsumexp, cum_seq_q, cum_seq_k, max_q, max_k,
+    ///         philox_seed, philox_offset, debug_attn_mask)`
+    Cudnn,
+    /// `aten.scaled_dot_product_attention.default(q, k, v, attn_mask=None,
+    ///     dropout_p=0., is_causal=False, *, scale=None, enable_gqa=False)
+    ///     -> Tensor` (single output, no tuple).
+    Unified,
+}
+
+impl<'a> Translator<'a> {
+    /// Translate any SDPA op variant into `softmax((Q@K^T)*scale + causal_mask +
+    /// attn_bias) @ V`. Stores the primary `output` by the node's first output
+    /// name. Other tuple outputs (logsumexp, philox_seed, etc.) are unused in
+    /// inference — left unbound; the downstream `getitem(node, 0)` resolves
+    /// to `output` via the tuple-output name list.
+    pub(crate) fn translate_sdpa(&mut self, node: &Node, variant: SdpaVariant) -> Result<()> {
+        let query = self.get_input_tensor(node, 0)?;
+        let key = self.get_input_tensor(node, 1)?;
+        let value = self.get_input_tensor(node, 2)?;
+
+        // Resolve args by NAME rather than positional index. PT2 serializes
+        // kwargs inline in `node.inputs` with `kind=2`, so any arg that wasn't
+        // passed positionally by the caller shifts the indices of subsequent
+        // positional args. Name-based lookup is unambiguous across variants
+        // and across caller argument-passing styles.
+        let arg_by_name =
+            |name: &str| -> Option<&NodeInput> { node.inputs.iter().find(|i| i.name == name) };
+        let tensor_arg = |name: &str| -> Option<GraphTensor> {
+            arg_by_name(name)
+                .and_then(|i| i.arg.as_tensor_name())
+                .and_then(|n| self.get_tensor(n).ok())
+        };
+        let float_arg =
+            |name: &str| -> Option<f64> { arg_by_name(name).and_then(|i| i.arg.as_float()) };
+        let bool_arg =
+            |name: &str| -> Option<bool> { arg_by_name(name).and_then(|i| i.arg.as_bool()) };
+
+        // attn_bias (Efficient/Cudnn/Unified) or attn_mask (FlashForCpu/Unified).
+        let additive = tensor_arg("attn_bias").or_else(|| tensor_arg("attn_mask"));
+
+        let dropout_p = float_arg("dropout_p").unwrap_or(0.0) as f32;
+        anyhow::ensure!(
+            dropout_p == 0.0,
+            "SDPA: dropout_p={dropout_p} unsupported (inference only)"
+        );
+        let is_causal = bool_arg("is_causal").unwrap_or(false);
+        // Silence compiler warnings — variant arg remains for branch-specific
+        // logic (output tuple-name resolution below) and for future divergence.
+        let _ = variant;
+
+        // `scale` kwarg, default 1/sqrt(head_dim).
+        let head_dim = query
+            .shape
+            .dims
+            .last()
+            .and_then(|d| d.to_usize())
+            .context("SDPA: query head_dim must be concrete")?;
+        let default_scale = 1.0_f32 / (head_dim as f32).sqrt();
+        let scale = float_arg("scale")
+            .map(|v| v as f32)
+            .unwrap_or(default_scale);
+
+        // Math form: scores = (Q @ K^T) * scale; + causal_mask; + attn_bias;
+        // attn = softmax(scores, dim=-1); out = attn @ V.
+        let q_ndim = query.shape.len();
+        anyhow::ensure!(
+            q_ndim >= 2,
+            "SDPA: query must have at least 2 dims (got {q_ndim})"
+        );
+        // Transpose last two dims of key.
+        let mut perm: Vec<usize> = (0..q_ndim).collect();
+        perm.swap(q_ndim - 2, q_ndim - 1);
+        let key_t = key.permute(perm);
+        let (q_for_mm, k_for_mm) = ensure_same_dtype(query, key_t);
+        let scores = q_for_mm.matmul(k_for_mm);
+        let scale_t = self
+            .graph
+            .constant_float(scale)
+            .cast(scores.dtype)
+            .expand_rhs(scores.shape);
+        let mut scores = scores * scale_t;
+
+        if is_causal {
+            let s_q = scores
+                .shape
+                .dims
+                .get(q_ndim - 2)
+                .and_then(|d| d.to_usize())
+                .context("SDPA is_causal: S_q must be concrete")?;
+            let s_k = scores
+                .shape
+                .dims
+                .get(q_ndim - 1)
+                .and_then(|d| d.to_usize())
+                .context("SDPA is_causal: S_k must be concrete")?;
+            let size = s_q.max(s_k);
+            // triu with diagonal=1 = 1 strictly above diagonal, 0 elsewhere.
+            let mut mask = self.graph.triu(size, 1).cast(DType::F32);
+            if s_q != size || s_k != size {
+                mask = mask.slice_along(0..s_q, 0).slice_along(0..s_k, 1);
+            }
+            // -1e9 * mask ≈ -inf where masked, 0 otherwise. Broadcast across
+            // batch/head prefix dims of `scores`.
+            let neg_large = mask * (-1e9_f32);
+            let mut neg_large = neg_large.cast(scores.dtype);
+            for _ in 0..(q_ndim - 2) {
+                neg_large = neg_large.expand_dim(0, Expression::from(1usize));
+            }
+            let (scores_b, mask_b) = broadcast_binary(scores, neg_large);
+            scores = scores_b + mask_b;
+        }
+        if let Some(bias) = additive {
+            let (scores_b, bias_b) = ensure_same_dtype(scores, bias);
+            let (scores_b, bias_b) = broadcast_binary(scores_b, bias_b);
+            scores = scores_b + bias_b;
+        }
+
+        let attn = scores.softmax(q_ndim - 1);
+        let (attn, value) = ensure_same_dtype(attn, value);
+        let out = attn.matmul(value);
+
+        // Store the primary output by name. The other tuple outputs are
+        // inference-time dead ends — downstream getitem(node, 0) resolves to
+        // the same tensor name we bind here, because pt2 serializes the
+        // multi-output name list with output[0] as the primary slot.
+        let out_name = if let Some(ts) = node.outputs.first().and_then(|o| o.as_tensors.as_ref()) {
+            ts.first().map(|t| t.name.clone())
+        } else if variant == SdpaVariant::Unified {
+            node.outputs
+                .first()
+                .and_then(|o| o.as_tensor.as_ref().map(|t| t.name.clone()))
+        } else {
+            node.outputs
+                .first()
+                .and_then(|o| o.as_tensor.as_ref().map(|t| t.name.clone()))
+                .or_else(|| {
+                    node.outputs
+                        .first()
+                        .and_then(|o| o.as_tensors.as_ref())
+                        .and_then(|ts| ts.first().map(|t| t.name.clone()))
+                })
+        };
+
+        if let Some(name) = out_name
+            && !name.is_empty()
+        {
+            self.tensors.insert(name, out);
+        } else {
+            anyhow::bail!("SDPA: no output tensor name found on node {}", node.target);
+        }
+
+        Ok(())
+    }
+}
+
+impl PartialEq for SdpaVariant {
+    fn eq(&self, other: &Self) -> bool {
+        matches!(
+            (self, other),
+            (SdpaVariant::Efficient, SdpaVariant::Efficient)
+                | (SdpaVariant::Flash, SdpaVariant::Flash)
+                | (SdpaVariant::FlashForCpu, SdpaVariant::FlashForCpu)
+                | (SdpaVariant::Cudnn, SdpaVariant::Cudnn)
+                | (SdpaVariant::Unified, SdpaVariant::Unified)
+        )
+    }
+}

--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -5,6 +5,7 @@ use crate::pt2_schema::*;
 use crate::pt2_util::*;
 
 use super::Translator;
+use super::attention::SdpaVariant;
 
 impl<'a> Translator<'a> {
     pub(crate) fn translate_node(&mut self, node: &Node) -> Result<()> {
@@ -392,6 +393,29 @@ impl<'a> Translator<'a> {
             // Sort — handles its own output storage, returns early
             "torch.ops.aten.sort.default" => {
                 self.translate_sort(node)?;
+                return Ok(());
+            }
+
+            // Scaled dot-product attention — each variant binds args slightly
+            // differently but all lower to matmul+softmax via translate_sdpa.
+            "torch.ops.aten._scaled_dot_product_efficient_attention.default" => {
+                self.translate_sdpa(node, SdpaVariant::Efficient)?;
+                return Ok(());
+            }
+            "torch.ops.aten._scaled_dot_product_flash_attention.default" => {
+                self.translate_sdpa(node, SdpaVariant::Flash)?;
+                return Ok(());
+            }
+            "torch.ops.aten._scaled_dot_product_flash_attention_for_cpu.default" => {
+                self.translate_sdpa(node, SdpaVariant::FlashForCpu)?;
+                return Ok(());
+            }
+            "torch.ops.aten._scaled_dot_product_cudnn_attention.default" => {
+                self.translate_sdpa(node, SdpaVariant::Cudnn)?;
+                return Ok(());
+            }
+            "torch.ops.aten.scaled_dot_product_attention.default" => {
+                self.translate_sdpa(node, SdpaVariant::Unified)?;
                 return Ok(());
             }
 

--- a/crates/luminal_python/rust/src/translator/mod.rs
+++ b/crates/luminal_python/rust/src/translator/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! Walks the parsed PT2 graph and constructs an equivalent Luminal computation graph.
 
+mod attention;
 mod binary;
 mod conv;
 mod dispatch;

--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -110,6 +110,32 @@ def _export_kwargs():
     return kwargs
 
 
+def _decomp_table():
+    """Decomposition table for `ep.run_decompositions()` that preserves SDPA.
+
+    The default table decomposes `aten.scaled_dot_product_attention.default`
+    into ~20 ops (matmul/softmax + an `eq.Scalar`/`logical_not`/`any.dim`/
+    `where`/`full_like` "all-masked" sentinel chain). We translate SDPA as a
+    single fused op via `translate_sdpa`, so we strip the SDPA decompositions
+    here to let them survive into the FX graph the translator walks.
+    """
+    try:
+        from torch.export import default_decompositions
+    except ImportError:
+        return None
+    table = default_decompositions()
+    sdpa_ops = [
+        torch.ops.aten.scaled_dot_product_attention.default,
+        torch.ops.aten._scaled_dot_product_efficient_attention.default,
+        torch.ops.aten._scaled_dot_product_flash_attention.default,
+        torch.ops.aten._scaled_dot_product_flash_attention_for_cpu.default,
+        torch.ops.aten._scaled_dot_product_cudnn_attention.default,
+    ]
+    for op in sdpa_ops:
+        table.pop(op, None)
+    return table
+
+
 def _save_and_compile(ep_or_path, factory, search_iterations, original_weights=None):
     """Compile a PT2 model via Rust, return CompiledModel.
 
@@ -270,7 +296,7 @@ def compile(
                     dynamic_shapes=dynamic_shapes,
                     **extra,
                 )
-                ep = ep.run_decompositions()
+                ep = ep.run_decompositions(_decomp_table())
                 break
             except Exception:
                 continue
@@ -283,7 +309,7 @@ def compile(
             dynamic_shapes=None,
             **extra,
         )
-        ep = ep.run_decompositions()
+        ep = ep.run_decompositions(_decomp_table())
 
     return _save_and_compile(ep, factory, search_iterations)
 
@@ -302,7 +328,7 @@ def pt2_backend(gm, example_inputs, factory=None):
     gm, user_inputs, original_weights = _reinternalize_lifted_params(gm, example_inputs)
 
     ep = torch.export.export(gm, tuple(user_inputs), **_export_kwargs())
-    ep = ep.run_decompositions()
+    ep = ep.run_decompositions(_decomp_table())
 
     # When using shared memory (original_weights), strip large weight buffers from
     # the EP before saving.  The Rust side uses device pointers for these weights,

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -1847,6 +1847,60 @@ def test_scaled_dot_product_attention(device: torch.device):
     assert torch.allclose(output, original, atol=1e-5)
 
 
+# ========== F.scaled_dot_product_attention (SDPA aten variants) ==========
+# Tests for `torch.nn.functional.scaled_dot_product_attention`, which lowers
+# to one of `aten._scaled_dot_product_*_attention.default` (variant chosen by
+# PyTorch's dispatcher: efficient/flash/flash_for_cpu/cudnn). Coverage here
+# exercises `translate_sdpa` end-to-end.
+
+
+def _sdpa_qkv(device: torch.device, b: int = 1, h: int = 2, s: int = 4, d: int = 8):
+    """Build a `(B, H, S, D)` Q/K/V triple of float32 tensors on `device`."""
+    torch.manual_seed(0)
+    q = torch.rand((b, h, s, d), device=device)
+    k = torch.rand((b, h, s, d), device=device)
+    v = torch.rand((b, h, s, d), device=device)
+    return q, k, v
+
+
+def test_sdpa_basic(device: torch.device):
+    """`F.scaled_dot_product_attention(q, k, v)` — default scale, no mask."""
+    from test_models import SdpaBasicModel
+
+    model: torch.nn.Module = SdpaBasicModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    q, k, v = _sdpa_qkv(device)
+    expected: torch.Tensor = model(q, k, v)
+    actual: torch.Tensor = compiled(q, k, v)
+    assert torch.allclose(actual, expected, atol=1e-5)
+
+
+def test_sdpa_causal(device: torch.device):
+    """`F.scaled_dot_product_attention(q, k, v, is_causal=True)`."""
+    from test_models import SdpaCausalModel
+
+    model: torch.nn.Module = SdpaCausalModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    q, k, v = _sdpa_qkv(device)
+    expected: torch.Tensor = model(q, k, v)
+    actual: torch.Tensor = compiled(q, k, v)
+    assert torch.allclose(actual, expected, atol=1e-5)
+
+
+def test_sdpa_with_attn_bias(device: torch.device):
+    """SDPA with an additive `attn_mask` (float bias) broadcast over heads."""
+    from test_models import SdpaWithBiasModel
+
+    model: torch.nn.Module = SdpaWithBiasModel().to(device)
+    compiled: Callable = torch.compile(model, backend=luminal_backend)
+    q, k, v = _sdpa_qkv(device)
+    bias = torch.zeros((1, 1, q.shape[-2], k.shape[-2]), device=device)
+    bias[..., 0, 1] = -1.0  # any non-trivial bias to verify it's actually applied
+    expected: torch.Tensor = model(q, k, v, bias)
+    actual: torch.Tensor = compiled(q, k, v, bias)
+    assert torch.allclose(actual, expected, atol=1e-5)
+
+
 def test_mlp_block(device: torch.device):
     """Test two-layer MLP: Linear(8,16) -> ReLU -> Linear(16,4) on input (2,8)."""
     model: torch.nn.Module = MLPBlockModel().to(device)

--- a/crates/luminal_python/tests/test_models.py
+++ b/crates/luminal_python/tests/test_models.py
@@ -2280,3 +2280,48 @@ class IntIndexAssignScalarModel(torch.nn.Module):
         out = x.clone()
         out[indices] = 42.0
         return out
+
+
+class SdpaBasicModel(torch.nn.Module):
+    """`F.scaled_dot_product_attention(q, k, v)` with no mask, no causal flag.
+
+    Lowers to `aten._scaled_dot_product_*_attention` (variant chosen by
+    PyTorch based on device/dtype). Tests the default-scale matmul+softmax
+    path. Inputs are 4-D `(B, H, S, D)`.
+    """
+
+    def forward(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+    ) -> torch.Tensor:
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v)
+
+
+class SdpaCausalModel(torch.nn.Module):
+    """`F.scaled_dot_product_attention(q, k, v, is_causal=True)`.
+
+    Tests the `is_causal` branch of `translate_sdpa`, which materializes a
+    triangular mask and adds `-1e9 * mask` to the pre-softmax scores.
+    """
+
+    def forward(
+        self, q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+    ) -> torch.Tensor:
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v, is_causal=True)
+
+
+class SdpaWithBiasModel(torch.nn.Module):
+    """SDPA with an additive `attn_mask` bias (float, broadcast over heads).
+
+    Tests the additive-bias branch of `translate_sdpa`. The bias has shape
+    `(1, 1, S_q, S_k)` so it broadcasts across batch/head prefix dims of
+    the scores tensor.
+    """
+
+    def forward(
+        self,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        bias: torch.Tensor,
+    ) -> torch.Tensor:
+        return torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=bias)


### PR DESCRIPTION
## Summary
- Adds `translate_sdpa` lowering for `aten.scaled_dot_product_attention.default` and the four backend variants (`_efficient`, `_flash`, `_flash_for_cpu`, `_cudnn`). One matmul → softmax → matmul instead of the ~20-op default decomposition.
- **Decomp table change (call-out):** `ep.run_decompositions()` would otherwise decompose SDPA into a manual `eq.Scalar` / `logical_not` / `any.dim` / `where.self` / `full_like` chain that implements the all-masked-row sentinel. New `pt2.py:_decomp_table()` strips the five SDPA entries from `default_decompositions()` so the op survives into the FX graph and our translator catches it. All three `run_decompositions()` call sites now pass this table.
- Three tests cover the three commonly-hit branches: basic Q/K/V, `is_causal=True`, and additive `attn_mask`.

## Test plan
- [x] `uv run pytest tests/test_hlir_ops.py tests/test_unary.py` — 224 passed (native)
- [x] `LUMINAL_TEST_DEVICE=cuda uv run pytest tests/test_hlir_ops.py tests/test_unary.py tests/test_llama3.py tests/test_kv_cache_comparison.py tests/test_kv_cache_growing.py` — 239 passed / 4 xfailed (CUDA)
- [x] `cargo fmt --check` + `cargo clippy --features cuda -- -D warnings` + `ruff check` + `ruff format --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)