### PR TITLE
Add gemma4_moe to Modal CI and simplify cuda_lite fusion/runtime handling

### DIFF
--- a/.github/workflows/modal-examples.yml
+++ b/.github/workflows/modal-examples.yml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                example: [llama, gemma, qwen, qwen3_moe]
+                example: [llama, gemma, qwen, qwen3_moe, gemma4_moe]
                 gpu:
                     - { type: "A100-80GB" }
                     # To add more GPUs, just append another entry:

--- a/crates/luminal_cuda_lite/src/kernel/fusion/markers.rs
+++ b/crates/luminal_cuda_lite/src/kernel/fusion/markers.rs
@@ -209,14 +209,6 @@ impl EgglogOp for FusionEnd {
     }
 
     fn rewrites(&self) -> Vec<Rule> {
-        // Ablation switch: with `LUMINAL_DISABLE_BINARY_FUSION=1` set, do
-        // not register any fusion rules. The e-graph never sees the FS/FE
-        // bracketed alternative, extraction always picks the un-fused
-        // form, and the runtime path matches main with no fusion at all.
-        // Used to A/B fusion's runtime impact on a single binary.
-        if std::env::var("LUMINAL_DISABLE_BINARY_FUSION").is_ok() {
-            return Vec::new();
-        }
         // Seven rule families build and extend FE-bracketed regions. Each
         // pair-fuse rule's LHS pattern matches *un-fused* `KernelX` ops; the
         // RHS produces `FusedX` variants in a different egglog sort, so the
@@ -409,8 +401,11 @@ impl EgglogOp for FusionEnd {
         }
 
         // 7. Merge two FEs at a binary: B(FE(ia), FE(ib)) → FE(FB(ia, ib)).
-        //    Both inners reused, no new FS — shared external tensors with
-        //    upstream FSes stay at one FS.
+        //
+        // This is destructive: after creating the larger region, subsume the
+        // two smaller FusionEnd rows. Without that, independently-grown left
+        // and right regions form a Cartesian product, then those alternatives
+        // can merge again higher in the graph.
         for (kb, fb, lb) in binaries {
             rules.push(Rule::raw(format!(
                 "(rule (
@@ -423,6 +418,8 @@ impl EgglogOp for FusionEnd {
                                    (ICons ?inner_a (ICons ?inner_b (INil)))))
                     (let ?new_fe (Op (FusionEnd ?shape ?o_s ?dt) (ICons ?fbin (INil))))
                     (union ?bin ?new_fe)
+                    (subsume (Op (FusionEnd ?shape ?a_s ?dt) (ICons ?inner_a (INil))))
+                    (subsume (Op (FusionEnd ?shape ?b_s ?dt) (ICons ?inner_b (INil))))
                  ) :name \"merge-FE-FE-{lb}\")"
             )));
         }

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -64,17 +64,28 @@ impl Debug for ExecutableHostOp {
     }
 }
 
-/// Per-bucket compiled state. Each bucket holds its own LLIR graph, exec graph,
-/// intermediate buffers, and node mappings. Weights (hlir_buffers) are shared.
+#[derive(Clone)]
+pub(crate) struct BufferSpec {
+    bytes: Expression,
+    dtype: DType,
+}
+
+/// Per-bucket compiled state. Each bucket holds its own executable graph,
+/// explicit runtime metadata, intermediate buffers, and node mappings.
+/// Weights (hlir_buffers) are shared.
 pub(crate) struct CompiledBucket {
-    pub(crate) llir_graph: luminal::graph::LLIRGraph,
     pub(crate) exec_graph: StableGraph<ExecutableHostOp, (), Directed>,
     pub(crate) node_to_exec: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) buffers: FxHashMap<NodeIndex, CudaSlice<u8>>,
     pub(crate) cached_buffer_ptrs: FxHashMap<NodeIndex, u64>,
+    pub(crate) buffer_specs: FxHashMap<NodeIndex, BufferSpec>,
     pub(crate) llir_to_hlir: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) hlir_to_llir: FxHashMap<NodeIndex, NodeIndex>,
+    pub(crate) output_producers: FxHashMap<NodeIndex, NodeIndex>,
     pub(crate) output_alias_map: FxHashMap<NodeIndex, NodeIndex>,
+    pub(crate) output_data_map: FxHashMap<NodeIndex, NodeIndex>,
+    pub(crate) preserved_hlir_inputs: FxHashSet<NodeIndex>,
+    pub(crate) kernel_names: Vec<&'static str>,
     pub(crate) last_dyn_map: FxHashMap<char, usize>,
     pub(crate) intermediate_buffer_dims: FxHashSet<char>,
     /// Which bucket index per dim this compilation targets
@@ -86,14 +97,18 @@ pub(crate) struct CompiledBucket {
 impl CompiledBucket {
     fn new() -> Self {
         CompiledBucket {
-            llir_graph: StableGraph::default(),
             exec_graph: StableGraph::default(),
             node_to_exec: FxHashMap::default(),
             buffers: FxHashMap::default(),
             cached_buffer_ptrs: FxHashMap::default(),
+            buffer_specs: FxHashMap::default(),
             llir_to_hlir: FxHashMap::default(),
             hlir_to_llir: FxHashMap::default(),
+            output_producers: FxHashMap::default(),
             output_alias_map: FxHashMap::default(),
+            output_data_map: FxHashMap::default(),
+            preserved_hlir_inputs: FxHashSet::default(),
+            kernel_names: Vec::new(),
             last_dyn_map: FxHashMap::default(),
             intermediate_buffer_dims: FxHashSet::default(),
             bucket_indices: FxHashMap::default(),
@@ -157,9 +172,18 @@ impl CudaRuntime {
         &mut self.compiled_buckets[self.active_bucket]
     }
 
-    /// Public access to the active LLIR graph (for tests and diagnostics).
-    pub fn llir_graph(&self) -> &luminal::graph::LLIRGraph {
-        &self.active().llir_graph
+    /// Names of CUDA kernels compiled into the active bucket.
+    pub fn kernel_names(&self) -> &[&'static str] {
+        &self.active().kernel_names
+    }
+
+    /// Host operations in the active executable graph, for diagnostics.
+    pub fn host_ops(&self) -> Vec<&dyn HostOp> {
+        self.active()
+            .exec_graph
+            .node_weights()
+            .map(|op| op.internal.as_ref().as_ref() as &dyn HostOp)
+            .collect()
     }
 
     /// Public access to the active intermediate buffers (for tests and diagnostics).
@@ -257,37 +281,18 @@ impl CudaRuntime {
     fn find_producer_node(&self, id: impl ToId) -> NodeIndex {
         let id = id.to_id();
         let bucket = self.active();
-        let output_id = bucket
-            .llir_graph
-            .node_indices()
-            .find(|n| {
-                if let Some(Output { node }) = bucket.llir_graph[*n].to_op::<Output>() {
-                    *node == id.index()
-                } else {
-                    false
-                }
-            })
-            .expect("Cannot find output tensor!");
-        bucket
-            .llir_graph
-            .neighbors_directed(output_id, Direction::Incoming)
-            .next()
-            .unwrap()
+        *bucket
+            .output_producers
+            .get(&id)
+            .expect("Cannot find output tensor!")
     }
 
     /// Follow `output_aliases_input` to find the node whose buffer actually contains
     /// the output data. For in-place ops, data lives in the aliased input's buffer.
     fn follow_aliases(&self, mut node: NodeIndex) -> NodeIndex {
         let bucket = self.active();
-        while let Some(kernel_op) = bucket.llir_graph[node].to_dialect::<dyn KernelOp>()
-            && let Some(input_idx) = kernel_op.output_aliases_input()
-        {
-            node = bucket
-                .llir_graph
-                .neighbors_directed(node, Direction::Incoming)
-                .sorted_by_key(|n| bucket.llir_graph.find_edge(*n, node).unwrap())
-                .nth(input_idx)
-                .expect("output_aliases_input index out of range");
+        while let Some(alias_target) = bucket.output_alias_map.get(&node) {
+            node = *alias_target;
         }
         node
     }
@@ -301,15 +306,8 @@ impl CudaRuntime {
     /// to the HLIR input, so the roundtrip correctly swaps the HLIR buffer.
     fn follow_data_lineage(&self, mut node: NodeIndex) -> NodeIndex {
         let bucket = self.active();
-        while let Some(kernel_op) = bucket.llir_graph[node].to_dialect::<dyn KernelOp>()
-            && let Some(input_idx) = kernel_op.output_data_input()
-        {
-            node = bucket
-                .llir_graph
-                .neighbors_directed(node, Direction::Incoming)
-                .sorted_by_key(|n| bucket.llir_graph.find_edge(*n, node).unwrap())
-                .nth(input_idx)
-                .expect("output_data_input index out of range");
+        while let Some(data_target) = bucket.output_data_map.get(&node) {
+            node = *data_target;
         }
         node
     }
@@ -586,23 +584,10 @@ impl CudaRuntime {
         let bi = self.active_bucket;
 
         let bucket = &self.compiled_buckets[bi];
-        // Find LLIR Output node for output_id
-        let output_llir_node = bucket
-            .llir_graph
-            .node_indices()
-            .find(|n| {
-                bucket.llir_graph[*n]
-                    .to_op::<Output>()
-                    .is_some_and(|o| o.node == output_id.index())
-            })
+        let data_llir_node = *bucket
+            .output_producers
+            .get(&output_id)
             .expect("Cannot find output node for swap!");
-
-        // Get its data-producing predecessor
-        let data_llir_node = bucket
-            .llir_graph
-            .neighbors_directed(output_llir_node, Direction::Incoming)
-            .next()
-            .unwrap();
 
         // Get the LLIR node for the input
         let input_llir_node = *bucket
@@ -660,38 +645,11 @@ impl CudaRuntime {
         bucket.intermediate_buffer_dims.clear();
         let mut total_alloc: usize = 0;
         let mut realloc_count: usize = 0;
-        for node in bucket.llir_graph.node_indices().collect_vec() {
-            if bucket.llir_graph[node].to_op::<Input>().is_some() {
-                continue;
-            }
-            // Skip fusion marker / interior nodes. Region codegen folds
-            // FusionStart / FusionEnd / FusedX into a single CUDA function
-            // anchored at the FusionEnd; these marker nodes never need a
-            // device buffer of their own at runtime, so walking them here
-            // each step (with `p` incrementing every decode token) is
-            // pure overhead. Skipping them recovers ~2 ms / token on
-            // llama with fusion enabled.
-            if let Some(op) = bucket.llir_graph[node].to_dialect::<dyn KernelOp>() {
-                let kn = op.kernel_name();
-                if kn == "FusionStart" || kn.starts_with("Fused") {
-                    continue;
-                }
-                // Note: we deliberately keep "FusionEnd" because it is the
-                // anchor for the region's compiled kernel and DOES need a
-                // buffer for the region's output.
-            }
-            let needed_bytes =
-                if let Some(op) = bucket.llir_graph[node].to_dialect::<dyn KernelOp>() {
-                    let out_bytes = op.output_bytes();
-                    bucket.intermediate_buffer_dims.extend(out_bytes.dyn_vars());
-                    out_bytes.exec(dyn_dims).unwrap()
-                } else if let Some(op) = bucket.llir_graph[node].to_dialect::<dyn HostOp>() {
-                    let out_bytes = op.output_bytes();
-                    bucket.intermediate_buffer_dims.extend(out_bytes.dyn_vars());
-                    out_bytes.exec(dyn_dims).unwrap()
-                } else {
-                    continue;
-                };
+        for (node, spec) in bucket.buffer_specs.clone() {
+            bucket
+                .intermediate_buffer_dims
+                .extend(spec.bytes.dyn_vars());
+            let needed_bytes = spec.bytes.exec(dyn_dims).unwrap();
 
             if needed_bytes == 0 {
                 continue;
@@ -943,7 +901,7 @@ impl Runtime for CudaRuntime {
             .sum()
     }
 
-    fn has_nan_outputs(&self, llir_graph: &LLIRGraph, _dyn_map: &FxHashMap<char, usize>) -> bool {
+    fn has_nan_outputs(&self, _llir_graph: &LLIRGraph, _dyn_map: &FxHashMap<char, usize>) -> bool {
         let _ = self.cuda_stream.synchronize();
         let bucket = self.active();
         for (node_id, buf) in &bucket.buffers {
@@ -951,14 +909,14 @@ impl Runtime for CudaRuntime {
             if n_bytes == 0 || n_bytes % 4 != 0 {
                 continue;
             }
-            // Determine buffer dtype from the producing LLIR node's kernel op.
+            // Determine buffer dtype from the compiled buffer metadata.
             // Only check F32 buffers for NaN; integer/bool buffers have no NaN concept
             // and their bit patterns can produce false positives when reinterpreted as f32.
-            let is_float = llir_graph
-                .node_weight(*node_id)
-                .and_then(|op| op.to_dialect::<dyn KernelOp>())
-                .map(|k| matches!(k.output_dtype(), DType::F32))
-                .unwrap_or(true); // default to float check if node not found
+            let is_float = bucket
+                .buffer_specs
+                .get(node_id)
+                .map(|spec| matches!(spec.dtype, DType::F32))
+                .unwrap_or(true);
 
             if !is_float {
                 continue;
@@ -1234,32 +1192,7 @@ impl Runtime for CudaRuntime {
             return;
         }
         let bucket = &self.compiled_buckets[self.active_bucket];
-        let mut inputs_with_outputs: FxHashSet<NodeIndex> = bucket
-            .llir_graph
-            .node_indices()
-            .filter(|n| bucket.llir_graph[*n].to_op::<Output>().is_some())
-            .filter_map(|output_node| {
-                bucket
-                    .llir_graph
-                    .neighbors_directed(output_node, Direction::Incoming)
-                    .next()
-                    .and_then(|pred| bucket.llir_to_hlir.get(&pred).copied())
-            })
-            .collect();
-        let alias_preserved: Vec<NodeIndex> = bucket
-            .llir_graph
-            .node_indices()
-            .filter(|n| bucket.llir_graph[*n].to_op::<Output>().is_some())
-            .filter_map(|output_node| {
-                let pred = bucket
-                    .llir_graph
-                    .neighbors_directed(output_node, Direction::Incoming)
-                    .next()?;
-                let alias_target = bucket.output_alias_map.get(&pred)?;
-                bucket.llir_to_hlir.get(alias_target).copied()
-            })
-            .collect();
-        inputs_with_outputs.extend(alias_preserved);
+        let mut inputs_with_outputs = bucket.preserved_hlir_inputs.clone();
 
         // For multi-bucket: also preserve inputs needed by other buckets
         if self.compiled_buckets.len() > 1 {
@@ -1333,19 +1266,94 @@ impl CudaRuntime {
         // Compile kernel subgraphs into CudaGraphOps (which implement HostOp)
         crate::kernel::kernel_to_host(&mut llir_graph, &self.cuda_stream, &mut self.kernel_cache);
 
-        // Build output alias map
+        // Extract all runtime metadata we used to recover from the lowered LLIR
+        // at execution time. After this point the LLIR is compile-time only.
         for node in llir_graph.node_indices() {
-            if let Some(kernel_op) = llir_graph[node].to_dialect::<dyn KernelOp>()
-                && let Some(input_idx) = kernel_op.output_aliases_input()
+            if let Some(Input {
+                node: hlir_node, ..
+            }) = llir_graph[node].to_op::<Input>()
             {
-                let alias_target = llir_graph
+                bucket.llir_to_hlir.insert(node, NodeIndex::new(*hlir_node));
+                bucket.hlir_to_llir.insert(NodeIndex::new(*hlir_node), node);
+                continue;
+            }
+
+            if let Some(Output { node: hlir_node }) = llir_graph[node].to_op::<Output>() {
+                let producer = llir_graph
+                    .neighbors_directed(node, Direction::Incoming)
+                    .next()
+                    .expect("Output node without producer");
+                bucket
+                    .output_producers
+                    .insert(NodeIndex::new(*hlir_node), producer);
+                continue;
+            }
+
+            let inputs = || {
+                llir_graph
                     .edges_directed(node, Direction::Incoming)
                     .sorted_by_key(|e| e.id())
                     .map(|e| e.source())
-                    .nth(input_idx);
-                if let Some(target) = alias_target {
+                    .collect_vec()
+            };
+
+            if let Some(kernel_op) = llir_graph[node].to_dialect::<dyn KernelOp>() {
+                let kernel_name = kernel_op.kernel_name();
+                bucket.kernel_names.push(kernel_name);
+
+                if kernel_name != "FusionStart" && !kernel_name.starts_with("Fused") {
+                    bucket.buffer_specs.insert(
+                        node,
+                        BufferSpec {
+                            bytes: kernel_op.output_bytes(),
+                            dtype: kernel_op.output_dtype(),
+                        },
+                    );
+                }
+
+                if let Some(input_idx) = kernel_op.output_aliases_input()
+                    && let Some(target) = inputs().get(input_idx).copied()
+                {
                     bucket.output_alias_map.insert(node, target);
                 }
+
+                if let Some(input_idx) = kernel_op.output_data_input()
+                    && let Some(target) = inputs().get(input_idx).copied()
+                {
+                    bucket.output_data_map.insert(node, target);
+                }
+            }
+
+            if let Some(host_op) = llir_graph[node].to_dialect::<dyn HostOp>() {
+                bucket.buffer_specs.insert(
+                    node,
+                    BufferSpec {
+                        bytes: host_op.output_bytes(),
+                        dtype: DType::F32,
+                    },
+                );
+            }
+        }
+
+        for producer in bucket.output_producers.values().copied() {
+            let mut alias_node = producer;
+            while let Some(target) = bucket.output_alias_map.get(&alias_node) {
+                alias_node = *target;
+            }
+            if let Some(hlir_node) = bucket.llir_to_hlir.get(&alias_node) {
+                bucket.preserved_hlir_inputs.insert(*hlir_node);
+            }
+
+            let mut data_node = producer;
+            while let Some(target) = bucket.output_data_map.get(&data_node) {
+                data_node = *target;
+            }
+            if let Some(hlir_node) = bucket.llir_to_hlir.get(&data_node) {
+                bucket.preserved_hlir_inputs.insert(*hlir_node);
+            }
+
+            if let Some(hlir_node) = bucket.llir_to_hlir.get(&producer) {
+                bucket.preserved_hlir_inputs.insert(*hlir_node);
             }
         }
 
@@ -1391,22 +1399,6 @@ impl CudaRuntime {
 
         bucket.exec_graph = exec_graph;
         bucket.node_to_exec = node_to_exec;
-
-        // Build HLIR<->LLIR mappings
-        let input_nodes: Vec<_> = llir_graph
-            .node_indices()
-            .filter_map(|n| llir_graph[n].to_op::<Input>().map(|op| (op.node, n)))
-            .collect_vec();
-        for (hlir_node, llir_node) in input_nodes {
-            bucket
-                .llir_to_hlir
-                .insert(llir_node, NodeIndex::new(hlir_node));
-            bucket
-                .hlir_to_llir
-                .insert(NodeIndex::new(hlir_node), llir_node);
-        }
-
-        bucket.llir_graph = llir_graph;
         bucket.hlir_synced = false;
         bucket
     }

--- a/crates/luminal_cuda_lite/src/tests/consumed_buffer_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/consumed_buffer_tests.rs
@@ -243,11 +243,9 @@ fn test_scatter_kv_cache_roundtrip() {
     rt = cx.search(rt, 5);
 
     // Print which scatter variant was selected
-    for node in rt.llir_graph().node_weights() {
-        if let Some(k) = node.to_dialect::<dyn KernelOp>()
-            && k.kernel_name().contains("catter")
-        {
-            println!("Selected: {}", k.kernel_name());
+    for name in rt.kernel_names() {
+        if name.contains("catter") {
+            println!("Selected: {name}");
         }
     }
 
@@ -350,11 +348,9 @@ fn test_scatter_dual_cache() {
     rt = cx.search_options(rt, SearchOptions::new(5), &mut rng);
 
     // Print selected variants
-    for node in rt.llir_graph().node_weights() {
-        if let Some(k) = node.to_dialect::<dyn KernelOp>()
-            && k.kernel_name().contains("catter")
-        {
-            println!("Dual test selected: {}", k.kernel_name());
+    for name in rt.kernel_names() {
+        if name.contains("catter") {
+            println!("Dual test selected: {name}");
         }
     }
 

--- a/crates/luminal_cuda_lite/src/tests/qwen3_moe_rewrite.rs
+++ b/crates/luminal_cuda_lite/src/tests/qwen3_moe_rewrite.rs
@@ -3,10 +3,7 @@ use luminal::{dtype::DType, prelude::*, shape::Expression};
 
 use super::utilities::{assert_close, get_cuda_stream, random_f32_vec};
 use crate::{
-    host::{
-        HostOp,
-        moe::{GLUMoE, GLUMoEMode},
-    },
+    host::moe::{GLUMoE, GLUMoEMode},
     runtime::CudaRuntime,
 };
 
@@ -176,10 +173,9 @@ fn gemma_gelu(x: GraphTensor) -> GraphTensor {
 }
 
 fn glumoe_modes(rt: &CudaRuntime) -> Vec<GLUMoEMode> {
-    rt.llir_graph()
-        .node_weights()
-        .filter_map(|node| {
-            let op = node.to_dialect::<dyn HostOp>()?;
+    rt.host_ops()
+        .into_iter()
+        .filter_map(|op| {
             op.as_any()
                 .downcast_ref::<GLUMoE>()
                 .map(|glumoe| glumoe.mode)


### PR DESCRIPTION
## Summary
- Add `gemma4_moe` to the Modal examples workflow matrix so it runs alongside the other examples in CI.
- Keep the simplified `luminal_cuda_lite` runtime structure that stores exec graphs and associated metadata instead of carrying the original LLIR graph around.
- Remove the `disable_fusion` / fusion env-switch path and keep fusion rules always enabled.
- Preserve the destructive FE+FE merge behavior that prevents region blowup.

## Testing
- `cargo fmt`
- `cargo check -p luminal_cuda_lite -p gemma4_moe`
- `cargo clippy -p luminal_cuda_lite -p gemma4_moe --all-targets -- -D warnings`
- `cargo test -p luminal_cuda_lite`
- Local release run of `gemma4_moe` verified correct token output