### PR TITLE
Fix MetalGather output dtype inference

### DIFF
--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -2056,6 +2056,10 @@ impl MetalKernelOp for MetalGather {
             .max(Expression::from(1))
     }
 
+    fn infer_output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        input_dtypes.get(1).copied().unwrap_or(DType::F32)
+    }
+
     fn encode(
         &self,
         encoder: &ComputeCommandEncoderRef,

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -1012,3 +1012,21 @@ fn test_scatter_all_positions() {
     let out = rt.get_f32(result);
     assert_close(&out, &[10.0, 20.0, 30.0, 40.0], 0.001);
 }
+
+#[test]
+fn test_gather_preserves_data_dtype() {
+    let mut cx = Graph::default();
+    let data = cx.tensor(2);
+    let indexes = cx.tensor(1).as_dtype(DType::Int);
+    let out = data.gather(indexes).output();
+
+    cx.build_search_space::<MetalRuntime>();
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(data, &[1.25, 2.5]);
+    rt.set_data(indexes, &[1.0]);
+    rt = cx.search(rt, 1);
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(out), &[2.5], 0.001);
+}


### PR DESCRIPTION
MetalGather was using the default kernel dtype inference, which takes the first input dtype. For gather, the first input is the Int index tensor and the second input is the gathered data tensor, so F32 gathers were compiled with Int outputs.

Infer the output dtype from the data input instead.