### PR TITLE
Remove early rewrites and move GLUMoE and sigmoid staging into main schedule

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ generational-box = "0.5.6"
 serde_json = "1.0.140"
 egglog = {git="https://github.com/egraphs-good/egglog", rev="0a8cc35a6c68d0460c20449d5fa19ca3caba2923"}
 egglog-ast = {git="https://github.com/egraphs-good/egglog", rev="0a8cc35a6c68d0460c20449d5fa19ca3caba2923"}
+egglog-reports = {git="https://github.com/egraphs-good/egglog", rev="0a8cc35a6c68d0460c20449d5fa19ca3caba2923"}
 egraph-serialize = { version = "0.3.0", default-features = false, features = ["graphviz", "serde"]}
 tracing = "0.1.43"
 paste = "1.0.15"

--- a/crates/luminal_cuda_lite/src/host/moe/glumoe_rewrite.egg
+++ b/crates/luminal_cuda_lite/src/host/moe/glumoe_rewrite.egg
@@ -5,12 +5,19 @@
 ;   mode=1: Gemma-style GELU (gate * sigmoid(1.595769 * gate * (1 + 0.044715 * gate^2)))
 ;
 ; To keep matching fast, we stage through marker states:
-;   1) Shared gate-up matmul marker
-;   2) Activation marker (separate swiglu / gemma_gelu paths)
-;   3) Down matmul marker (separate swiglu / gemma_gelu paths)
-;   4) Final GLUMoE fusion (separate swiglu / gemma_gelu rules)
+;   1) Shared expert index/gather markers
+;   2) Shared gate-up matmul marker
+;   3) Activation marker (separate swiglu / gemma_gelu paths)
+;   4) Down matmul marker (separate swiglu / gemma_gelu paths)
+;   5) Final GLUMoE fusion (separate swiglu / gemma_gelu rules)
 
 (datatype*
+    (GLUMoEExpertIndexState
+        (MkGLUMoEExpertIndexState Expression Expression IR)
+    )
+    (GLUMoEExpertGatherState
+        (MkGLUMoEExpertGatherState Expression Expression IR IR)
+    )
     (GLUMoEGateUpState
         (MkGLUMoEGateUpState Expression Expression Expression IR IR IR)
     )
@@ -28,6 +35,8 @@
     )
 )
 
+(function glumoe_expert_index (IR) GLUMoEExpertIndexState :merge new)
+(function glumoe_expert_gather (IR) GLUMoEExpertGatherState :merge new)
 (function glumoe_gate_up (IR) GLUMoEGateUpState :merge new)
 (function glumoe_swiglu (IR) GLUMoESwiGLUState :merge new)
 (function glumoe_gemma_gelu (IR) GLUMoEGemmaGELUState :merge new)
@@ -36,17 +45,36 @@
 
 (rule
     (
-        ; ===== Gate-up expert gather =====
-        (= ?gu_iota_base (Op (Iota ?gu_io ?gu_iota_base_range) (INil)))
-        (= ?gu_mul_base (Op (Mul ?gu_mul_base_shape ?gu_mul_base_a_stride ?gu_mul_base_b_stride ?gu_mul_base_out_stride) (ICons ?topk_idx (ICons ?gu_iota_base (INil)))))
-        (= ?gu_iota_within (Op (Iota (MIter) ?gu_iota_within_range) (INil)))
-        (= ?gu_add_idx (Op (Add ?gu_add_shape ?gu_add_a_stride ?gu_add_b_stride ?gu_add_out_stride) (ICons ?gu_mul_base (ICons ?gu_iota_within (INil)))))
-        (= ?gu_gathered (Op (Gather ?gu_gather_idx_shape ?gu_gather_idx_stride ?gu_gather_data_shape ?gu_gather_data_stride) (ICons ?gu_add_idx (ICons ?gate_up_w (INil)))))
+        (= ?iota_base (Op (Iota ?io ?iota_base_range) (INil)))
+        (= ?mul_base (Op (Mul ?mul_base_shape ?mul_base_a_stride ?mul_base_b_stride ?mul_base_out_stride) (ICons ?topk_idx (ICons ?iota_base (INil)))))
+        (= ?iota_within (Op (Iota (MIter) ?iota_within_range) (INil)))
+        (= ?add_idx (Op (Add ?add_shape ?add_a_stride ?add_b_stride ?add_out_stride) (ICons ?mul_base (ICons ?iota_within (INil)))))
+    )
+    (
+        (set (glumoe_expert_index ?add_idx)
+            (MkGLUMoEExpertIndexState ?io ?iota_within_range ?topk_idx))
+    )
+    :name "GLUMoE expert index marker"
+)
 
-        ; ===== Cast BF16→F32 =====
-        (= ?gu_f32 (Op (Cast ?gu_f32_size (F32)) (ICons ?gu_gathered (INil))))
+(rule
+    (
+        (= ?index_state (glumoe_expert_index ?idx))
+        (= ?index_state (MkGLUMoEExpertIndexState ?io ?within_range ?topk_idx))
+        (= ?gathered (Op (Gather ?gather_idx_shape ?gather_idx_stride ?gather_data_shape ?gather_data_stride) (ICons ?idx (ICons ?weights (INil)))))
+        (= ?f32 (Op (Cast ?f32_size (F32)) (ICons ?gathered (INil))))
+    )
+    (
+        (set (glumoe_expert_gather ?f32)
+            (MkGLUMoEExpertGatherState ?io ?within_range ?topk_idx ?weights))
+    )
+    :name "GLUMoE expert gather marker"
+)
 
-        ; ===== Gate-up batched matmul =====
+(rule
+    (
+        (= ?gather_state (glumoe_expert_gather ?gu_f32))
+        (= ?gather_state (MkGLUMoEExpertGatherState ?gu_io ?gu_iota_within_range ?topk_idx ?gate_up_w))
         (= ?gu_matmul_mul (Op (Mul ?gu_matmul_mul_shape ?gu_matmul_a_stride ?gu_matmul_b_stride ?gu_matmul_mul_out_stride) (ICons ?x (ICons ?gu_f32 (INil)))))
         (= ?gu_matmul (Op (Sum ?gu_matmul_out_shape ?gu_matmul_k ?gu_matmul_in_stride ?gu_matmul_k_stride ?gu_matmul_out_stride) (ICons ?gu_matmul_mul (INil))))
     )
@@ -122,12 +150,8 @@
         (= ?swiglu_state (glumoe_swiglu ?swiglu_out))
         (= ?swiglu_state (MkGLUMoESwiGLUState ?gate_up_state))
 
-        (= ?dn_iota_base (Op (Iota ?dn_io ?dn_iota_base_range) (INil)))
-        (= ?dn_mul_base (Op (Mul ?dn_mul_base_shape ?dn_mul_base_a_stride ?dn_mul_base_b_stride ?dn_mul_base_out_stride) (ICons ?topk_idx (ICons ?dn_iota_base (INil)))))
-        (= ?dn_iota_within (Op (Iota (MIter) ?dn_iota_within_range) (INil)))
-        (= ?dn_add_idx (Op (Add ?dn_add_shape ?dn_add_a_stride ?dn_add_b_stride ?dn_add_out_stride) (ICons ?dn_mul_base (ICons ?dn_iota_within (INil)))))
-        (= ?dn_gathered (Op (Gather ?dn_gather_idx_shape ?dn_gather_idx_stride ?dn_gather_data_shape ?dn_gather_data_stride) (ICons ?dn_add_idx (ICons ?down_w (INil)))))
-        (= ?dn_f32 (Op (Cast ?dn_f32_size (F32)) (ICons ?dn_gathered (INil))))
+        (= ?gather_state (glumoe_expert_gather ?dn_f32))
+        (= ?gather_state (MkGLUMoEExpertGatherState ?dn_io ?dn_iota_within_range ?topk_idx ?down_w))
         (= ?dn_matmul_mul (Op (Mul ?dn_matmul_mul_shape ?dn_matmul_a_stride ?dn_matmul_b_stride ?dn_matmul_mul_out_stride) (ICons ?swiglu_out (ICons ?dn_f32 (INil)))))
         (= ?dn_matmul (Op (Sum ?dn_matmul_out_shape ?dn_matmul_k ?dn_matmul_in_stride ?dn_matmul_k_stride ?dn_matmul_out_stride) (ICons ?dn_matmul_mul (INil))))
     )
@@ -144,12 +168,8 @@
         (= ?gemma_state (glumoe_gemma_gelu ?gemma_out))
         (= ?gemma_state (MkGLUMoEGemmaGELUState ?gate_up_state))
 
-        (= ?dn_iota_base (Op (Iota ?dn_io ?dn_iota_base_range) (INil)))
-        (= ?dn_mul_base (Op (Mul ?dn_mul_base_shape ?dn_mul_base_a_stride ?dn_mul_base_b_stride ?dn_mul_base_out_stride) (ICons ?topk_idx (ICons ?dn_iota_base (INil)))))
-        (= ?dn_iota_within (Op (Iota (MIter) ?dn_iota_within_range) (INil)))
-        (= ?dn_add_idx (Op (Add ?dn_add_shape ?dn_add_a_stride ?dn_add_b_stride ?dn_add_out_stride) (ICons ?dn_mul_base (ICons ?dn_iota_within (INil)))))
-        (= ?dn_gathered (Op (Gather ?dn_gather_idx_shape ?dn_gather_idx_stride ?dn_gather_data_shape ?dn_gather_data_stride) (ICons ?dn_add_idx (ICons ?down_w (INil)))))
-        (= ?dn_f32 (Op (Cast ?dn_f32_size (F32)) (ICons ?dn_gathered (INil))))
+        (= ?gather_state (glumoe_expert_gather ?dn_f32))
+        (= ?gather_state (MkGLUMoEExpertGatherState ?dn_io ?dn_iota_within_range ?topk_idx ?down_w))
         (= ?dn_matmul_mul (Op (Mul ?dn_matmul_mul_shape ?dn_matmul_a_stride ?dn_matmul_b_stride ?dn_matmul_mul_out_stride) (ICons ?gemma_out (ICons ?dn_f32 (INil)))))
         (= ?dn_matmul (Op (Sum ?dn_matmul_out_shape ?dn_matmul_k ?dn_matmul_in_stride ?dn_matmul_k_stride ?dn_matmul_out_stride) (ICons ?dn_matmul_mul (INil))))
     )
@@ -177,6 +197,8 @@
             ?gu_within_range ?dn_within_range (MNum 0))
             (ICons ?x (ICons ?topk_idx (ICons ?topk_vals (ICons ?gate_up_w (ICons ?down_w (ICons ?topk_vals (INil)))))))))
         (union ?output ?glumoe)
+        (subsume (Op (Sum ?output_shape ?output_k ?output_in_stride ?output_k_stride ?output_out_stride) (ICons ?weighted (INil))))
+        (subsume (Op (KernelSum ?output_shape ?output_k ?output_in_stride ?output_k_stride ?output_out_stride (F32)) (ICons ?weighted (INil))))
     )
     :name "GLUMoE fused expert computation (swiglu)"
 )
@@ -208,6 +230,8 @@
             ?gu_within_range ?dn_within_range (MNum 1))
             (ICons ?x (ICons ?topk_idx (ICons ?topk_vals (ICons ?gate_up_w (ICons ?down_w (ICons ?per_expert_scale (INil)))))))))
         (union ?output ?glumoe)
+        (subsume (Op (Sum ?output_shape ?output_k ?output_in_stride ?output_k_stride ?output_out_stride) (ICons ?weighted (INil))))
+        (subsume (Op (KernelSum ?output_shape ?output_k ?output_in_stride ?output_k_stride ?output_out_stride (F32)) (ICons ?weighted (INil))))
     )
     :name "GLUMoE fused expert computation (gemma_gelu)"
 )

--- a/crates/luminal_cuda_lite/src/host/moe/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/moe/mod.rs
@@ -224,8 +224,9 @@ impl EgglogOp for GLUMoE {
     }
 
     fn rewrites(&self) -> Vec<Rule> {
-        vec![Rule::raw(
-            "(rule
+        vec![
+            Rule::raw(
+                "(rule
                 (
                     (= ?e (Op (GLUMoE ?gu_io ?dn_io ?gu_matmul_k ?dn_matmul_k ?output_k ?gu_within_range ?dn_within_range ?mode) ?inputs))
                 )
@@ -234,15 +235,13 @@ impl EgglogOp for GLUMoE {
                 )
                 :ruleset dtype_prop
             )",
-        )]
+            ),
+            Rule::raw(include_str!["glumoe_rewrite.egg"]),
+        ]
     }
 
     fn n_inputs(&self) -> usize {
         6
-    }
-
-    fn early_rewrites(&self) -> Vec<Rule> {
-        vec![Rule::raw(include_str!["glumoe_rewrite.egg"])]
     }
 
     fn extract<'a>(

--- a/crates/luminal_cuda_lite/src/kernel/other_ops.rs
+++ b/crates/luminal_cuda_lite/src/kernel/other_ops.rs
@@ -1611,9 +1611,17 @@ impl EgglogOp for KernelSigmoid {
 
     fn rewrites(&self) -> Vec<Rule> {
         vec![
-            // Match the HLIR pattern directly: Recip(Add(Exp2(Mul(Mul(x, -1), log2e)), 1))
+            // Stage the HLIR sigmoid pattern through a small marker so repeated
+            // default passes do not re-run one large join over every Mul/Add/Recip.
             Rule::raw(
-                "(rule
+                "(datatype*
+                    (KernelSigmoidScaledState
+                        (MkKernelSigmoidScaledState IR EList EList DType)
+                    )
+                )
+                (function kernel_sigmoid_scaled (IR) KernelSigmoidScaledState :merge new)
+
+                (rule
                 (
                     (= ?neg1 (Op (Constant ?nv) (INil)))
                     (< ?nv -0.99)
@@ -1623,13 +1631,25 @@ impl EgglogOp for KernelSigmoid {
                     (> ?lv 1.44)
                     (< ?lv 1.45)
                     (= ?scaled (Op (Mul ?shape ?neg_out_stride ?log2e_stride ?scaled_stride) (ICons ?neg_x (ICons ?log2e (INil)))))
+                    (= ?dt (dtype ?x))
+                )
+                (
+                    (set (kernel_sigmoid_scaled ?scaled)
+                        (MkKernelSigmoidScaledState ?x ?shape ?x_stride ?dt))
+                )
+                :name \"direct-sigmoid-scaled-marker\"
+            )
+
+                (rule
+                (
+                    (= ?scaled_state (kernel_sigmoid_scaled ?scaled))
+                    (= ?scaled_state (MkKernelSigmoidScaledState ?x ?shape ?x_stride ?dt))
                     (= ?exp2 (Op (Exp2 ?shape ?scaled_stride ?exp_stride) (ICons ?scaled (INil))))
                     (= ?one (Op (Constant ?ov) (INil)))
                     (> ?ov 0.99)
                     (< ?ov 1.01)
                     (= ?plus_one (Op (Add ?shape ?exp_stride ?one_stride ?add_stride) (ICons ?exp2 (ICons ?one (INil)))))
                     (= ?sig_out (Op (Recip ?shape ?add_stride ?out_stride) (ICons ?plus_one (INil))))
-                    (= ?dt (dtype ?x))
                 )
                 (
                     (let ?ksig (Op (KernelSigmoid ?shape ?x_stride ?out_stride ?dt) (ICons ?x (INil))))

--- a/src/egglog_utils/base.rs
+++ b/src/egglog_utils/base.rs
@@ -444,7 +444,6 @@ pub fn base_expression_egglog() -> String {
     p.add_ruleset("expr");
     p.add_ruleset("dtype_prop");
     p.add_ruleset("cleanup");
-    p.add_ruleset("early");
 
     // Register all sorts
     s.register(&mut p);

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -13,6 +13,8 @@ pub mod api;
 pub mod base;
 
 const MAIN_SCHEDULE_PASSES: usize = 10;
+const SLOW_PHASE_TIME: Duration = Duration::from_secs(1);
+const BIG_TUPLE_DELTA: isize = 5_000;
 
 #[derive(Debug, Clone)]
 struct EgglogSchedulePhase {
@@ -216,6 +218,7 @@ use crate::{
     shape::Expression,
 };
 use egglog::{ArcSort, CommandOutput, EGraph, Value};
+use egglog_reports::ReportLevel;
 use egraph_serialize::{ClassId, NodeId};
 
 #[derive(Debug)]
@@ -572,12 +575,6 @@ fn trace_stage_report(header: &str, report: &EgglogStageReport) {
     );
 }
 
-fn egglog_metrics_enabled() -> bool {
-    std::env::var("LUMINAL_EGGLOG_METRICS")
-        .map(|value| !matches!(value.as_str(), "0" | "false" | "FALSE" | "off" | "OFF"))
-        .unwrap_or(true)
-}
-
 fn metric_duration(duration: Duration) -> String {
     pretty_duration::pretty_duration(&duration, None)
 }
@@ -591,10 +588,289 @@ fn metric_name(name: &str) -> String {
     name
 }
 
+fn sorted_rule_metrics(report: &egglog_reports::RunReport) -> Vec<(String, Duration, usize)> {
+    let mut rules = report
+        .search_and_apply_time_per_rule
+        .iter()
+        .map(|(rule, elapsed)| {
+            (
+                rule.to_string(),
+                *elapsed,
+                report
+                    .num_matches_per_rule
+                    .get(rule)
+                    .copied()
+                    .unwrap_or_default(),
+            )
+        })
+        .collect_vec();
+    rules.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| b.2.cmp(&a.2)));
+    rules
+}
+
+fn print_rule_plan_hotspots(
+    report: &egglog_reports::RunReport,
+    rules: &[(String, Duration, usize)],
+) {
+    for (rule, _, _) in rules.iter().take(3) {
+        let mut max_stage = None;
+        let mut max_shape = None;
+        for iteration in &report.iterations {
+            if let Some(rule_reports) = iteration.rule_reports().get(rule.as_str()) {
+                for rule_report in rule_reports {
+                    if let Some(plan) = &rule_report.plan {
+                        let scans = plan
+                            .stages
+                            .iter()
+                            .map(|(stage, _, _)| match stage {
+                                egglog_reports::Stage::Intersect { scans } => scans.len(),
+                                egglog_reports::Stage::FusedIntersect { to_intersect, .. } => {
+                                    to_intersect.len() + 1
+                                }
+                            })
+                            .sum::<usize>();
+                        max_shape = Some(
+                            max_shape
+                                .map(|(stages, shape_scans)| {
+                                    if plan.stages.len() > stages {
+                                        (plan.stages.len(), scans)
+                                    } else {
+                                        (stages, shape_scans)
+                                    }
+                                })
+                                .unwrap_or((plan.stages.len(), scans)),
+                        );
+                        for (_, stats, _) in &plan.stages {
+                            if let Some(stats) = stats {
+                                if max_stage
+                                    .map(|(candidates, _)| stats.num_candidates > candidates)
+                                    .unwrap_or(true)
+                                {
+                                    max_stage = Some((stats.num_candidates, stats.num_succeeded));
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if let Some((stages, scans)) = max_shape {
+            eprintln!(
+                "      plan    {:<96} stages {:>2} scans {:>2} | max candidates {}",
+                metric_name(rule),
+                stages,
+                scans,
+                max_stage
+                    .map(|(candidates, succeeded)| format!("{candidates} -> {succeeded}"))
+                    .unwrap_or_else(|| "n/a".to_string())
+            );
+        }
+    }
+}
+
+fn print_slow_phase_detail(
+    phase: &EgglogSchedulePhase,
+    report: &egglog_reports::RunReport,
+    tuple_delta: isize,
+    elapsed: Duration,
+    rules: &[(String, Duration, usize)],
+) {
+    eprintln!("      detail  schedule {}", metric_name(&phase.schedule));
+    if tuple_delta > 0 && elapsed > Duration::ZERO {
+        eprintln!(
+            "      detail  growth {:.0} tuples/s | {:.3} ms/new tuple",
+            tuple_delta as f64 / elapsed.as_secs_f64(),
+            elapsed.as_secs_f64() * 1_000.0 / tuple_delta as f64
+        );
+    }
+    for (rule, elapsed, _) in rules
+        .iter()
+        .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO && *matches == 0)
+        .take(5)
+    {
+        eprintln!(
+            "      zero    {:<96} {:>10}",
+            metric_name(rule),
+            metric_duration(*elapsed)
+        );
+    }
+    let mut per_match = rules
+        .iter()
+        .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO && *matches > 0)
+        .map(|(rule, elapsed, matches)| {
+            (
+                rule,
+                elapsed.as_secs_f64() * 1_000.0 / *matches as f64,
+                *matches,
+            )
+        })
+        .collect_vec();
+    per_match.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    for (rule, ms_per_match, matches) in per_match.into_iter().take(3) {
+        eprintln!(
+            "      cost    {:<96} {:.3} ms/match | matches {}",
+            metric_name(rule),
+            ms_per_match,
+            matches
+        );
+    }
+    print_rule_plan_hotspots(report, rules);
+
+    let iteration_count = report.iterations.len();
+    for (index, iteration) in report.iterations.iter().enumerate() {
+        if iteration_count > 12 && (8..iteration_count.saturating_sub(3)).contains(&index) {
+            if index == 8 {
+                eprintln!("      iter   ...");
+            }
+            continue;
+        }
+        let (rule, elapsed, matches) = iteration
+            .rule_reports()
+            .iter()
+            .map(|(rule, reports)| {
+                (
+                    rule.to_string(),
+                    reports
+                        .iter()
+                        .map(|report| report.search_and_apply_time)
+                        .sum::<Duration>(),
+                    reports
+                        .iter()
+                        .map(|report| report.num_matches)
+                        .sum::<usize>(),
+                )
+            })
+            .max_by(|a, b| a.1.cmp(&b.1).then_with(|| a.2.cmp(&b.2)))
+            .unwrap_or_else(|| ("-".to_string(), Duration::ZERO, 0));
+        eprintln!(
+            "      iter   {:>2} changed={} | search {:>10} | merge {:>10} | rebuild {:>10} | top {:<64} {:>10} matches {}",
+            index + 1,
+            iteration.changed(),
+            metric_duration(iteration.search_and_apply_time()),
+            metric_duration(iteration.rule_set_report.merge_time),
+            metric_duration(iteration.rebuild_time),
+            metric_name(&rule),
+            metric_duration(elapsed),
+            matches
+        );
+    }
+}
+
+fn print_run_summary(run_report: &EgglogRunReport) {
+    eprintln!(
+        "{}",
+        format!(
+            "   Egglog summary total {} | phases {}",
+            metric_duration(run_report.total_time),
+            run_report.phases.len()
+        )
+        .cyan()
+    );
+    let mut phases = run_report.phases.iter().collect_vec();
+    phases.sort_by_key(|phase| std::cmp::Reverse(phase.total_time));
+    for phase in phases.into_iter().take(5) {
+        eprintln!(
+            "      phase   {:<28} {:>10} | tuples {:+} | iterations {}",
+            metric_name(&phase.name),
+            metric_duration(phase.total_time),
+            phase.tuples_after as isize - phase.tuples_before as isize,
+            phase.iterations
+        );
+    }
+    let mut growth = run_report
+        .phases
+        .iter()
+        .map(|phase| {
+            (
+                phase,
+                phase.tuples_after as isize - phase.tuples_before as isize,
+            )
+        })
+        .filter(|(_, delta)| *delta > 0)
+        .collect_vec();
+    growth.sort_by_key(|(_, delta)| std::cmp::Reverse(*delta));
+    for (phase, delta) in growth.into_iter().take(3) {
+        eprintln!(
+            "      growth  {:<28} tuples {:+} | {}",
+            metric_name(&phase.name),
+            delta,
+            metric_duration(phase.total_time)
+        );
+    }
+    let mut rules = run_report
+        .full
+        .search_and_apply_time_per_rule
+        .iter()
+        .map(|(rule, elapsed)| {
+            (
+                rule,
+                *elapsed,
+                run_report
+                    .full
+                    .num_matches_per_rule
+                    .get(rule)
+                    .copied()
+                    .unwrap_or_default(),
+            )
+        })
+        .collect_vec();
+    rules.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| b.2.cmp(&a.2)));
+    for (rule, elapsed, matches) in rules
+        .iter()
+        .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO || *matches > 0)
+        .take(8)
+    {
+        eprintln!(
+            "      slow    {:<96} {:>10} | matches {}",
+            metric_name(rule),
+            metric_duration(*elapsed),
+            matches
+        );
+    }
+    for (rule, elapsed, _) in rules
+        .iter()
+        .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO && *matches == 0)
+        .take(8)
+    {
+        eprintln!(
+            "      zero    {:<96} {:>10}",
+            metric_name(rule),
+            metric_duration(*elapsed)
+        );
+    }
+}
+
+fn print_serialized_shape(s: &egglog::SerializeOutput) {
+    let mut classes = FxHashSet::default();
+    let mut labels: FxHashMap<String, usize> = FxHashMap::default();
+    let mut nodes = 0;
+    for node in s.egraph.nodes.values().filter(|node| !node.subsumed) {
+        nodes += 1;
+        classes.insert(node.eclass.clone());
+        *labels.entry(node.op.clone()).or_default() += 1;
+    }
+    let mut labels = labels.into_iter().collect_vec();
+    labels.sort_by_key(|(_, count)| std::cmp::Reverse(*count));
+    eprintln!(
+        "{}",
+        format!(
+            "   Egglog extract root shape nodes={} classes={} roots={} top_ops={}",
+            nodes,
+            classes.len(),
+            s.egraph.root_eclasses.len(),
+            labels
+                .into_iter()
+                .take(8)
+                .map(|(label, count)| format!("{}={}", metric_name(&label), count))
+                .join(", ")
+        )
+        .cyan()
+    );
+}
+
 fn run_schedule_phase(
     egraph: &mut egglog::EGraph,
     phases: &mut Vec<EgglogPhaseReport>,
-    metrics: bool,
     phase: &EgglogSchedulePhase,
 ) -> Result<bool, egglog::Error> {
     let command = format!("(run-schedule {})", phase.schedule);
@@ -614,99 +890,88 @@ fn run_schedule_phase(
 
     let updated = report.updated;
     let iterations = report.iterations.len();
-    if metrics {
-        let tuple_delta = tuples_after as isize - tuples_before as isize;
-        eprintln!(
-            "{}",
-            format!(
-                "   Egglog {:<28} {:>10} | tuples {} -> {} ({:+}) | updated={} | iterations={}",
-                phase.name,
-                metric_duration(elapsed),
-                tuples_before,
-                tuples_after,
-                tuple_delta,
-                updated,
-                iterations,
-            )
-            .cyan()
-        );
+    let tuple_delta = tuples_after as isize - tuples_before as isize;
+    eprintln!(
+        "{}",
+        format!(
+            "   Egglog {:<28} {:>10} | tuples {} -> {} ({:+}) | updated={} | iterations={}",
+            phase.name,
+            metric_duration(elapsed),
+            tuples_before,
+            tuples_after,
+            tuple_delta,
+            updated,
+            iterations,
+        )
+        .cyan()
+    );
 
-        let mut rulesets = report
+    let mut rulesets = report
+        .search_and_apply_time_per_ruleset
+        .keys()
+        .chain(report.merge_time_per_ruleset.keys())
+        .chain(report.rebuild_time_per_ruleset.keys())
+        .map(|ruleset| ruleset.to_string())
+        .unique()
+        .collect_vec();
+    let ruleset_total = |ruleset: &str| {
+        report
             .search_and_apply_time_per_ruleset
-            .keys()
-            .chain(report.merge_time_per_ruleset.keys())
-            .chain(report.rebuild_time_per_ruleset.keys())
-            .map(|ruleset| ruleset.to_string())
-            .unique()
-            .collect_vec();
-        let ruleset_total = |ruleset: &str| {
-            report
-                .search_and_apply_time_per_ruleset
+            .get(ruleset)
+            .copied()
+            .unwrap_or(Duration::ZERO)
+            + report
+                .merge_time_per_ruleset
                 .get(ruleset)
                 .copied()
                 .unwrap_or(Duration::ZERO)
-                + report
-                    .merge_time_per_ruleset
-                    .get(ruleset)
-                    .copied()
-                    .unwrap_or(Duration::ZERO)
-                + report
-                    .rebuild_time_per_ruleset
-                    .get(ruleset)
-                    .copied()
-                    .unwrap_or(Duration::ZERO)
-        };
-        rulesets.sort_by_key(|ruleset| std::cmp::Reverse(ruleset_total(ruleset)));
-        for ruleset in rulesets.into_iter().take(4) {
-            let search = report
-                .search_and_apply_time_per_ruleset
-                .get(ruleset.as_str())
-                .copied()
-                .unwrap_or(Duration::ZERO);
-            let merge = report
-                .merge_time_per_ruleset
-                .get(ruleset.as_str())
-                .copied()
-                .unwrap_or(Duration::ZERO);
-            let rebuild = report
+            + report
                 .rebuild_time_per_ruleset
-                .get(ruleset.as_str())
+                .get(ruleset)
                 .copied()
-                .unwrap_or(Duration::ZERO);
-            eprintln!(
-                "      ruleset {:<18} search {:>10} | merge {:>10} | rebuild {:>10}",
-                metric_name(&ruleset),
-                metric_duration(search),
-                metric_duration(merge),
-                metric_duration(rebuild)
-            );
-        }
+                .unwrap_or(Duration::ZERO)
+    };
+    rulesets.sort_by_key(|ruleset| std::cmp::Reverse(ruleset_total(ruleset)));
+    for ruleset in rulesets.into_iter().take(4) {
+        let search = report
+            .search_and_apply_time_per_ruleset
+            .get(ruleset.as_str())
+            .copied()
+            .unwrap_or(Duration::ZERO);
+        let merge = report
+            .merge_time_per_ruleset
+            .get(ruleset.as_str())
+            .copied()
+            .unwrap_or(Duration::ZERO);
+        let rebuild = report
+            .rebuild_time_per_ruleset
+            .get(ruleset.as_str())
+            .copied()
+            .unwrap_or(Duration::ZERO);
+        eprintln!(
+            "      ruleset {:<18} search {:>10} | merge {:>10} | rebuild {:>10}",
+            metric_name(&ruleset),
+            metric_duration(search),
+            metric_duration(merge),
+            metric_duration(rebuild)
+        );
+    }
 
-        let mut rules = report
-            .search_and_apply_time_per_rule
-            .iter()
-            .map(|(rule, elapsed)| {
-                let matches = report
-                    .num_matches_per_rule
-                    .get(rule)
-                    .copied()
-                    .unwrap_or_default();
-                (rule.to_string(), *elapsed, matches)
-            })
-            .collect_vec();
-        rules.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| b.2.cmp(&a.2)));
-        for (rule, elapsed, matches) in rules
-            .into_iter()
-            .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO || *matches > 0)
-            .take(5)
-        {
-            eprintln!(
-                "      rule    {:<96} {:>10} | matches {}",
-                metric_name(&rule),
-                metric_duration(elapsed),
-                matches
-            );
-        }
+    let rules = sorted_rule_metrics(&report);
+    for (rule, elapsed, matches) in rules
+        .iter()
+        .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO || *matches > 0)
+        .take(5)
+    {
+        eprintln!(
+            "      rule    {:<96} {:>10} | matches {}",
+            metric_name(rule),
+            metric_duration(*elapsed),
+            matches
+        );
+    }
+    if elapsed >= SLOW_PHASE_TIME || tuple_delta.abs() >= BIG_TUPLE_DELTA {
+        print_slow_phase_detail(phase, &report, tuple_delta, elapsed, &rules);
     }
 
     phases.push(EgglogPhaseReport {
@@ -746,43 +1011,53 @@ pub fn run_egglog_with_report_parts(
     let total_start = std::time::Instant::now();
 
     let full_start = std::time::Instant::now();
+    let setup_text_start = std::time::Instant::now();
     let setup_code = egglog_setup_with(program, op_parts);
+    let setup_text_elapsed = setup_text_start.elapsed();
+    let setup_lines = setup_code.lines().count();
     let mut egraph = egglog::EGraph::default();
+    egraph.set_report_level(ReportLevel::WithPlan);
     let setup_start = std::time::Instant::now();
     let setup_tuples_before = egraph.num_tuples();
+    let parse_start = std::time::Instant::now();
     let commands = egraph.parser.get_program_from_string(None, &setup_code)?;
+    let parse_elapsed = parse_start.elapsed();
     trace!("{}", "Egglog setup running...".green());
+    let setup_run_start = std::time::Instant::now();
     let _outputs = egraph.run_program(commands)?;
-    let metrics = egglog_metrics_enabled();
-    if metrics {
-        let setup_tuples_after = egraph.num_tuples();
-        eprintln!(
-            "{}",
-            format!(
-                "   Egglog {:<28} {:>10} | tuples {} -> {} ({:+})",
-                "setup",
-                metric_duration(setup_start.elapsed()),
-                setup_tuples_before,
-                setup_tuples_after,
-                setup_tuples_after as isize - setup_tuples_before as isize,
-            )
-            .cyan()
-        );
-    }
+    let setup_run_elapsed = setup_run_start.elapsed();
+    let setup_tuples_after = egraph.num_tuples();
+    eprintln!(
+        "{}",
+        format!(
+            "   Egglog {:<28} {:>10} | text {} parse {} run {} | lines {} bytes {} | tuples {} -> {} ({:+})",
+            "setup",
+            metric_duration(setup_start.elapsed()),
+            metric_duration(setup_text_elapsed),
+            metric_duration(parse_elapsed),
+            metric_duration(setup_run_elapsed),
+            setup_lines,
+            setup_code.len(),
+            setup_tuples_before,
+            setup_tuples_after,
+            setup_tuples_after as isize - setup_tuples_before as isize,
+        )
+        .cyan()
+    );
 
     trace!("{}", "Egglog running...".green());
     let mut phases = Vec::new();
     for pass in 1..=MAIN_SCHEDULE_PASSES {
         let mut pass_updated = false;
         for phase in egglog_main_pass_phases(pass) {
-            pass_updated |= run_schedule_phase(&mut egraph, &mut phases, metrics, &phase)?;
+            pass_updated |= run_schedule_phase(&mut egraph, &mut phases, &phase)?;
         }
         if !pass_updated {
             break;
         }
     }
     for phase in egglog_final_phases() {
-        run_schedule_phase(&mut egraph, &mut phases, metrics, &phase)?;
+        run_schedule_phase(&mut egraph, &mut phases, &phase)?;
     }
     let full_report = stage_report(&egraph, full_start.elapsed());
     trace_stage_report("---- Egglog Rule Matches ----", &full_report);
@@ -792,6 +1067,7 @@ pub fn run_egglog_with_report_parts(
         phases,
         total_time: total_start.elapsed(),
     };
+    print_run_summary(&run_report);
     trace!(
         "{}",
         format!(
@@ -808,6 +1084,7 @@ pub fn run_egglog_with_report_parts(
         include_temporary_functions: false,
         max_calls_per_function: None,
     });
+    print_serialized_shape(&s);
     // Convert to SerializedEGraph
     let mut classes = FxHashMap::default();
     for (node_id, node) in s.egraph.nodes.iter().filter(|(_, node)| !node.subsumed) {

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -12,16 +12,13 @@ use tracing::trace;
 pub mod api;
 pub mod base;
 
-pub const RUN_SCHEDULE: &str = "(run-schedule
-    (repeat 10
-        (saturate expr)
-        (saturate dtype_prop)
-        (run)
-    )
-    (saturate expr)
-    (saturate cleanup)
-    (saturate base_cleanup)
-)";
+const MAIN_SCHEDULE_PASSES: usize = 10;
+
+#[derive(Debug, Clone)]
+struct EgglogSchedulePhase {
+    name: String,
+    schedule: String,
+}
 
 fn op_defs_string(ops: &[Arc<Box<dyn EgglogOp>>]) -> String {
     // Partition ops by sort class: IR-class (Input, Output) vs OpKind-class (everything else)
@@ -106,31 +103,19 @@ fn op_cleanups_string(ops: &[Arc<Box<dyn EgglogOp>>]) -> String {
     )
 }
 
-pub fn early_egglog(
-    program: &str,
-    root: &str,
-    ops: &[Arc<Box<dyn EgglogOp>>],
-    cleanup: bool,
-) -> String {
-    let parts = OpTextParts::new(ops, cleanup);
-    early_egglog_with(program, root, &parts)
-}
-
 pub fn full_egglog(program: &str, ops: &[Arc<Box<dyn EgglogOp>>], cleanup: bool) -> String {
     let parts = OpTextParts::new(ops, cleanup);
     full_egglog_with(program, &parts)
 }
 
-/// Pre-computed per-op text fragments. `run_egglog` calls early + full back
-/// to back with identical `ops`; materialising all op-derived strings once
-/// up front means callers that want to drive multiple egglog runs in parallel
-/// only need to share `&str` references and never touch the non-Send trait
-/// objects in `ops`.
+/// Pre-computed per-op text fragments. Materialising all op-derived strings
+/// once up front means callers that want to drive multiple egglog runs in
+/// parallel only need to share `&str` references and never touch the non-Send
+/// trait objects in `ops`.
 pub struct OpTextParts {
     op_defs: String,
     cleanups: String,
-    early_rewrites: String,
-    full_rewrites: String,
+    rewrites: String,
 }
 
 impl OpTextParts {
@@ -142,12 +127,7 @@ impl OpTextParts {
             } else {
                 String::new()
             },
-            early_rewrites: ops
-                .iter()
-                .flat_map(|o| o.early_rewrites())
-                .map(|r| r.to_egglog_string())
-                .join("\n"),
-            full_rewrites: ops
+            rewrites: ops
                 .iter()
                 .flat_map(|o| o.rewrites())
                 .map(|r| r.to_egglog_string())
@@ -156,37 +136,74 @@ impl OpTextParts {
     }
 }
 
-fn early_egglog_with(program: &str, root: &str, parts: &OpTextParts) -> String {
-    [
-        base::base_expression_egglog(),
-        parts.op_defs.clone(),
-        parts.early_rewrites.clone(),
-        parts.cleanups.clone(),
-        base::base_cleanup_egglog(),
-        program.to_string(),
-        format!(
-            "(run-schedule
-                (repeat 6
-                    (saturate expr)
-                    (run)
-                )
-                (saturate base_cleanup)
-            )
-            (extract {root})"
-        ),
-    ]
-    .join("\n")
+fn full_egglog_with(program: &str, parts: &OpTextParts) -> String {
+    [egglog_setup_with(program, parts), egglog_schedule_program()].join("\n")
 }
 
-fn full_egglog_with(program: &str, parts: &OpTextParts) -> String {
+fn egglog_main_pass_phases(pass: usize) -> Vec<EgglogSchedulePhase> {
+    vec![
+        EgglogSchedulePhase {
+            name: format!("main {pass:02} expr"),
+            schedule: "(saturate expr)".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: format!("main {pass:02} dtype"),
+            schedule: "(saturate dtype_prop)".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: format!("main {pass:02} default"),
+            schedule: "(run)".to_string(),
+        },
+    ]
+}
+
+fn egglog_final_phases() -> Vec<EgglogSchedulePhase> {
+    vec![
+        EgglogSchedulePhase {
+            name: "final expr".to_string(),
+            schedule: "(saturate expr)".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "cleanup".to_string(),
+            schedule: "(saturate cleanup)".to_string(),
+        },
+        EgglogSchedulePhase {
+            name: "base cleanup".to_string(),
+            schedule: "(saturate base_cleanup)".to_string(),
+        },
+    ]
+}
+
+fn egglog_main_pass_schedule() -> String {
+    "(seq
+        (saturate expr)
+        (saturate dtype_prop)
+        (run)
+    )"
+    .to_string()
+}
+
+fn egglog_schedule_program() -> String {
+    let mut schedules = vec![format!(
+        "(run-schedule (repeat {MAIN_SCHEDULE_PASSES} {}))",
+        egglog_main_pass_schedule()
+    )];
+    schedules.extend(
+        egglog_final_phases()
+            .into_iter()
+            .map(|phase| format!("(run-schedule {})", phase.schedule)),
+    );
+    schedules.join("\n")
+}
+
+fn egglog_setup_with(program: &str, parts: &OpTextParts) -> String {
     [
         base::base_expression_egglog(),
         parts.op_defs.clone(),
         parts.cleanups.clone(),
         base::base_cleanup_egglog(),
-        parts.full_rewrites.clone(),
+        parts.rewrites.clone(),
         program.to_string(),
-        RUN_SCHEDULE.to_string(),
     ]
     .join("\n")
 }
@@ -220,8 +237,19 @@ pub struct EgglogStageReport {
 
 #[derive(Debug, Clone, Default)]
 pub struct EgglogRunReport {
-    pub early: EgglogStageReport,
     pub full: EgglogStageReport,
+    pub phases: Vec<EgglogPhaseReport>,
+    pub total_time: Duration,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct EgglogPhaseReport {
+    pub name: String,
+    pub schedule: String,
+    pub updated: bool,
+    pub iterations: usize,
+    pub tuples_before: usize,
+    pub tuples_after: usize,
     pub total_time: Duration,
 }
 
@@ -238,7 +266,7 @@ impl SerializedEGraph {
         });
         // Convert to SerializedEGraph
         let mut classes = FxHashMap::default();
-        for (node_id, node) in &s.egraph.nodes {
+        for (node_id, node) in s.egraph.nodes.iter().filter(|(_, node)| !node.subsumed) {
             classes
                 .entry(node.eclass.clone())
                 .or_insert(vec![])
@@ -250,12 +278,14 @@ impl SerializedEGraph {
                 .egraph
                 .nodes
                 .iter()
+                .filter(|(_, enode)| !enode.subsumed)
                 .map(|(n, enode)| (n.clone(), enode.eclass.clone()))
                 .collect(),
             enodes: s
                 .egraph
                 .nodes
                 .iter()
+                .filter(|(_, enode)| !enode.subsumed)
                 .map(|(n, enode)| {
                     (
                         n.clone(),
@@ -274,7 +304,11 @@ impl SerializedEGraph {
                 .egraph
                 .class_data
                 .iter()
-                .map(|(c, eclass)| (c.clone(), (eclass.typ.clone().unwrap(), classes[c].clone())))
+                .filter_map(|(c, eclass)| {
+                    classes
+                        .get(c)
+                        .map(|nodes| (c.clone(), (eclass.typ.clone().unwrap(), nodes.clone())))
+                })
                 .collect(),
         };
         // Strip out all [...] enodes
@@ -283,10 +317,9 @@ impl SerializedEGraph {
             let mut to_remove = vec![];
             for (id, (_, children)) in &s_egraph.enodes {
                 if children.iter().any(|c| {
-                    !s_egraph.eclasses[c]
-                        .1
-                        .iter()
-                        .any(|n| s_egraph.enodes.contains_key(n))
+                    s_egraph.eclasses.get(c).is_none_or(|(_, nodes)| {
+                        !nodes.iter().any(|n| s_egraph.enodes.contains_key(n))
+                    })
                 }) {
                     to_remove.push(id.clone());
                 }
@@ -496,22 +529,6 @@ pub fn list_to_egglog(list: &[impl ToString], cons: &str, nil: &str) -> String {
     }
 }
 
-fn termdag_to_egglog(td: &egglog::TermDag, root: egglog::TermId) -> (String, String) {
-    let mut out = String::new();
-    for id in 0..td.size() {
-        let code = match td.get(id) {
-            egglog::Term::Lit(lit) => format!("{lit}"),
-            egglog::Term::Var(v) => v.clone(),
-            egglog::Term::App(head, args) => format!(
-                "({head} {})",
-                args.iter().map(|s| format!("t{s}")).join(" ")
-            ),
-        };
-        out.push_str(&format!("(let t{id} {code})\n"));
-    }
-    (out.replace("(MVar \"z\")", "(MIter)"), format!("t{root}"))
-}
-
 fn stage_report(egraph: &egglog::EGraph, total_time: Duration) -> EgglogStageReport {
     let run_report = egraph.get_overall_run_report();
     EgglogStageReport {
@@ -555,6 +572,156 @@ fn trace_stage_report(header: &str, report: &EgglogStageReport) {
     );
 }
 
+fn egglog_metrics_enabled() -> bool {
+    std::env::var("LUMINAL_EGGLOG_METRICS")
+        .map(|value| !matches!(value.as_str(), "0" | "false" | "FALSE" | "off" | "OFF"))
+        .unwrap_or(true)
+}
+
+fn metric_duration(duration: Duration) -> String {
+    pretty_duration::pretty_duration(&duration, None)
+}
+
+fn metric_name(name: &str) -> String {
+    let mut name = name.split_whitespace().join(" ");
+    if name.len() > 96 {
+        name.truncate(93);
+        name.push_str("...");
+    }
+    name
+}
+
+fn run_schedule_phase(
+    egraph: &mut egglog::EGraph,
+    phases: &mut Vec<EgglogPhaseReport>,
+    metrics: bool,
+    phase: &EgglogSchedulePhase,
+) -> Result<bool, egglog::Error> {
+    let command = format!("(run-schedule {})", phase.schedule);
+    let tuples_before = egraph.num_tuples();
+    let start = std::time::Instant::now();
+    let outputs = egraph.parse_and_run_program(None, &command)?;
+    let elapsed = start.elapsed();
+    let tuples_after = egraph.num_tuples();
+
+    let report = outputs
+        .into_iter()
+        .find_map(|output| match output {
+            CommandOutput::RunSchedule(report) => Some(report),
+            _ => None,
+        })
+        .expect("run-schedule did not return a report");
+
+    let updated = report.updated;
+    let iterations = report.iterations.len();
+    if metrics {
+        let tuple_delta = tuples_after as isize - tuples_before as isize;
+        eprintln!(
+            "{}",
+            format!(
+                "   Egglog {:<28} {:>10} | tuples {} -> {} ({:+}) | updated={} | iterations={}",
+                phase.name,
+                metric_duration(elapsed),
+                tuples_before,
+                tuples_after,
+                tuple_delta,
+                updated,
+                iterations,
+            )
+            .cyan()
+        );
+
+        let mut rulesets = report
+            .search_and_apply_time_per_ruleset
+            .keys()
+            .chain(report.merge_time_per_ruleset.keys())
+            .chain(report.rebuild_time_per_ruleset.keys())
+            .map(|ruleset| ruleset.to_string())
+            .unique()
+            .collect_vec();
+        let ruleset_total = |ruleset: &str| {
+            report
+                .search_and_apply_time_per_ruleset
+                .get(ruleset)
+                .copied()
+                .unwrap_or(Duration::ZERO)
+                + report
+                    .merge_time_per_ruleset
+                    .get(ruleset)
+                    .copied()
+                    .unwrap_or(Duration::ZERO)
+                + report
+                    .rebuild_time_per_ruleset
+                    .get(ruleset)
+                    .copied()
+                    .unwrap_or(Duration::ZERO)
+        };
+        rulesets.sort_by_key(|ruleset| std::cmp::Reverse(ruleset_total(ruleset)));
+        for ruleset in rulesets.into_iter().take(4) {
+            let search = report
+                .search_and_apply_time_per_ruleset
+                .get(ruleset.as_str())
+                .copied()
+                .unwrap_or(Duration::ZERO);
+            let merge = report
+                .merge_time_per_ruleset
+                .get(ruleset.as_str())
+                .copied()
+                .unwrap_or(Duration::ZERO);
+            let rebuild = report
+                .rebuild_time_per_ruleset
+                .get(ruleset.as_str())
+                .copied()
+                .unwrap_or(Duration::ZERO);
+            eprintln!(
+                "      ruleset {:<18} search {:>10} | merge {:>10} | rebuild {:>10}",
+                metric_name(&ruleset),
+                metric_duration(search),
+                metric_duration(merge),
+                metric_duration(rebuild)
+            );
+        }
+
+        let mut rules = report
+            .search_and_apply_time_per_rule
+            .iter()
+            .map(|(rule, elapsed)| {
+                let matches = report
+                    .num_matches_per_rule
+                    .get(rule)
+                    .copied()
+                    .unwrap_or_default();
+                (rule.to_string(), *elapsed, matches)
+            })
+            .collect_vec();
+        rules.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| b.2.cmp(&a.2)));
+        for (rule, elapsed, matches) in rules
+            .into_iter()
+            .filter(|(_, elapsed, matches)| *elapsed > Duration::ZERO || *matches > 0)
+            .take(5)
+        {
+            eprintln!(
+                "      rule    {:<96} {:>10} | matches {}",
+                metric_name(&rule),
+                metric_duration(elapsed),
+                matches
+            );
+        }
+    }
+
+    phases.push(EgglogPhaseReport {
+        name: phase.name.clone(),
+        schedule: phase.schedule.clone(),
+        updated,
+        iterations,
+        tuples_before,
+        tuples_after,
+        total_time: elapsed,
+    });
+
+    Ok(updated)
+}
+
 #[tracing::instrument(skip_all)]
 pub fn run_egglog_with_report(
     program: &str,
@@ -578,31 +745,51 @@ pub fn run_egglog_with_report_parts(
 ) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
     let total_start = std::time::Instant::now();
 
-    let early_start = std::time::Instant::now();
-    let code = early_egglog_with(program, root, op_parts);
-    let mut egraph = egglog::EGraph::default();
-    let commands = egraph.parser.get_program_from_string(None, &code)?;
-    let outputs = egraph.run_program(commands)?;
-    let early_report = stage_report(&egraph, early_start.elapsed());
-
-    let CommandOutput::ExtractBest(termdag, _cost, term) = outputs.last().unwrap() else {
-        panic!();
-    };
-    let (program, root) = termdag_to_egglog(termdag, termdag.lookup(term));
-
     let full_start = std::time::Instant::now();
-    let code = full_egglog_with(&program, op_parts);
+    let setup_code = egglog_setup_with(program, op_parts);
     let mut egraph = egglog::EGraph::default();
-    let commands = egraph.parser.get_program_from_string(None, &code)?;
-    trace!("{}", "Egglog running...".green());
+    let setup_start = std::time::Instant::now();
+    let setup_tuples_before = egraph.num_tuples();
+    let commands = egraph.parser.get_program_from_string(None, &setup_code)?;
+    trace!("{}", "Egglog setup running...".green());
     let _outputs = egraph.run_program(commands)?;
+    let metrics = egglog_metrics_enabled();
+    if metrics {
+        let setup_tuples_after = egraph.num_tuples();
+        eprintln!(
+            "{}",
+            format!(
+                "   Egglog {:<28} {:>10} | tuples {} -> {} ({:+})",
+                "setup",
+                metric_duration(setup_start.elapsed()),
+                setup_tuples_before,
+                setup_tuples_after,
+                setup_tuples_after as isize - setup_tuples_before as isize,
+            )
+            .cyan()
+        );
+    }
+
+    trace!("{}", "Egglog running...".green());
+    let mut phases = Vec::new();
+    for pass in 1..=MAIN_SCHEDULE_PASSES {
+        let mut pass_updated = false;
+        for phase in egglog_main_pass_phases(pass) {
+            pass_updated |= run_schedule_phase(&mut egraph, &mut phases, metrics, &phase)?;
+        }
+        if !pass_updated {
+            break;
+        }
+    }
+    for phase in egglog_final_phases() {
+        run_schedule_phase(&mut egraph, &mut phases, metrics, &phase)?;
+    }
     let full_report = stage_report(&egraph, full_start.elapsed());
-    trace_stage_report("---- Egglog Early Rule Matches ----", &early_report);
-    trace_stage_report("---- Egglog Full Rule Matches ----", &full_report);
+    trace_stage_report("---- Egglog Rule Matches ----", &full_report);
 
     let run_report = EgglogRunReport {
-        early: early_report,
         full: full_report,
+        phases,
         total_time: total_start.elapsed(),
     };
     trace!(
@@ -623,7 +810,7 @@ pub fn run_egglog_with_report_parts(
     });
     // Convert to SerializedEGraph
     let mut classes = FxHashMap::default();
-    for (node_id, node) in &s.egraph.nodes {
+    for (node_id, node) in s.egraph.nodes.iter().filter(|(_, node)| !node.subsumed) {
         classes
             .entry(node.eclass.clone())
             .or_insert(vec![])
@@ -635,12 +822,14 @@ pub fn run_egglog_with_report_parts(
             .egraph
             .nodes
             .iter()
+            .filter(|(_, enode)| !enode.subsumed)
             .map(|(n, enode)| (n.clone(), enode.eclass.clone()))
             .collect(),
         enodes: s
             .egraph
             .nodes
             .iter()
+            .filter(|(_, enode)| !enode.subsumed)
             .map(|(n, enode)| {
                 (
                     n.clone(),
@@ -659,7 +848,11 @@ pub fn run_egglog_with_report_parts(
             .egraph
             .class_data
             .iter()
-            .map(|(c, eclass)| (c.clone(), (eclass.typ.clone().unwrap(), classes[c].clone())))
+            .filter_map(|(c, eclass)| {
+                classes
+                    .get(c)
+                    .map(|nodes| (c.clone(), (eclass.typ.clone().unwrap(), nodes.clone())))
+            })
             .collect(),
     };
     // Strip out all [...] enodes
@@ -670,10 +863,10 @@ pub fn run_egglog_with_report_parts(
         let mut to_remove = vec![];
         for (id, (_, children)) in &egraph.enodes {
             if children.iter().any(|c| {
-                !egraph.eclasses[c]
-                    .1
-                    .iter()
-                    .any(|n| egraph.enodes.contains_key(n))
+                egraph
+                    .eclasses
+                    .get(c)
+                    .is_none_or(|(_, nodes)| !nodes.iter().any(|n| egraph.enodes.contains_key(n)))
             }) {
                 to_remove.push(id.clone());
             }

--- a/src/hlir.rs
+++ b/src/hlir.rs
@@ -128,11 +128,9 @@ pub fn binary_sort(name: &str) -> SortDef {
 /// a tiny chain blocks the fusion entirely and the extracted graph is
 /// strictly worse than not rolling.
 ///
-/// **Register in both `EgglogOp::early_rewrites()` AND `rewrites()`.** The
-/// driver feeds `early_rewrites` into the early-stage program only and
-/// `rewrites` into the full-stage program only; we need the unrolled chain
-/// visible in both stages so early-stage fusion patterns (GLUMoE) AND
-/// full-stage kernel rewrites (`direct-exp-fusion`) can both match it.
+/// Register these in `EgglogOp::rewrites()`. The driver feeds this normal
+/// rewrite set into the single egglog run, so the unrolled chain is visible to
+/// fusion patterns (GLUMoE) and kernel rewrites (`direct-exp-fusion`).
 ///
 /// Generates 2 rules per iter count (state at body input position 0 vs 1)
 /// for every `n_iters` in `2..=max_trips`. Larger trips stay rolled-only —
@@ -652,23 +650,21 @@ impl EgglogOp for LoopInput {
     }
 
     fn rewrites(&self) -> Vec<Rule> {
-        vec![dtype_from_kind_field(&self.sort(), "dtype")]
-    }
-
-    fn early_rewrites(&self) -> Vec<Rule> {
         // Declare the `identical_inputs` relation and the three-way unification
         // chain between `LoopInput`, `LoopInputStatic`, and an inlined source.
-        // Running in Stage 1 alongside fusion rules (e.g. GLUMoE) so that
-        // fusion patterns that expect raw op kinds at boundary positions can
-        // match via the unioned eclass.
-        vec![Rule::raw(
-            r#"
+        // Running alongside fusion rules (e.g. GLUMoE) so that fusion patterns
+        // that expect raw op kinds at boundary positions can match via the
+        // unioned eclass.
+        vec![
+            dtype_from_kind_field(&self.sort(), "dtype"),
+            Rule::raw(
+                r#"
             (relation identical_inputs (IList))
 
-            ; All four rules live in the `expr` ruleset, which the early/full
-            ; schedules saturate each iteration. Default-ruleset scheduling
-            ; only runs each rule once per outer step, which is not enough to
-            ; propagate `identical_inputs` through an N-element IList.
+            ; All four rules live in the `expr` ruleset, which the schedule
+            ; saturates each iteration. Default-ruleset scheduling only runs
+            ; each rule once per outer step, which is not enough to propagate
+            ; `identical_inputs` through an N-element IList.
 
             ; Base: single-element list is trivially identical.
             (rule ((= ?l (ICons ?x (INil))))
@@ -698,7 +694,8 @@ impl EgglogOp for LoopInput {
                   :ruleset expr
                   :name "LoopInputStatic inline")
             "#,
-        )]
+            ),
+        ]
     }
 
     fn extract<'a>(
@@ -1679,11 +1676,8 @@ impl EgglogOp for Add {
     }
     fn rewrites(&self) -> Vec<Rule> {
         let mut r = vec![dtype_propagation_op(&self.sort())];
-        r.extend(self.early_rewrites());
+        r.extend(binary_op_unroll_rules("Add", 4));
         r
-    }
-    fn early_rewrites(&self) -> Vec<Rule> {
-        binary_op_unroll_rules("Add", 4)
     }
     fn extract<'a>(
         &'a self,
@@ -1769,11 +1763,8 @@ impl EgglogOp for Mul {
     }
     fn rewrites(&self) -> Vec<Rule> {
         let mut r = vec![dtype_propagation_op(&self.sort())];
-        r.extend(self.early_rewrites());
+        r.extend(binary_op_unroll_rules("Mul", 4));
         r
-    }
-    fn early_rewrites(&self) -> Vec<Rule> {
-        binary_op_unroll_rules("Mul", 4)
     }
     fn extract<'a>(
         &'a self,
@@ -1859,11 +1850,8 @@ impl EgglogOp for Mod {
     }
     fn rewrites(&self) -> Vec<Rule> {
         let mut r = vec![dtype_propagation_op(&self.sort())];
-        r.extend(self.early_rewrites());
+        r.extend(binary_op_unroll_rules("Mod", 4));
         r
-    }
-    fn early_rewrites(&self) -> Vec<Rule> {
-        binary_op_unroll_rules("Mod", 4)
     }
     fn extract<'a>(
         &'a self,
@@ -1950,11 +1938,8 @@ impl EgglogOp for LessThan {
     fn rewrites(&self) -> Vec<Rule> {
         // Comparisons output Bool, not the input dtype.
         let mut r = vec![dtype_fixed_op(&self.sort(), &SORTS.bool_dt)];
-        r.extend(self.early_rewrites());
+        r.extend(binary_op_unroll_rules("LessThan", 4));
         r
-    }
-    fn early_rewrites(&self) -> Vec<Rule> {
-        binary_op_unroll_rules("LessThan", 4)
     }
     fn extract<'a>(
         &'a self,

--- a/src/op.rs
+++ b/src/op.rs
@@ -172,9 +172,6 @@ pub trait EgglogOp: Debug {
     fn rewrites(&self) -> Vec<crate::egglog_utils::api::Rule> {
         vec![]
     }
-    fn early_rewrites(&self) -> Vec<crate::egglog_utils::api::Rule> {
-        vec![]
-    }
     fn cleanup(&self) -> bool;
 
     /// Additional IR datatype variants this op needs (e.g. `"(ConsumedBuffer IR)"`).


### PR DESCRIPTION
## Summary
- Removed the separate `early` rewrite path and run GLUMoE rewrites through the main egglog schedule instead.
- Split GLUMoE matching into smaller marker states for expert index, gather, and downstream fusion so the heavy joins happen in staged passes.
- Reworked `KernelSigmoid` matching to use a staged marker around the scaled sigmoid pattern.
- Updated egglog scheduling and reporting to run phased main passes, emit phase-level metrics, and filter subsumed nodes from serialized egraphs.
- Added subsumption for redundant GLUMoE sum variants so the fused result can replace both `Sum` and `KernelSum` forms.

## Testing
- Not run (not requested).