### PR TITLE
`copy_device_buffer_to_new_slice` synchronizes stream unnecessarily

### DIFF
--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -225,7 +225,6 @@ impl CudaRuntime {
             result::memcpy_dtod_async(dst_ptr, src.ptr(), src.len(), stream.cu_stream())
                 .expect("cuMemcpyDtoDAsync failed");
         }
-        stream.synchronize().unwrap();
         dst
     }
 


### PR DESCRIPTION
CUDA streams are strictly ordered — every operation submitted to a stream executes after all prior operations on that same stream, guaranteed. So any future kernel launch or memory op submitted to the same stream will automatically wait for this copy to complete. There is no need for the CPU to wait.