### PR TITLE
Add Metal support for Qwen3-4B generation

### DIFF
--- a/ci/modal_example.py
+++ b/ci/modal_example.py
@@ -45,6 +45,10 @@ EXPECTED_OUTPUT = {
     ],
 }
 
+EXAMPLE_CARGO_ARGS = {
+    "qwen": ["--features", "cuda"],
+}
+
 
 def run_and_capture(command: list[str], *, cwd: str, env: dict[str, str]) -> str:
     process = subprocess.Popen(
@@ -130,7 +134,7 @@ def run_example(example: str):
         "HF_HOME": HF_CACHE_PATH,
     }
     output = run_and_capture(
-        ["cargo", "run", "--release"],
+        ["cargo", "run", "--release", *EXAMPLE_CARGO_ARGS.get(example, [])],
         cwd=f"{WORKDIR}/examples/{example}",
         env=run_env,
     )

--- a/crates/luminal_metal/Cargo.toml
+++ b/crates/luminal_metal/Cargo.toml
@@ -11,8 +11,11 @@ metal = "0.31"
 objc = "0.2"
 as-any = "0.3.2"
 itertools = "0.12.1"
-half = "2.7.1"
+half = { version = "2.7.1", features = ["bytemuck"] }
 tracing = "0.1.43"
+safetensors = "0.7.0"
+memmap2 = "0.9.9"
+bytemuck = "1.24.0"
 
 [dev-dependencies]
 candle-core = "0.9.2-alpha.1"

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -1,11 +1,11 @@
 use crate::kernel::{
     MatmulDescriptor, MetalKernelOp, MetalMatmul, MetalMatmulPlanner, DYN_SLOT_COUNT,
 };
-use half::f16;
+use half::{bf16, f16};
 use itertools::Itertools;
 use luminal::{
     dtype::DType,
-    graph::LLIRGraph,
+    graph::{Graph, LLIRGraph},
     hlir::{Input, NativeData, Output},
     op::{ExecutionStats, Runtime, RuntimeStats, TimingMethod},
     prelude::{
@@ -13,9 +13,11 @@ use luminal::{
         FxHashMap, NodeIndex, ToId,
     },
 };
+use memmap2::MmapOptions;
 use metal::{Buffer, CommandQueue, ComputePipelineState, Device, MTLResourceOptions};
 use objc::runtime::Object;
-use std::time::Duration;
+use safetensors::{Dtype as SafeDType, SafeTensors};
+use std::{fs::File, time::Duration};
 
 pub struct MetalRuntime {
     device: Device,
@@ -37,6 +39,89 @@ pub struct MetalRuntime {
 }
 
 impl MetalRuntime {
+    fn input_dtype(&self, id: NodeIndex) -> Option<DType> {
+        self.llir_graph.node_indices().find_map(|node| {
+            self.llir_graph[node]
+                .to_op::<Input>()
+                .and_then(|input| (input.node == id.index()).then_some(input.dtype))
+        })
+    }
+
+    fn output_data_node(&self, id: NodeIndex) -> NodeIndex {
+        let output_id = self
+            .llir_graph
+            .node_indices()
+            .find(|n| {
+                if let Some(Output { node }) = self.llir_graph[*n].to_op::<Output>() {
+                    *node == id.index()
+                } else {
+                    false
+                }
+            })
+            .expect("Cannot find output tensor!");
+
+        self.llir_graph
+            .neighbors_directed(output_id, Direction::Incoming)
+            .next()
+            .unwrap()
+    }
+
+    fn buffer_from_slice<T>(&self, values: &[T]) -> Buffer {
+        self.device.new_buffer_with_data(
+            values.as_ptr() as *const _,
+            std::mem::size_of_val(values) as u64,
+            MTLResourceOptions::StorageModeShared,
+        )
+    }
+
+    fn buffer_from_safetensor(
+        &self,
+        tensor: &safetensors::tensor::TensorView<'_>,
+        dtype: DType,
+    ) -> Buffer {
+        match (tensor.dtype(), dtype) {
+            (SafeDType::F32, DType::F32) | (SafeDType::F16, DType::F16) => {
+                let data = tensor.data();
+                self.device.new_buffer_with_data(
+                    data.as_ptr() as *const _,
+                    data.len() as u64,
+                    MTLResourceOptions::StorageModeShared,
+                )
+            }
+            (SafeDType::F16, DType::F32) => {
+                let values: Vec<f32> = bytemuck::cast_slice::<u8, f16>(tensor.data())
+                    .iter()
+                    .map(|v| v.to_f32())
+                    .collect();
+                self.buffer_from_slice(&values)
+            }
+            (SafeDType::BF16, DType::F32) => {
+                let values: Vec<f32> = bytemuck::cast_slice::<u8, bf16>(tensor.data())
+                    .iter()
+                    .map(|v| v.to_f32())
+                    .collect();
+                self.buffer_from_slice(&values)
+            }
+            (SafeDType::F32, DType::F16) => {
+                let values: Vec<f16> = bytemuck::cast_slice::<u8, f32>(tensor.data())
+                    .iter()
+                    .map(|v| f16::from_f32(*v))
+                    .collect();
+                self.buffer_from_slice(&values)
+            }
+            (SafeDType::BF16, DType::F16) => {
+                let values: Vec<f16> = bytemuck::cast_slice::<u8, bf16>(tensor.data())
+                    .iter()
+                    .map(|v| f16::from_f32(v.to_f32()))
+                    .collect();
+                self.buffer_from_slice(&values)
+            }
+            (tensor_dtype, dtype) => {
+                panic!("Cannot load safetensor dtype {tensor_dtype:?} into Metal dtype {dtype:?}")
+            }
+        }
+    }
+
     fn fuse_matmuls(llir_graph: &LLIRGraph) -> LLIRGraph {
         let mut graph = llir_graph.clone();
         let planner = MetalMatmulPlanner;
@@ -132,29 +217,74 @@ impl MetalRuntime {
             .collect()
     }
 
+    pub fn load_safetensors(&mut self, cx: &Graph, file_path: &str) {
+        let f = File::open(file_path).unwrap();
+        let mmap = unsafe { MmapOptions::new().map(&f).unwrap() };
+        let st = SafeTensors::deserialize(&mmap).unwrap();
+
+        for node in cx.graph.node_indices() {
+            if let Some(input) = (*cx.graph[node]).as_any().downcast_ref::<Input>() {
+                if let Ok(tensor) = st.tensor(&input.label) {
+                    let buffer = self.buffer_from_safetensor(&tensor, input.dtype);
+                    self.input_data.remove(&node);
+                    self.hlir_buffers.insert(node, buffer);
+                }
+            }
+        }
+    }
+
     pub fn set_data(&mut self, id: impl ToId, data: impl Into<NativeData>) {
-        self.input_data.insert(id.to_id(), data.into());
+        let id = id.to_id();
+        let data = data.into();
+        if let Some(dtype) = self.input_dtype(id) {
+            let buffer = self.create_input_buffer(&data, dtype);
+            self.hlir_buffers.insert(id, buffer);
+        }
+        self.input_data.insert(id, data);
+    }
+
+    pub fn set_zeros(&mut self, id: impl ToId, num_bytes: usize) {
+        let id = id.to_id();
+        let buffer = self
+            .device
+            .new_buffer(num_bytes as u64, MTLResourceOptions::StorageModeShared);
+        unsafe {
+            std::ptr::write_bytes(buffer.contents(), 0, num_bytes);
+        }
+        self.input_data.remove(&id);
+        self.hlir_buffers.insert(id, buffer);
+    }
+
+    pub fn remove_buffer(&mut self, id: impl ToId) -> Buffer {
+        let data_id = self.output_data_node(id.to_id());
+
+        if let Some(buffer) = self.buffers.remove(&data_id) {
+            let replacement = self
+                .device
+                .new_buffer(buffer.length(), MTLResourceOptions::StorageModeShared);
+            self.buffers.insert(data_id, replacement);
+            return buffer;
+        }
+
+        if let Some(Input { node, .. }) = self.llir_graph[data_id].to_op::<Input>() {
+            return self
+                .hlir_buffers
+                .get(&NodeIndex::new(*node))
+                .expect("Cannot find input tensor in runtime!")
+                .to_owned();
+        }
+
+        panic!("Cannot find tensor in runtime!");
+    }
+
+    pub fn set_buffer(&mut self, id: impl ToId, buffer: Buffer) {
+        let id = id.to_id();
+        self.input_data.remove(&id);
+        self.hlir_buffers.insert(id, buffer);
     }
 
     pub fn get_f32(&self, id: impl ToId) -> Vec<f32> {
-        let id = id.to_id();
-        let output_id = self
-            .llir_graph
-            .node_indices()
-            .find(|n| {
-                if let Some(Output { node }) = self.llir_graph[*n].to_op::<Output>() {
-                    *node == id.index()
-                } else {
-                    false
-                }
-            })
-            .expect("Cannot find output tensor!");
-
-        let data_id = self
-            .llir_graph
-            .neighbors_directed(output_id, Direction::Incoming)
-            .next()
-            .unwrap();
+        let data_id = self.output_data_node(id.to_id());
 
         let buffer = self
             .buffers
@@ -242,7 +372,6 @@ impl Runtime for MetalRuntime {
     fn load_llir(&mut self, llir_graph: &LLIRGraph) {
         self.pipelines.clear();
         self.buffers.clear();
-        self.hlir_buffers.clear();
         self.node_dtypes.clear();
         self.llir_graph = Self::fuse_matmuls(llir_graph);
 

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -1,8 +1,16 @@
 use crate::{kernel::lower_expression_for_metal, runtime::MetalRuntime};
 use candle_core::{Device as CandleDevice, Tensor as CandleTensor};
-use half::f16;
+use half::{bf16, f16};
 use luminal::prelude::*;
 use proptest::prelude::*;
+use safetensors::{tensor::TensorView, Dtype as SafeDType};
+use std::{
+    collections::HashMap,
+    path::PathBuf,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+static SAFETENSORS_TEST_FILE_ID: AtomicUsize = AtomicUsize::new(0);
 
 fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32) {
     assert_eq!(
@@ -24,6 +32,32 @@ fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32) {
             rel_err
         );
     }
+}
+
+fn bytes_of<T: bytemuck::NoUninit>(values: &[T]) -> Vec<u8> {
+    bytemuck::cast_slice(values).to_vec()
+}
+
+fn write_test_safetensors(tensors: &[(&str, SafeDType, Vec<usize>, Vec<u8>)]) -> PathBuf {
+    let tensor_views: HashMap<String, TensorView<'_>> = tensors
+        .iter()
+        .map(|(name, dtype, shape, data)| {
+            (
+                (*name).to_string(),
+                TensorView::new(*dtype, shape.clone(), data).unwrap(),
+            )
+        })
+        .collect();
+    let serialized = safetensors::serialize(&tensor_views, None).unwrap();
+    let id = SAFETENSORS_TEST_FILE_ID.fetch_add(1, Ordering::Relaxed);
+    let mut path = std::env::temp_dir();
+    path.push(format!(
+        "luminal_metal_runtime_{}_{}.safetensors",
+        std::process::id(),
+        id
+    ));
+    std::fs::write(&path, serialized).unwrap();
+    path
 }
 
 const TRANSFORMER_SEQ: usize = 4;
@@ -986,6 +1020,131 @@ fn test_scatter_basic() {
 
     let out = rt.get_f32(result);
     assert_close(&out, &[0.0, 10.0, 0.0, 20.0, 30.0], 0.001);
+}
+
+#[test]
+fn test_scatter_buffer_roundtrip() {
+    let mut cx = Graph::default();
+    let src = cx.tensor(1);
+    let indexes = cx.tensor(1).as_dtype(DType::Int);
+    let cache = cx.tensor(4).persist();
+    let cache_out = src.scatter(indexes, cache);
+    let read = cache_out.output();
+
+    cx.build_search_space::<MetalRuntime>();
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(src, &[0.0]);
+    rt.set_data(indexes, &[0.0]);
+    rt.set_zeros(cache, 4 * std::mem::size_of::<f32>());
+    rt = cx.search(rt, 1);
+
+    for (pos, value, expected) in [
+        (0, 10.0, [10.0, 0.0, 0.0, 0.0]),
+        (1, 20.0, [10.0, 20.0, 0.0, 0.0]),
+        (2, 30.0, [10.0, 20.0, 30.0, 0.0]),
+    ] {
+        rt.set_data(src, &[value]);
+        rt.set_data(indexes, &[pos as f32]);
+        rt.allocate_intermediate_buffers(&cx.dyn_map);
+        rt.execute(&cx.dyn_map);
+        assert_close(&rt.get_f32(read), &expected, 0.001);
+
+        let updated_cache = rt.remove_buffer(cache_out);
+        rt.set_buffer(cache, updated_cache);
+    }
+}
+
+#[test]
+fn test_load_safetensors_f32_survives_search_and_overrides_input_data() {
+    let mut cx = Graph::default();
+    let weights = cx.named_tensor("weights", 3);
+    let bias = cx.named_tensor("bias", 3);
+    let out = (weights + bias).output();
+
+    let weight_values = [1.25f32, -2.5, 4.0];
+    let tensors = [("weights", SafeDType::F32, vec![3], bytes_of(&weight_values))];
+    let path = write_test_safetensors(&tensors);
+
+    cx.build_search_space::<MetalRuntime>();
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(weights, &[99.0, 99.0, 99.0]);
+    rt.set_data(bias, &[0.5, 1.0, -1.5]);
+    rt.load_safetensors(&cx, path.to_str().unwrap());
+    rt = cx.search(rt, 1);
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(out), &[1.75, -1.5, 2.5], 0.001);
+    std::fs::remove_file(path).ok();
+}
+
+#[test]
+fn test_load_safetensors_converts_supported_float_dtypes() {
+    let mut cx = Graph::default();
+    let f16_to_f32 = cx.named_tensor("f16_to_f32", 2);
+    let bf16_to_f32 = cx.named_tensor("bf16_to_f32", 2);
+    let f16_to_f16 = cx.named_tensor("f16_to_f16", 2).as_dtype(DType::F16);
+    let f32_to_f16 = cx.named_tensor("f32_to_f16", 2).as_dtype(DType::F16);
+    let bf16_to_f16 = cx.named_tensor("bf16_to_f16", 2).as_dtype(DType::F16);
+
+    let f16_to_f32_out = (f16_to_f32 + 0.0).output();
+    let bf16_to_f32_out = (bf16_to_f32 + 0.0).output();
+    let f16_to_f16_out = f16_to_f16.cast(DType::F32).output();
+    let f32_to_f16_out = f32_to_f16.cast(DType::F32).output();
+    let bf16_to_f16_out = bf16_to_f16.cast(DType::F32).output();
+
+    let f16_to_f32_values = [f16::from_f32(1.5), f16::from_f32(-2.25)];
+    let bf16_to_f32_values = [bf16::from_f32(3.5), bf16::from_f32(-4.25)];
+    let f16_to_f16_values = [f16::from_f32(5.5), f16::from_f32(-6.25)];
+    let f32_to_f16_values = [7.5f32, -8.25];
+    let bf16_to_f16_values = [bf16::from_f32(9.5), bf16::from_f32(-10.25)];
+    let tensors = [
+        (
+            "f16_to_f32",
+            SafeDType::F16,
+            vec![2],
+            bytes_of(&f16_to_f32_values),
+        ),
+        (
+            "bf16_to_f32",
+            SafeDType::BF16,
+            vec![2],
+            bytes_of(&bf16_to_f32_values),
+        ),
+        (
+            "f16_to_f16",
+            SafeDType::F16,
+            vec![2],
+            bytes_of(&f16_to_f16_values),
+        ),
+        (
+            "f32_to_f16",
+            SafeDType::F32,
+            vec![2],
+            bytes_of(&f32_to_f16_values),
+        ),
+        (
+            "bf16_to_f16",
+            SafeDType::BF16,
+            vec![2],
+            bytes_of(&bf16_to_f16_values),
+        ),
+    ];
+    let path = write_test_safetensors(&tensors);
+
+    cx.build_search_space::<MetalRuntime>();
+    let mut rt = MetalRuntime::initialize(());
+    rt.load_safetensors(&cx, path.to_str().unwrap());
+    rt = cx.search(rt, 1);
+    rt.allocate_intermediate_buffers(&cx.dyn_map);
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(f16_to_f32_out), &[1.5, -2.25], 0.001);
+    assert_close(&rt.get_f32(bf16_to_f32_out), &[3.5, -4.25], 0.001);
+    assert_close(&rt.get_f32(f16_to_f16_out), &[5.5, -6.25], 0.001);
+    assert_close(&rt.get_f32(f32_to_f16_out), &[7.5, -8.25], 0.001);
+    assert_close(&rt.get_f32(bf16_to_f16_out), &[9.5, -10.25], 0.001);
+    std::fs::remove_file(path).ok();
 }
 
 #[test]

--- a/examples/qwen/Cargo.toml
+++ b/examples/qwen/Cargo.toml
@@ -8,22 +8,26 @@ name = "qwen"
 path = "src/main.rs"
 
 [features]
+default = []
+cuda = ["dep:luminal_cuda_lite"]
+metal = ["dep:luminal_metal"]
 
 [dependencies]
 luminal = { path = "../.." }
 luminal_nn = { path = "../../crates/luminal_nn" }
-luminal_cuda_lite = { path = "../../crates/luminal_cuda_lite" }
-luminal_tracing = {path="../../crates/luminal_tracing"}
+luminal_tracing = { path = "../../crates/luminal_tracing" }
+luminal_cuda_lite = { path = "../../crates/luminal_cuda_lite", optional = true }
+luminal_metal = { path = "../../crates/luminal_metal", optional = true }
 tokenizers = "0.22.2"
 tracing = "0.1.43"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 # HuggingFace model download
-hf-hub = {version = "0.4", default-features = false, features = ["rustls-tls", "ureq"]}
+hf-hub = { version = "0.4", default-features = false, features = ["rustls-tls", "ureq"] }
 safetensors = "0.7.0"
-serde = {version = "1.0", features = ["derive"]}
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-half = {version = "2.7.1", features = ["bytemuck"]}
+half = { version = "2.7.1", features = ["bytemuck"] }
 bytemuck = "1.24.0"
 memmap2 = "0.9.9"
 rustc-hash = "2.1"

--- a/examples/qwen/README.md
+++ b/examples/qwen/README.md
@@ -1,0 +1,15 @@
+# Qwen3 4B
+
+Run Qwen3-4B through Luminal's CUDA backend:
+
+```bash
+cargo run --release -p qwen --features cuda
+```
+
+Run Qwen3-4B through Luminal's Metal backend on Apple targets:
+
+```bash
+cargo run --release -p qwen --features metal
+```
+
+The first run downloads `Qwen/Qwen3-4B`, converts the safetensors weights to a combined FP32 file, compiles the selected backend graph, and then generates text.

--- a/examples/qwen/src/lib.rs
+++ b/examples/qwen/src/lib.rs
@@ -1,0 +1,268 @@
+pub mod hf;
+pub mod model;
+
+use hf::prepare_hf_model;
+pub use luminal::prelude::Runtime;
+use luminal::prelude::*;
+use luminal_tracing::luminal_filter;
+use model::*;
+use rustc_hash::FxHashSet;
+use std::{error::Error, io::Write, time::Duration};
+use tokenizers::Tokenizer;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+const EOS_TOKEN: u32 = 151645; // <|endoftext|>
+const STOP_TOKEN: u32 = 151643; // <|end|>
+
+pub struct QwenRunConfig {
+    pub repo_id: String,
+    pub max_seq_len: usize,
+    pub gen_tokens: usize,
+    pub search_graphs: usize,
+    pub prompt: String,
+    pub repetition_penalty: f32,
+}
+
+impl Default for QwenRunConfig {
+    fn default() -> Self {
+        Self {
+            repo_id: "Qwen/Qwen3-4B".to_string(),
+            max_seq_len: 4096,
+            gen_tokens: 500,
+            search_graphs: 500,
+            prompt: "Explain what a neural network is in a paragraph.".to_string(),
+            repetition_penalty: 1.05,
+        }
+    }
+}
+
+pub trait QwenRuntime: Runtime<ExecReturn = ()> {
+    type Buffer;
+
+    fn load_safetensors(&mut self, cx: &Graph, file_path: &str);
+    fn set_i32_data(&mut self, id: NodeIndex, data: Vec<i32>);
+    fn set_zeros(&mut self, id: NodeIndex, num_bytes: usize);
+    fn remove_buffer(&mut self, id: NodeIndex) -> Self::Buffer;
+    fn set_buffer(&mut self, id: NodeIndex, buffer: Self::Buffer);
+    fn get_f32(&self, id: NodeIndex) -> Vec<f32>;
+
+    fn prepare_execute(&mut self, _dyn_map: &FxHashMap<char, usize>) {}
+}
+
+#[cfg(feature = "cuda")]
+impl QwenRuntime for luminal_cuda_lite::runtime::CudaRuntime {
+    type Buffer = luminal_cuda_lite::cudarc::driver::CudaSlice<u8>;
+
+    fn load_safetensors(&mut self, cx: &Graph, file_path: &str) {
+        luminal_cuda_lite::runtime::CudaRuntime::load_safetensors(self, cx, file_path);
+    }
+
+    fn set_i32_data(&mut self, id: NodeIndex, data: Vec<i32>) {
+        luminal_cuda_lite::runtime::CudaRuntime::set_data(self, id, data);
+    }
+
+    fn set_zeros(&mut self, id: NodeIndex, num_bytes: usize) {
+        luminal_cuda_lite::runtime::CudaRuntime::set_zeros(self, id, num_bytes);
+    }
+
+    fn remove_buffer(&mut self, id: NodeIndex) -> Self::Buffer {
+        luminal_cuda_lite::runtime::CudaRuntime::remove_buffer(self, id)
+    }
+
+    fn set_buffer(&mut self, id: NodeIndex, buffer: Self::Buffer) {
+        luminal_cuda_lite::runtime::CudaRuntime::set_buffer(self, id, buffer);
+    }
+
+    fn get_f32(&self, id: NodeIndex) -> Vec<f32> {
+        luminal_cuda_lite::runtime::CudaRuntime::get_f32(self, id)
+    }
+}
+
+#[cfg(feature = "metal")]
+impl QwenRuntime for luminal_metal::MetalRuntime {
+    type Buffer = luminal_metal::Buffer;
+
+    fn load_safetensors(&mut self, cx: &Graph, file_path: &str) {
+        luminal_metal::MetalRuntime::load_safetensors(self, cx, file_path);
+    }
+
+    fn set_i32_data(&mut self, id: NodeIndex, data: Vec<i32>) {
+        luminal_metal::MetalRuntime::set_data(self, id, data);
+    }
+
+    fn set_zeros(&mut self, id: NodeIndex, num_bytes: usize) {
+        luminal_metal::MetalRuntime::set_zeros(self, id, num_bytes);
+    }
+
+    fn remove_buffer(&mut self, id: NodeIndex) -> Self::Buffer {
+        luminal_metal::MetalRuntime::remove_buffer(self, id)
+    }
+
+    fn set_buffer(&mut self, id: NodeIndex, buffer: Self::Buffer) {
+        luminal_metal::MetalRuntime::set_buffer(self, id, buffer);
+    }
+
+    fn get_f32(&self, id: NodeIndex) -> Vec<f32> {
+        luminal_metal::MetalRuntime::get_f32(self, id)
+    }
+
+    fn prepare_execute(&mut self, dyn_map: &FxHashMap<char, usize>) {
+        luminal_metal::MetalRuntime::allocate_intermediate_buffers(self, dyn_map);
+    }
+}
+
+pub fn run_qwen<R>(mut runtime: R, config: QwenRunConfig) -> Result<(), Box<dyn Error>>
+where
+    R: QwenRuntime + 'static,
+{
+    let _ = tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(luminal_filter())
+        .try_init();
+
+    let model_dir = prepare_hf_model(&config.repo_id)?;
+    println!("Using model directory: {}", model_dir.display());
+
+    let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json"))
+        .map_err(|err| err as Box<dyn Error>)?;
+    let prompt_tokens = tokenizer
+        .encode(config.prompt.as_str(), true)
+        .map_err(|err| err as Box<dyn Error>)?
+        .get_ids()
+        .to_vec();
+
+    let mut cx = Graph::default();
+    let input = cx.named_tensor("input", 's').as_dtype(DType::Int);
+    let token_ids = cx.named_tensor("token_ids", 's').as_dtype(DType::Int);
+    let kv_cache = KVCache::new(&mut cx, config.max_seq_len);
+    let (logits, cache_outputs) = Qwen::init(&mut cx).forward(input, token_ids, &kv_cache);
+    let logits = logits.output();
+    for (k_out, v_out) in &cache_outputs {
+        k_out.output();
+        v_out.output();
+    }
+
+    println!("Building E-Graph...");
+    cx.build_search_space::<R>();
+
+    println!("Loading weights...");
+    let weights_path = model_dir.join("model_combined.safetensors");
+    runtime.load_safetensors(&cx, weights_path.to_str().unwrap());
+
+    let cache_bytes = N_KV_HEADS * config.max_seq_len * HEAD_DIM * std::mem::size_of::<f32>();
+    for i in 0..LAYERS {
+        runtime.set_zeros(kv_cache.k_caches[i].id, cache_bytes);
+        runtime.set_zeros(kv_cache.v_caches[i].id, cache_bytes);
+    }
+
+    println!("Compiling...");
+    cx.set_dim('s', 1);
+    cx.set_dim('p', 1);
+    runtime.set_i32_data(input.id, vec![1]);
+    runtime.set_i32_data(token_ids.id, vec![1]);
+    runtime = cx.search(runtime, config.search_graphs);
+
+    for i in 0..LAYERS {
+        runtime.set_zeros(kv_cache.k_caches[i].id, cache_bytes);
+        runtime.set_zeros(kv_cache.v_caches[i].id, cache_bytes);
+    }
+
+    let mut prev_seq = 1usize;
+    let mut sentence = vec![prompt_tokens[0]];
+    let total_steps = prompt_tokens.len() - 1 + config.gen_tokens;
+    let prompt_len = prompt_tokens.len();
+    let mut fwd_durations = vec![];
+    let mut seen_tokens = FxHashSet::default();
+
+    println!(
+        "Prompt: {} tokens, generating up to {} tokens",
+        prompt_len, config.gen_tokens
+    );
+
+    for i in 0..total_steps {
+        let start = std::time::Instant::now();
+        let is_prefill = i < prompt_len - 1;
+        let seq_len = sentence.len();
+
+        cx.set_dim('s', seq_len);
+        cx.set_dim('p', prev_seq);
+
+        runtime.set_i32_data(
+            input.id,
+            sentence.iter().map(|t| *t as i32).collect::<Vec<_>>(),
+        );
+        runtime.set_i32_data(
+            token_ids.id,
+            (prev_seq as i32..(seq_len + prev_seq) as i32).collect::<Vec<_>>(),
+        );
+        runtime.prepare_execute(&cx.dyn_map);
+
+        runtime.execute(&cx.dyn_map);
+        let logits_data = runtime.get_f32(logits.id);
+
+        for (layer_idx, (k_out, v_out)) in cache_outputs.iter().enumerate() {
+            let k_buf = runtime.remove_buffer(k_out.id);
+            let v_buf = runtime.remove_buffer(v_out.id);
+            runtime.set_buffer(kv_cache.k_caches[layer_idx].id, k_buf);
+            runtime.set_buffer(kv_cache.v_caches[layer_idx].id, v_buf);
+        }
+
+        prev_seq += seq_len;
+        fwd_durations.push(start.elapsed());
+
+        if is_prefill {
+            sentence = vec![prompt_tokens[i + 1]];
+            continue;
+        }
+
+        let mut last_row = logits_data[logits_data.len() - VOCAB_SIZE..].to_vec();
+        for &tok in &seen_tokens {
+            let logit = &mut last_row[tok as usize];
+            if *logit > 0.0 {
+                *logit /= config.repetition_penalty;
+            } else {
+                *logit *= config.repetition_penalty;
+            }
+        }
+        let next_token = last_row
+            .iter()
+            .enumerate()
+            .max_by(|(_, a), (_, b)| a.total_cmp(b))
+            .unwrap()
+            .0 as u32;
+        sentence = vec![next_token];
+        seen_tokens.insert(next_token);
+
+        if next_token == EOS_TOKEN || next_token == STOP_TOKEN {
+            break;
+        }
+
+        let decoded = tokenizer
+            .decode(&[next_token], true)
+            .map_err(|err| err as Box<dyn Error>)?;
+        print!("{}", decoded);
+        std::io::stdout().flush()?;
+    }
+    println!();
+
+    let decode_durations: Vec<_> = fwd_durations.iter().skip(prompt_len).collect();
+    if decode_durations.len() > 2 {
+        println!(
+            "  TTFT: {:.2} ms",
+            fwd_durations[..prompt_len]
+                .iter()
+                .sum::<Duration>()
+                .as_secs_f64()
+                * 1e3
+        );
+        println!(
+            "  TPOT: {:.2} ms",
+            (decode_durations.iter().skip(1).copied().sum::<Duration>()
+                / (decode_durations.len() - 1) as u32)
+                .as_secs_f64()
+                * 1_000.
+        );
+    }
+
+    Ok(())
+}

--- a/examples/qwen/src/main.rs
+++ b/examples/qwen/src/main.rs
@@ -1,174 +1,38 @@
-mod hf;
-mod model;
+#[cfg(all(feature = "cuda", feature = "metal"))]
+compile_error!("features `cuda` and `metal` are mutually exclusive");
 
-use hf::prepare_hf_model;
-use luminal::prelude::*;
+#[cfg(all(feature = "cuda", feature = "metal"))]
+fn main() {}
+
+#[cfg(all(feature = "cuda", not(feature = "metal")))]
 use luminal_cuda_lite::{cudarc::driver::CudaContext, runtime::CudaRuntime};
-use luminal_tracing::*;
-use model::*;
-use rustc_hash::FxHashSet;
-use std::{io::Write, time::Duration};
-use tokenizers::Tokenizer;
-use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+#[cfg(all(feature = "metal", not(feature = "cuda"), target_vendor = "apple"))]
+use luminal_metal::MetalRuntime;
+#[cfg(any(
+    all(feature = "cuda", not(feature = "metal")),
+    all(feature = "metal", not(feature = "cuda"), target_vendor = "apple")
+))]
+use qwen::{run_qwen, QwenRunConfig, Runtime};
 
-const REPO_ID: &str = "Qwen/Qwen3-4B";
-
+#[cfg(all(feature = "cuda", not(feature = "metal")))]
 fn main() {
-    let max_seq_len = 4096;
-    let gen_tokens = 500;
-    let search_graphs = 500;
-    let prompt = "Explain what a neural network is in a paragraph.";
-
-    tracing_subscriber::registry()
-        .with(tracing_subscriber::fmt::layer())
-        .with(luminal_filter())
-        .init();
-
     let ctx = CudaContext::new(0).unwrap();
     let stream = ctx.default_stream();
+    run_qwen(CudaRuntime::initialize(stream), QwenRunConfig::default()).unwrap();
+}
 
-    let model_dir = prepare_hf_model(REPO_ID).expect("Failed to prepare model");
-    println!("Using model directory: {}", model_dir.display());
+#[cfg(all(feature = "metal", not(feature = "cuda"), target_vendor = "apple"))]
+fn main() {
+    run_qwen(MetalRuntime::initialize(()), QwenRunConfig::default()).unwrap();
+}
 
-    let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json")).unwrap();
-    let prompt_tokens = tokenizer.encode(prompt, true).unwrap().get_ids().to_vec();
+#[cfg(all(feature = "metal", not(feature = "cuda"), not(target_vendor = "apple")))]
+fn main() {
+    eprintln!("qwen --features metal requires an Apple target with Metal support.");
+}
 
-    // Build graph
-    let mut cx = Graph::default();
-    let input = cx.named_tensor("input", 's').as_dtype(DType::Int);
-    let token_ids = cx.named_tensor("token_ids", 's').as_dtype(DType::Int);
-    let kv_cache = KVCache::new(&mut cx, max_seq_len);
-    let (logits, cache_outputs) = Qwen::init(&mut cx).forward(input, token_ids, &kv_cache);
-    let logits = logits.output();
-    for (k_out, v_out) in &cache_outputs {
-        k_out.output();
-        v_out.output();
-    }
-
-    println!("Building E-Graph...");
-    cx.build_search_space::<CudaRuntime>();
-
-    println!("Loading weights...");
-    let mut runtime = CudaRuntime::initialize(stream);
-    let weights_path = model_dir.join("model_combined.safetensors");
-    runtime.load_safetensors(&cx, weights_path.to_str().unwrap());
-
-    let cache_bytes = N_KV_HEADS * max_seq_len * HEAD_DIM * std::mem::size_of::<f32>();
-    for i in 0..LAYERS {
-        runtime.set_zeros(kv_cache.k_caches[i], cache_bytes);
-        runtime.set_zeros(kv_cache.v_caches[i], cache_bytes);
-    }
-
-    println!("Compiling...");
-    cx.set_dim('s', 1);
-    cx.set_dim('p', 1);
-    runtime.set_data(input, vec![1]);
-    runtime.set_data(token_ids, vec![1]);
-    runtime = cx.search(runtime, search_graphs);
-
-    for i in 0..LAYERS {
-        runtime.set_zeros(kv_cache.k_caches[i], cache_bytes);
-        runtime.set_zeros(kv_cache.v_caches[i], cache_bytes);
-    }
-
-    let mut prev_seq = 1usize;
-    let mut sentence = vec![prompt_tokens[0]];
-    let total_steps = prompt_tokens.len() - 1 + gen_tokens;
-    let prompt_len = prompt_tokens.len();
-    let mut fwd_durations = vec![];
-    let mut seen_tokens = FxHashSet::default();
-    let repetition_penalty: f32 = 1.05;
-
-    const EOS_TOKEN: u32 = 151645; // <|endoftext|>
-    const STOP_TOKEN: u32 = 151643; // <|end|>
-
-    println!(
-        "Prompt: {} tokens, generating up to {} tokens",
-        prompt_len, gen_tokens
-    );
-
-    for i in 0..total_steps {
-        let start = std::time::Instant::now();
-        let is_prefill = i < prompt_len - 1;
-        let seq_len = sentence.len();
-
-        cx.set_dim('s', seq_len);
-        cx.set_dim('p', prev_seq);
-
-        runtime.set_data(
-            input,
-            sentence.iter().map(|t| *t as i32).collect::<Vec<_>>(),
-        );
-        runtime.set_data(
-            token_ids,
-            (prev_seq as i32..(seq_len + prev_seq) as i32).collect::<Vec<_>>(),
-        );
-
-        runtime.execute(&cx.dyn_map);
-        let logits_data = runtime.get_f32(logits);
-
-        // Round-trip KV cache
-        for (layer_idx, (k_out, v_out)) in cache_outputs.iter().enumerate() {
-            let k_buf = runtime.remove_buffer(*k_out);
-            let v_buf = runtime.remove_buffer(*v_out);
-            runtime.set_buffer(kv_cache.k_caches[layer_idx], k_buf);
-            runtime.set_buffer(kv_cache.v_caches[layer_idx], v_buf);
-        }
-
-        prev_seq += seq_len;
-        fwd_durations.push(start.elapsed());
-
-        if is_prefill {
-            sentence = vec![prompt_tokens[i + 1]];
-            continue;
-        }
-
-        // Greedy decode with repetition penalty
-        let mut last_row = logits_data[logits_data.len() - VOCAB_SIZE..].to_vec();
-        for &tok in &seen_tokens {
-            let logit = &mut last_row[tok as usize];
-            if *logit > 0.0 {
-                *logit /= repetition_penalty;
-            } else {
-                *logit *= repetition_penalty;
-            }
-        }
-        let next_token = last_row
-            .iter()
-            .enumerate()
-            .max_by(|(_, a), (_, b)| a.total_cmp(b))
-            .unwrap()
-            .0 as u32;
-        sentence = vec![next_token];
-        seen_tokens.insert(next_token);
-
-        if next_token == EOS_TOKEN || next_token == STOP_TOKEN {
-            break;
-        }
-
-        let decoded = tokenizer.decode(&[next_token], true).unwrap();
-        print!("{}", decoded);
-        std::io::stdout().flush().unwrap();
-    }
-    println!();
-
-    // Benchmarks
-    let decode_durations: Vec<_> = fwd_durations.iter().skip(prompt_len).collect();
-    if decode_durations.len() > 2 {
-        println!(
-            "  TTFT: {:.2} ms",
-            fwd_durations[..prompt_len]
-                .iter()
-                .sum::<Duration>()
-                .as_secs_f64()
-                * 1e3
-        );
-        println!(
-            "  TPOT: {:.2} ms",
-            (decode_durations.iter().skip(1).copied().sum::<Duration>()
-                / (decode_durations.len() - 1) as u32)
-                .as_secs_f64()
-                * 1_000.
-        );
-    }
+#[cfg(not(any(feature = "cuda", feature = "metal")))]
+fn main() {
+    eprintln!("select exactly one backend with `--features cuda` or `--features metal`.");
+    std::process::exit(2);
 }


### PR DESCRIPTION
Extend MetalRuntime with the runtime APIs needed for loading safetensors, managing persistent KV-cache buffers, round-tripping output buffers back into inputs, and reading logits during autoregressive decoding.

Update the Qwen example to support both CUDA and Metal through mutually exclusive CUDA and Metal feature flags.