### PR TITLE
Add modal example output checks and enable gemma4_moe in CI

### DIFF
--- a/.github/workflows/modal-examples.yml
+++ b/.github/workflows/modal-examples.yml
@@ -22,7 +22,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                example: [llama, gemma, qwen, qwen3_moe]
+                example: [llama, gemma, qwen, qwen3_moe, gemma4_moe]
                 gpu:
                     - { type: "A100-80GB" }
                     # To add more GPUs, just append another entry:

--- a/ci/modal_example.py
+++ b/ci/modal_example.py
@@ -1,6 +1,9 @@
-import modal
-import subprocess
 import os
+import re
+import subprocess
+import sys
+
+import modal
 
 example = os.environ.get("EXAMPLE", "llama")
 gpu_type = os.environ.get("GPU_TYPE", "A100-80GB")
@@ -17,6 +20,76 @@ hf_cache = modal.Volume.from_name(
 )
 
 WORKDIR = "/workspace/luminal"
+
+ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+
+EXPECTED_OUTPUT = {
+    "llama": [
+        "complex system modeled after the structure and function of the human brain",
+    ],
+    "gemma": [
+        "recognize pictures of cats",
+        "little detectives looking for specific features",
+    ],
+    "qwen": [
+        "computational model inspired by the structure and function of the human brain",
+    ],
+    "qwen3_moe": [
+        "The capital of France is Paris",
+    ],
+    "gemma4_moe": [
+        "city of romance, art and culture",
+    ],
+}
+
+
+def run_and_capture(command: list[str], *, cwd: str, env: dict[str, str]) -> str:
+    process = subprocess.Popen(
+        command,
+        cwd=cwd,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+    )
+    assert process.stdout is not None
+
+    chunks = []
+    while True:
+        chunk = process.stdout.read1(4096)
+        if not chunk:
+            break
+        sys.stdout.buffer.write(chunk)
+        sys.stdout.buffer.flush()
+        chunks.append(chunk)
+
+    return_code = process.wait()
+    output = b"".join(chunks).decode("utf-8", errors="replace")
+    if return_code:
+        raise subprocess.CalledProcessError(return_code, command, output=output)
+    return output
+
+
+def normalize_output(output: str) -> str:
+    output = ANSI_ESCAPE.sub("", output)
+    output = output.replace("\r", "\n")
+    return re.sub(r"\s+", " ", output).casefold()
+
+
+def validate_output(example: str, output: str):
+    expected_phrases = EXPECTED_OUTPUT.get(example)
+    if expected_phrases is None:
+        raise ValueError(f"No expected output phrases configured for example {example!r}")
+
+    normalized_output = normalize_output(output)
+    for phrase in expected_phrases:
+        if normalize_output(phrase) in normalized_output:
+            print(f"\nOutput check passed for {example!r}: found {phrase!r}")
+            return
+
+    expected = "\n  - ".join(expected_phrases)
+    raise AssertionError(
+        f"Output check failed for {example!r}. Expected one of:\n  - {expected}"
+    )
 
 cuda_image = (
     modal.Image.from_registry(
@@ -48,16 +121,17 @@ def run_example(example: str):
     """Build and run a luminal example on a Modal GPU."""
     subprocess.run(["nvidia-smi"], check=True)
 
-    subprocess.run(
+    run_env = {
+        **os.environ,
+        "CUDARC_CUDA_VERSION": CUDARC_CUDA_VERSION,
+        "HF_HOME": HF_CACHE_PATH,
+    }
+    output = run_and_capture(
         ["cargo", "run", "--release"],
         cwd=f"{WORKDIR}/examples/{example}",
-        env={
-            **os.environ,
-            "CUDARC_CUDA_VERSION": CUDARC_CUDA_VERSION,
-            "HF_HOME": HF_CACHE_PATH,
-        },
-        check=True,
+        env=run_env,
     )
+    validate_output(example, output)
 
     hf_cache.commit()
 

--- a/crates/luminal_cuda_lite/src/kernel/fusion/markers.rs
+++ b/crates/luminal_cuda_lite/src/kernel/fusion/markers.rs
@@ -209,14 +209,6 @@ impl EgglogOp for FusionEnd {
     }
 
     fn rewrites(&self) -> Vec<Rule> {
-        // Ablation switch: with `LUMINAL_DISABLE_BINARY_FUSION=1` set, do
-        // not register any fusion rules. The e-graph never sees the FS/FE
-        // bracketed alternative, extraction always picks the un-fused
-        // form, and the runtime path matches main with no fusion at all.
-        // Used to A/B fusion's runtime impact on a single binary.
-        if std::env::var("LUMINAL_DISABLE_BINARY_FUSION").is_ok() {
-            return Vec::new();
-        }
         // Seven rule families build and extend FE-bracketed regions. Each
         // pair-fuse rule's LHS pattern matches *un-fused* `KernelX` ops; the
         // RHS produces `FusedX` variants in a different egglog sort, so the
@@ -409,8 +401,11 @@ impl EgglogOp for FusionEnd {
         }
 
         // 7. Merge two FEs at a binary: B(FE(ia), FE(ib)) → FE(FB(ia, ib)).
-        //    Both inners reused, no new FS — shared external tensors with
-        //    upstream FSes stay at one FS.
+        //
+        // This is destructive: after creating the larger region, subsume the
+        // two smaller FusionEnd rows. Without that, independently-grown left
+        // and right regions form a Cartesian product, then those alternatives
+        // can merge again higher in the graph.
         for (kb, fb, lb) in binaries {
             rules.push(Rule::raw(format!(
                 "(rule (
@@ -423,6 +418,8 @@ impl EgglogOp for FusionEnd {
                                    (ICons ?inner_a (ICons ?inner_b (INil)))))
                     (let ?new_fe (Op (FusionEnd ?shape ?o_s ?dt) (ICons ?fbin (INil))))
                     (union ?bin ?new_fe)
+                    (subsume (Op (FusionEnd ?shape ?a_s ?dt) (ICons ?inner_a (INil))))
+                    (subsume (Op (FusionEnd ?shape ?b_s ?dt) (ICons ?inner_b (INil))))
                  ) :name \"merge-FE-FE-{lb}\")"
             )));
         }


### PR DESCRIPTION
## Summary
- Add `gemma4_moe` to the Modal examples matrix.
- Teach the Modal example runner to capture stdout and assert a simple expected phrase per example.
- Remove the old `LUMINAL_DISABLE_BINARY_FUSION` escape hatch and keep the destructive FE+FE merge fix that prevents fusion blowups.

## Testing
- `cargo fmt`
- `python -m py_compile ci/modal_example.py`
- `cargo check -p luminal_cuda_lite -p gemma4_moe`
- `cargo clippy -p luminal_cuda_lite -p gemma4_moe --all-targets -- -D warnings`
- `cargo test -p luminal_cuda_lite`
- Local release runs verified the expected output phrases for `llama`, `gemma`, `qwen`, `qwen3_moe`, and `gemma4_moe`.