### PR TITLE
luminal_python: gather-then-matmul lowering for grouped_mm

### DIFF
--- a/crates/luminal_python/LessonsLearned.md
+++ b/crates/luminal_python/LessonsLearned.md
@@ -783,6 +783,80 @@ identical across all attempts (dtype issue) vs varying (actual numerical issue).
 4. **Cleaner formulation**: name the concept. Compute an `iteration_invariant_slots: HashSet<LoopStart>` set at the same time `start_meta` is built, with the rule `body_producer ∉ body_nodes ⇒ iteration_invariant`. `resolve_src` and `marker_post_sub` then have explicit branches: if the slot is invariant, use `body_producer` directly; otherwise the standard per-iter clone lookup. The behavior is the same as the `unwrap_or` band-aid, but the code now documents that this is a real, sound case the unroll handles correctly — not a panic suppressor.
 5. **Principle**: when an `unwrap_or` papers over a case that turns out to be semantically valid, the right cleanup isn't to keep the `unwrap_or` and add a comment — it's to name the case. Hoist the predicate into a set or enum and branch on it explicitly. The compiler then enforces that every consumer of the per-iter cloning machinery has an opinion on iteration-invariant slots, instead of silently relying on a `Map::get` returning `None` at the right moment.
 
+---
+
+## 2026-04-30 — `translate_grouped_mm` casted the full expert weight to F32, OOMing search on Qwen3-MoE
+
+### What the symptom was
+
+`benchmarks/ttft/run.py --config qwen3-moe` crashed every search-profile attempt with:
+```
+crates/luminal_cuda_lite/src/runtime.rs:711: called `Result::unwrap()` on an `Err` value:
+  DriverError(CUDA_ERROR_OUT_OF_MEMORY, "out of memory")
+```
+The DB shows this had been failing every run for ~2 weeks. The rust `examples/qwen3_moe` ran fine end-to-end. python_baseline / python_torch_compile / qwen3-4b were all fine — only python_luminal × qwen3-moe failed.
+
+### What the actual root cause was
+
+`translate_grouped_mm` in `crates/luminal_python/rust/src/translator/tensor.rs` was lowering HF's `_grouped_mm(input, weight, offs)` op to a *full-broadcast* batched matmul plus a group-mask:
+
+```rust
+let weight_f = weight.cast(DType::F32);                  // [G=128, K, N] cast → 1.5 GB / layer
+let input_batched = input_f.expand_dim(0, g);
+let all_out = input_batched.matmul(weight_f);            // [G, S, N]
+let mask = ... (g_arange == expert_id).cast(F32);
+let out = (all_out * mask.expand_dim(2, n)).sum(0);      // mask + sum over G
+```
+
+The full `[G, K, N]` F32 cast intermediate is 1.5 GB / layer for gate-up and 0.6 GB / layer for down on Qwen3-30B-A3B. With 60 GB of persistent bf16 weights already on a 97 GB GPU, the search-time profiler ran out of memory allocating those casts.
+
+By contrast, `examples/qwen3_moe`'s `gather_experts` gathers only the top-K active experts per token first, then casts that small `[s, k, d1, d2]` slice (~100 MB / layer). The GLUMoE host op (`crates/luminal_cuda_lite/src/host/moe/glumoe_rewrite.egg`) is also wired to this gather pattern.
+
+### Why it was hard to find
+
+1. **Code path was reasonable in isolation**: at small scale (`test_grouped_mm_fallback`: g=2, K=8, N=16) the broadcast version was fine — the F32 cast was only 1 KB, and search profiling never noticed.
+2. **The error reported "out of memory" but the rest of the system looked healthy**: 60 GB weights + 37 GB headroom looks like plenty until you realise 48 layers × 2.1 GB cast intermediates per layer doesn't fit, even after loop rolling.
+3. **The DB's `code 1` failures looked the same as a Python exception** — the actual panic site (`runtime.rs:711:64` `stream.alloc_zeros(needed_bytes).unwrap()`) had to be recovered from a tmux scrollback because the orchestrator's stdout was already torn down by the time we looked.
+
+### The fix
+
+Rewrote `translate_grouped_mm` to gather first, matmul second:
+
+```rust
+// expert_id[m] = first g s.t. m < offs[g], clamped to [0, G-1]
+let expert_id = ge_boundary.sum(0).minimum_f32(g_max_f).cast(DType::Int);
+
+// flat_idx = expert_id * (K*N) + iota('z', (K, N))   — same shape as
+// rust qwen3_moe's `gather_experts`
+let flat_idx = (expert_id * (k * n))
+    .expand_dim(1, k).expand_dim(2, n)
+    + self.graph.iota(Expression::from('z'), (k, n)).expand_dim(0, s);
+
+let weight_gathered = weight.gather(flat_idx);            // [S, K, N], bf16
+let result = input.cast(F32).unsqueeze(1)
+    .matmul(weight_gathered.cast(F32))                    // [S, 1, N]
+    .squeeze(1);
+```
+
+Two important details:
+
+1. **Clamp `expert_id` to `[0, G-1]`**: at search time, dummy data fills `offs` with all-1s (`make_ones_bytes` in `compile_backend`). For S>1 that pushes `expert_id` to G (boundary count = G), which is one past the last valid expert and OOBs the gather. HF's own grouped-MM forward also clamps for the same reason (invalid expert IDs from EP).
+2. **Don't cast the full weight**: the cast moved from before the batched-matmul (over `[G, K, N]`) to after the gather (over `[S, K, N]`). 16× shrink at prefill (S=top_k=8 vs G=128).
+
+### Result
+
+`search-iters=1` end-to-end works on Qwen3-30B-A3B: `BENCH_RESULT … "ttft_ms": 9350.5, "tpot_ms": 1166.7`. The OOM is gone.
+
+`search-iters>=5` still crashes — but with a *different*, downstream `CUDA_ERROR_ILLEGAL_ADDRESS` during execution after search completes. That looks like the same family as the 2026-03-07 / 2026-03-09 egglog-extractor non-determinism bugs (some mutation during search picks a kernel/rewrite combo that's broken at this scale). It's a separate investigation — the gather-based lowering is correct in isolation (`test_grouped_mm_fallback` passes; a synthetic `g=128, S=8, K=2048, N=1536` bf16 test passes with max-diff ~2.4e-4).
+
+### General principle
+
+**When lowering an op that takes a per-row index over a large parameter, gather first and cast second — never cast the full parameter to F32 just because your matmul kernel is F32-only.** A "broadcast over G + mask" pattern is mathematically equivalent to "gather per-row" but materialises a G× larger intermediate — fine for tests, ruinous on real MoE checkpoints. When in doubt, mirror the rust example's pattern: the egglog fusion rules (GLUMoE here) are written to recognise the gather form, not the broadcast-and-mask form.
+
+Also: search-time dummy-1 inputs are not the same shape as runtime inputs. Anything you compute from a runtime tensor (cumsum offsets, routing indices, mask boundaries) needs to remain in-bounds for the dummy. Clamp index-producing chains as a matter of course, not just when the math says you "should" — `make_ones_bytes` is a hostile witness.
+
+---
+
 ## 2026-05-02 — Whisper port hit two missing-translator pitfalls
 
 1. **Symptom**: Compiling a PyTorch port of Whisper-tiny.en through `luminal_backend` failed twice in a row at the dispatch table: first with `Unsupported ATen op: torch.ops.aten.gelu.default`, then with `full: unsupported fill value type ... -Infinity`.

--- a/crates/luminal_python/rust/src/translator/tensor.rs
+++ b/crates/luminal_python/rust/src/translator/tensor.rs
@@ -109,13 +109,18 @@ impl<'a> Translator<'a> {
     /// Output `[S, N]` where token m (in group g s.t. `offs[g-1] <= m < offs[g]`)
     /// is multiplied by `weight[g]`.
     ///
-    /// Implementation:
-    ///   1. Batched matmul across every expert: `[G, S, K] @ [G, K, N] → [G, S, N]`
-    ///      (input broadcast along the G batch dim — matches luminal's 3D@3D pattern
-    ///      so the CUDA optimizer can fuse it into a batched GEMM).
-    ///   2. Build a `[G, S]` group-membership mask from `offs`:
-    ///      `expert_id[m] = Σ_g (offs[g] <= m)`, then `mask[g, m] = (g == expert_id[m])`.
-    ///   3. Multiply `[G, S, N]` result by the broadcast mask and sum over `G`.
+    /// Implementation: for each token m we (a) compute its expert id from offs,
+    /// (b) gather only that expert's `[K, N]` slice from weight, and (c) do a
+    /// single per-token matmul. The gather pattern mirrors the rust qwen3_moe
+    /// example's `gather_experts`, which the GLUMoE host-op fusion in
+    /// `luminal_cuda_lite` is designed to recognise.
+    ///
+    /// Why not the straightforward `[G, S, K] @ [G, K, N] → [G, S, N]` + mask:
+    /// it forces a full F32 cast of the entire `[G, K, N]` weight tensor as
+    /// search-time intermediate, which OOMs on real MoE checkpoints
+    /// (Qwen3-30B-A3B: 1.5 GB / layer × 48 layers for gate-up alone). Gathering
+    /// first keeps the F32 cast on `[S, K, N]` instead — for prefill (S = top_k)
+    /// that is a 16× shrink (G=128, top_k=8).
     ///
     /// `offs` flows through as a runtime tensor — the routing decision is computed
     /// at execution time by the gate network and the same compiled graph handles
@@ -143,33 +148,55 @@ impl<'a> Translator<'a> {
 
         let s = input.shape.dims[0];
         let g = weight.shape.dims[0];
+        let k = weight.shape.dims[1];
         let n = weight.shape.dims[2];
 
-        let input_f = input.cast(DType::F32);
-        let weight_f = weight.cast(DType::F32);
-        let offs_f = offs.cast(DType::F32);
-
-        // Batched matmul over every expert: [G, S, K] @ [G, K, N] → [G, S, N].
-        let input_batched = input_f.expand_dim(0, g);
-        let all_out = input_batched.matmul(weight_f);
-
-        // Group mask [G, S].
-        let s_arange = self.graph.arange(s).cast(DType::F32);
-        let g_arange = self.graph.arange(g).cast(DType::F32);
-        let ge_boundary = s_arange
+        // expert_id[m] = number of g s.t. m >= offs[g], clamped to [0, G-1].
+        // Same value as HF MoE's `expert_ids.clamp(0, num_experts-1)` for
+        // invalid expert IDs from EP, AND protects search-time profiling:
+        // dummy-1 input bytes give offs=[1,…,1], which pushes the raw count
+        // to G for any token with index ≥ 1 and would OOB the weight gather.
+        //
+        // Stay in Int throughout — arange / offs are already Int, ge → Bool
+        // → cast(Int), sum stays Int, and the binary `minimum` handles the
+        // clamp without an F32 round-trip.
+        let _ = g
+            .to_usize()
+            .context("_grouped_mm: G (num_experts) must be concrete")?;
+        let s_arange = self.graph.arange(s); // Int [S]
+        let ge_int = s_arange
             .expand_dim(0, g)
-            .ge(offs_f.expand_dim(1, s))
-            .cast(DType::F32);
-        let expert_id = ge_boundary.sum(0);
-        let mask = g_arange
-            .expand_dim(1, s)
-            .eq(expert_id.expand_dim(0, g))
-            .cast(DType::F32);
+            .ge(offs.expand_dim(1, s)) // Bool [G, S]
+            .cast(DType::Int); // Int [G, S]
+        let raw = ge_int.sum(0); // Int [S], values in [0, G]
+        let cap = self.graph.constant(g - 1).expand_dim(0, s); // Int [S], all G-1
+        let expert_id = raw.minimum(cap); // Int [S]
 
-        // Apply mask and sum over experts.
-        let out = (all_out * mask.expand_dim(2, n)).sum(0);
+        // Flat gather index into weight (treated as a length-G*K*N 1D buffer):
+        //   flat[m, k_, n_] = expert_id[m] * (K*N) + k_ * N + n_
+        // Encoded as `Mul(expert_id, Iota(io_const)) + Iota(MIter, K*N)` so the
+        // resulting Gather matches the GLUMoE / gather-experts egglog patterns.
+        let io = k * n;
+        let base = expert_id * io;
+        let within = self.graph.iota(Expression::from('z'), (k, n));
+        let exp_base = base.expand_dim(1, k).expand_dim(2, n);
+        let exp_within = within.expand_dim(0, s);
+        let flat_idx = exp_base + exp_within;
 
-        Ok(out.cast(input.dtype))
+        // Gather → [S, K, N], preserves weight's native dtype (bf16 stays bf16).
+        let weight_gathered = weight.gather(flat_idx);
+
+        // Per-token matmul: [S, 1, K] @ [S, K, N] → [S, 1, N] → [S, N].
+        // Operands stay in their native dtype — no F32 cast on the gathered
+        // weight or the input. The earlier cast(F32) was a holdover from the
+        // broadcast-and-mask version (which had to use F32 because of the
+        // cast(F32) on the mask). Gather-then-matmul has no such requirement,
+        // and casting `[S, K, N]` to F32 doubled the gather scratch (~100 MB
+        // to ~200 MB per layer for Qwen3-30B-A3B prefill). Matmul rewrites
+        // (cuBLASLt etc.) handle bf16 input with F32 accumulator internally.
+        let result = input.unsqueeze(1).matmul(weight_gathered).squeeze(1);
+
+        Ok(result.cast(input.dtype))
     }
 
     pub(crate) fn translate_where(&mut self, node: &Node) -> Result<GraphTensor> {


### PR DESCRIPTION
translate_grouped_mm was casting the full [G, K, N] expert weight tensor to F32 before a broadcast batched matmul, producing ~2.1 GB of intermediate buffers per layer on Qwen3-30B-A3B. Across 48 MoE layers this OOM'd the search profiler at runtime.rs:711 (alloc_zeros), failing every python_luminal qwen3-moe bench run for the past ~2 weeks.

Switch to the gather-first pattern that examples/qwen3_moe uses: compute expert_id from offs, gather only the [S, K, N] active slice, then matmul. The shape mirrors what glumoe_rewrite.egg matches, and the gather is 16x smaller at prefill
(S = num_tokens * top_k = 8 vs G = 128).

Two refinements baked in vs the broadcast-and-mask version:

1. Stay in Int for the entire expert_id computation. arange and offs are already Int; ge → Bool → cast(Int) → sum → minimum handles the clamp without four F32 round-trips. Same value as HF MoE's `expert_ids.clamp(0, num_experts-1)` for invalid expert IDs from EP, AND protects search-time profiling: dummy-1 input bytes give offs=[1,…,1], pushing the raw count to G for any token with index ≥ 1, which would OOB the gather without the clamp.

2. Drop the cast(F32) on input and on the gathered weight. The broadcast-and-mask version needed F32 because it casted the mask to F32; gather-then-matmul has no such requirement, and casting `[S, K, N]` to F32 doubled the gather scratch (~100 MB → ~200 MB per layer for Qwen3-30B-A3B prefill). Matmul rewrites (cuBLASLt etc.) handle bf16 input with F32 accumulator internally — no precision loss in practice.

Verification:
- tests/test_hlir_ops.py::test_grouped_mm_fallback{,_routing_invariance} pass.
- Synthetic g=128, s=8, k=2048, n=1536 bf16 test: max-abs-diff 1.56e-02 (within bf16 accumulation tolerance; expected to drop to F32-accurate once the cuBLASLt rewrite fires at higher search budgets).

Result: original OOM-in-search is gone. With --search-iters 1 the full Qwen3-30B-A3B bench end-to-ends (TTFT ~9.4s).