### PR TITLE
Fix Metal index arithmetic and non-contiguous gather lowering

### DIFF
--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -102,6 +102,21 @@ fn metal_copy_value(dtype: DType, buffer: &str, index: &str) -> String {
     }
 }
 
+fn metal_binary_op_values(
+    output_dtype: DType,
+    a_dtype: DType,
+    b_dtype: DType,
+    a_idx: &str,
+    b_idx: &str,
+) -> (String, String) {
+    let read: fn(DType, &str, &str) -> String = if output_dtype == DType::Int {
+        metal_copy_value
+    } else {
+        metal_numeric_read
+    };
+    (read(a_dtype, "a", a_idx), read(b_dtype, "b", b_idx))
+}
+
 fn call_sort_from_args(sort: &SortDef, args: &Args) -> EggTerm {
     let mut filtered_args = Args::new();
     for field in &sort.fields {
@@ -423,8 +438,7 @@ impl MetalKernelOp for MetalAdd {
         let a_idx = lower_expression_for_metal(&a_index, "idx");
         let b_idx = lower_expression_for_metal(&b_index, "idx");
         let out_idx = lower_expression_for_metal(&out_index, "idx");
-        let a_val = metal_numeric_read(a_dtype, "a", &a_idx);
-        let b_val = metal_numeric_read(b_dtype, "b", &b_idx);
+        let (a_val, b_val) = metal_binary_op_values(output_dtype, a_dtype, b_dtype, &a_idx, &b_idx);
         let out_val = metal_numeric_write(output_dtype, &format!("({a_val}) + ({b_val})"));
 
         let source = format!(
@@ -556,8 +570,7 @@ impl MetalKernelOp for MetalMul {
         let a_idx = lower_expression_for_metal(&a_index, "idx");
         let b_idx = lower_expression_for_metal(&b_index, "idx");
         let out_idx = lower_expression_for_metal(&out_index, "idx");
-        let a_val = metal_numeric_read(a_dtype, "a", &a_idx);
-        let b_val = metal_numeric_read(b_dtype, "b", &b_idx);
+        let (a_val, b_val) = metal_binary_op_values(output_dtype, a_dtype, b_dtype, &a_idx, &b_idx);
         let out_val = metal_numeric_write(output_dtype, &format!("({a_val}) * ({b_val})"));
 
         let source = format!(
@@ -699,9 +712,13 @@ impl MetalKernelOp for MetalMod {
         let a_idx = lower_expression_for_metal(&a_index, "idx");
         let b_idx = lower_expression_for_metal(&b_index, "idx");
         let out_idx = lower_expression_for_metal(&out_index, "idx");
-        let a_val = metal_numeric_read(a_dtype, "a", &a_idx);
-        let b_val = metal_numeric_read(b_dtype, "b", &b_idx);
-        let out_val = metal_numeric_write(output_dtype, &format!("fmod({a_val}, {b_val})"));
+        let (a_val, b_val) = metal_binary_op_values(output_dtype, a_dtype, b_dtype, &a_idx, &b_idx);
+        let out_expr = if output_dtype == DType::Int {
+            format!("({a_val}) % ({b_val})")
+        } else {
+            format!("fmod({a_val}, {b_val})")
+        };
+        let out_val = metal_numeric_write(output_dtype, &out_expr);
 
         let source = format!(
             r#"
@@ -1924,6 +1941,7 @@ impl MetalKernelOp for MetalIota {
 pub struct MetalGather {
     out_shape: Vec<Expression>,
     index_stride: Vec<Expression>,
+    data_shape: Vec<Expression>,
     data_stride: Vec<Expression>,
     out_stride: Vec<Expression>,
 }
@@ -1938,6 +1956,7 @@ impl EgglogOp for MetalGather {
                 ("indexes", IR),
                 ("index_strides", ELIST),
                 ("data", IR),
+                ("data_shape", ELIST),
                 ("data_strides", ELIST),
                 ("out_strides", ELIST),
             ],
@@ -1959,6 +1978,7 @@ impl EgglogOp for MetalGather {
                 gather_args["index_strides"].clone(),
             ),
             ("data".to_string(), gather_args["data"].clone()),
+            ("data_shape".to_string(), gather_args["data_shape"].clone()),
             (
                 "data_strides".to_string(),
                 gather_args["data_strides"].clone(),
@@ -1989,9 +2009,10 @@ impl EgglogOp for MetalGather {
                 out_shape: extract_expr_list(egraph, children[0], list_cache, expr_cache).unwrap(),
                 index_stride: extract_expr_list(egraph, children[2], list_cache, expr_cache)
                     .unwrap(),
-                data_stride: extract_expr_list(egraph, children[4], list_cache, expr_cache)
+                data_shape: extract_expr_list(egraph, children[4], list_cache, expr_cache).unwrap(),
+                data_stride: extract_expr_list(egraph, children[5], list_cache, expr_cache)
                     .unwrap(),
-                out_stride: extract_expr_list(egraph, children[5], list_cache, expr_cache).unwrap(),
+                out_stride: extract_expr_list(egraph, children[6], list_cache, expr_cache).unwrap(),
             })),
             vec![children[1], children[3]],
         )
@@ -2015,7 +2036,7 @@ impl MetalKernelOp for MetalGather {
             "idx",
         );
         let data_idx = lower_expression_for_metal(
-            &flatten_strides(&self.out_shape, &self.data_stride),
+            &flatten_strides(&self.data_shape, &self.data_stride),
             "gathered_index",
         );
         let gathered_val = metal_copy_value(data_dtype, "data", &data_idx);

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -250,6 +250,23 @@ fn dynamic_dim_sum_reduce_runs() {
     assert_close(&out, &[9.0, 12.0], 0.001);
 }
 
+#[test]
+fn metal_int_arithmetic_preserves_large_values() {
+    let mut cx = Graph::default();
+    let token = cx.tensor(1).as_dtype(DType::Int);
+    let large_index = (token * 1024) + 123;
+    let mod_output = (large_index % 65_537).output();
+
+    cx.build_search_space::<MetalRuntime>();
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(token, &[16_385i32]);
+    rt = cx.search(rt, 1);
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_eq!(rt.get_f32(mod_output), vec![891.0]);
+}
+
 proptest! {
     #![proptest_config(ProptestConfig::with_cases(5))]
 
@@ -969,6 +986,28 @@ fn test_scatter_basic() {
 
     let out = rt.get_f32(result);
     assert_close(&out, &[0.0, 10.0, 0.0, 20.0, 30.0], 0.001);
+}
+
+#[test]
+fn test_gather_noncontiguous_data_uses_data_shape() {
+    let mut cx = Graph::default();
+    let input = cx.tensor((4, 3));
+    let data = input.transpose(0, 1);
+    let indexes = cx.tensor((2, 2)).as_dtype(DType::Int);
+    let out = data.gather(indexes).output();
+
+    cx.build_search_space::<MetalRuntime>();
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(
+        input,
+        &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0],
+    );
+    rt.set_data(indexes, &[0.0, 3.0, 4.0, 7.0]);
+    rt = cx.search(rt, 1);
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(out), &[0.0, 9.0, 1.0, 10.0], 0.001);
 }
 
 #[test]


### PR DESCRIPTION
Metal binary kernels were reading Int inputs through float conversion, which could lose precision for large computed indices. Keep Add, Mul, and Mod in integer space when the output dtype is Int, and use the integer `%` operator for Int modulo.

MetalGather also lowered gathered data offsets using the output/index shape instead of the source data shape. Thread data_shape through the MetalGather egglog op and use it with data_strides when computing the final data index, so gathers from transposed or otherwise non-contiguous tensors address the right elements.