### PR TITLE
Dyn dim intervals

### DIFF
--- a/crates/luminal_bench/benches/micro.rs
+++ b/crates/luminal_bench/benches/micro.rs
@@ -39,7 +39,7 @@ fn run_metal_pattern_benchmark(
         let mut cx = Graph::default();
         pattern.build_graph(&mut cx, *size);
 
-        cx.build_search_space::<MetalRuntime>();
+        cx.build_search_space::<MetalRuntime>(CompileOptions::default());
         let mut rt = MetalRuntime::initialize(());
 
         let mut rng = rand::rng();
@@ -50,7 +50,7 @@ fn run_metal_pattern_benchmark(
             }
         }
 
-        let mut rt = cx.search(rt, 5);
+        let mut rt = cx.search(rt, CompileOptions::new(5));
         rt.allocate_intermediate_buffers(&cx.dyn_map);
 
         let mut bench_metrics = None;

--- a/crates/luminal_bench/benches/patterns.rs
+++ b/crates/luminal_bench/benches/patterns.rs
@@ -41,7 +41,7 @@ struct PreparedBench {
 
 #[cfg(feature = "metal")]
 fn prepare_and_search(cx: &mut Graph, input_sizes: &[(NodeIndex, usize)]) -> Option<PreparedBench> {
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
 
     let mut rng = rand::rng();
@@ -50,7 +50,7 @@ fn prepare_and_search(cx: &mut Graph, input_sizes: &[(NodeIndex, usize)]) -> Opt
         rt.set_data(*node, &data);
     }
 
-    let rt = cx.search(rt, 5);
+    let rt = cx.search(rt, CompileOptions::new(5));
 
     Some(PreparedBench {
         rt,

--- a/crates/luminal_bench/examples/debug_ops.rs
+++ b/crates/luminal_bench/examples/debug_ops.rs
@@ -41,7 +41,7 @@ mod metal_backend {
         const NAME: &'static str = "Metal";
 
         fn build_search_space(cx: &mut Graph) {
-            cx.build_search_space::<MetalRuntime>();
+            cx.build_search_space::<MetalRuntime>(CompileOptions::default());
         }
     }
 }

--- a/crates/luminal_cuda_lite/src/kernel/cuda_graph.rs
+++ b/crates/luminal_cuda_lite/src/kernel/cuda_graph.rs
@@ -498,8 +498,8 @@ mod tests {
         let data_b = random_f32_vec(size, 43, -0.5, 0.5);
         rt.set_data(a, data_a.clone());
         rt.set_data(b, data_b.clone());
-        cx.build_search_space::<CudaRuntime>();
-        rt = cx.search(rt, 5);
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::new(5));
         rt.execute(&cx.dyn_map);
         let result1 = rt.get_f32(c);
         rt.execute(&cx.dyn_map);
@@ -530,8 +530,8 @@ mod tests {
         let data_b = random_f32_vec(size, 43, -0.5, 0.5);
         rt.set_data(a, data_a.clone());
         rt.set_data(b, data_b.clone());
-        cx.build_search_space::<CudaRuntime>();
-        rt = cx.search(rt, 5);
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::new(5));
         let mut results = Vec::new();
         for _ in 0..5 {
             rt.execute(&cx.dyn_map);
@@ -568,8 +568,8 @@ mod tests {
         rt.set_data(a, data_a.clone());
         rt.set_data(b, data_b.clone());
         cx.set_dim('s', size);
-        cx.build_search_space::<CudaRuntime>();
-        rt = cx.search(rt, 5);
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::new(5));
         rt.execute(&cx.dyn_map);
         let expected: Vec<f32> = data_a
             .iter()
@@ -610,8 +610,8 @@ mod tests {
         let data_b = random_f32_vec(size, 43, -0.5, 0.5);
         rt.set_data(a, data_a.clone());
         rt.set_data(b, data_b.clone());
-        cx.build_search_space::<CudaRuntime>();
-        rt = cx.search(rt, 5);
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::new(5));
         rt.execute(&cx.dyn_map);
         let expected: Vec<f32> = data_a.iter().zip(&data_b).map(|(a, b)| a + b).collect();
         let eps = dtype_epsilon(luminal::dtype::DType::F32);
@@ -641,8 +641,8 @@ mod tests {
         let data_b = random_f32_vec(size, 43, -0.5, 0.5);
         rt.set_data(a, data_a.clone());
         rt.set_data(b, data_b.clone());
-        cx.build_search_space::<CudaRuntime>();
-        rt = cx.search(rt, 5);
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::new(5));
         for _ in 0..10 {
             rt.execute(&cx.dyn_map);
         }
@@ -674,8 +674,8 @@ mod tests {
         let data_b = random_f32_vec(initial_size, 43, -0.5, 0.5);
         rt.set_data(a, data_a.clone());
         rt.set_data(b, data_b.clone());
-        cx.build_search_space::<CudaRuntime>();
-        rt = cx.search(rt, 5);
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::new(5));
 
         // Initial execution
         rt.execute(&cx.dyn_map);

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -1307,7 +1307,7 @@ impl Runtime for CudaRuntime {
 
     fn late_egglog_passes(
         ops: &[Arc<Box<dyn luminal::op::EgglogOp>>],
-        options: &luminal::graph::BuildSearchSpaceOptions,
+        options: &luminal::graph::CompileOptions,
         dyn_map: &FxHashMap<char, usize>,
     ) -> Vec<luminal::egglog_utils::LateEgglogPass> {
         vec![crate::memory_analysis::cuda_memory_analysis_pass(

--- a/crates/luminal_cuda_lite/src/tests/bucket_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/bucket_tests.rs
@@ -22,6 +22,10 @@ fn build_dynamic_matmul_graph(k: usize, n: usize) -> (Graph, NodeIndex, NodeInde
     (cx, a.id, b.id, c.id)
 }
 
+fn bucket_options(buckets: &[DimBucket]) -> CompileOptions {
+    CompileOptions::default().dim_buckets('s', buckets)
+}
+
 #[test]
 fn test_bucket_dispatch_simple() {
     // Tests that bucketed compilation produces correct results for different dim values
@@ -31,9 +35,10 @@ fn test_bucket_dispatch_simple() {
 
     let (mut cx, a, b) = build_dynamic_add_graph();
 
-    cx.set_dim_buckets('s', &[DimBucket::new(1, 1), DimBucket::new(2, 4)]);
-
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(bucket_options(&[
+        DimBucket::new(1, 1),
+        DimBucket::new(2, 4),
+    ]));
     let mut rt = CudaRuntime::initialize(stream);
 
     // Set dummy input for search
@@ -41,7 +46,7 @@ fn test_bucket_dispatch_simple() {
     rt.set_data(a, vec![1.0f32; 4]);
 
     let mut rng = SmallRng::seed_from_u64(42);
-    rt = cx.search_options(rt, SearchOptions::new(5), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(5), &mut rng);
 
     // Test bucket 1: s=1
     cx.set_dim('s', 1);
@@ -73,9 +78,10 @@ fn test_bucket_matmul_dynamic() {
     let n = 4;
     let (mut cx, a, b_tensor, c) = build_dynamic_matmul_graph(k, n);
 
-    cx.set_dim_buckets('s', &[DimBucket::new(1, 1), DimBucket::new(2, 8)]);
-
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(bucket_options(&[
+        DimBucket::new(1, 1),
+        DimBucket::new(2, 8),
+    ]));
     let mut rt = CudaRuntime::initialize(stream);
 
     cx.set_dim('s', 1);
@@ -85,7 +91,7 @@ fn test_bucket_matmul_dynamic() {
     rt.set_data(b_tensor, b_data.clone());
 
     let mut rng = SmallRng::seed_from_u64(42);
-    rt = cx.search_options(rt, SearchOptions::new(5), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(5), &mut rng);
 
     // Execute at s=1
     cx.set_dim('s', 1);
@@ -135,12 +141,12 @@ fn test_bucket_results_match_unbucketed() {
     // Non-bucketed run
     let (mut cx1, a1, b1) = build_dynamic_add_graph();
     cx1.set_dim('s', 3);
-    cx1.build_search_space::<CudaRuntime>();
+    cx1.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt1 = CudaRuntime::initialize(stream.clone());
     let input_data = random_f32_vec(12, seed, -1.0, 1.0);
     rt1.set_data(a1, input_data.clone());
     let mut rng1 = SmallRng::seed_from_u64(seed);
-    rt1 = cx1.search_options(rt1, SearchOptions::new(5), &mut rng1);
+    rt1 = cx1.search_with_rng(rt1, CompileOptions::new(5), &mut rng1);
     rt1.set_data(a1, input_data.clone());
     rt1.execute(&cx1.dyn_map);
     let result_unbucketed = rt1.get_f32(b1);
@@ -148,12 +154,11 @@ fn test_bucket_results_match_unbucketed() {
     // Bucketed run with bucket that covers s=3
     let (mut cx2, a2, b2) = build_dynamic_add_graph();
     cx2.set_dim('s', 3);
-    cx2.set_dim_buckets('s', &[DimBucket::new(1, 4)]);
-    cx2.build_search_space::<CudaRuntime>();
+    cx2.build_search_space::<CudaRuntime>(bucket_options(&[DimBucket::new(1, 4)]));
     let mut rt2 = CudaRuntime::initialize(stream.clone());
     rt2.set_data(a2, input_data.clone());
     let mut rng2 = SmallRng::seed_from_u64(seed);
-    rt2 = cx2.search_options(rt2, SearchOptions::new(5), &mut rng2);
+    rt2 = cx2.search_with_rng(rt2, CompileOptions::new(5), &mut rng2);
     rt2.set_data(a2, input_data.clone());
     rt2.execute(&cx2.dyn_map);
     let result_bucketed = rt2.get_f32(b2);
@@ -172,14 +177,16 @@ fn test_bucket_out_of_range_panics() {
     };
 
     let (mut cx, a, _b) = build_dynamic_add_graph();
-    cx.set_dim_buckets('s', &[DimBucket::new(1, 1), DimBucket::new(2, 4)]);
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(bucket_options(&[
+        DimBucket::new(1, 1),
+        DimBucket::new(2, 4),
+    ]));
     let mut rt = CudaRuntime::initialize(stream);
     cx.set_dim('s', 1);
     rt.set_data(a, vec![1.0f32; 4]);
     let mut rng = SmallRng::seed_from_u64(42);
-    rt = cx.search_options(rt, SearchOptions::new(3), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(3), &mut rng);
 
     // s=10 is outside all buckets — should panic
     cx.set_dim('s', 10);
@@ -197,14 +204,14 @@ fn test_bucket_no_buckets_backward_compat() {
     let (mut cx, a, b) = build_dynamic_add_graph();
     cx.set_dim('s', 2);
 
-    // No set_dim_buckets call
+    // No bucket options
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream);
     let input_data = vec![1.0f32, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0];
     rt.set_data(a, input_data.clone());
     let mut rng = SmallRng::seed_from_u64(42);
-    rt = cx.search_options(rt, SearchOptions::new(3), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(3), &mut rng);
 
     rt.set_data(a, input_data.clone());
     rt.execute(&cx.dyn_map);
@@ -237,9 +244,10 @@ fn test_bucket_switch_preserves_weights() {
     let n = 4;
     let (mut cx, a, b_tensor, c) = build_dynamic_matmul_graph(k, n);
 
-    cx.set_dim_buckets('s', &[DimBucket::new(1, 1), DimBucket::new(2, 4)]);
-
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(bucket_options(&[
+        DimBucket::new(1, 1),
+        DimBucket::new(2, 4),
+    ]));
     let mut rt = CudaRuntime::initialize(stream);
 
     cx.set_dim('s', 1);
@@ -249,7 +257,7 @@ fn test_bucket_switch_preserves_weights() {
     rt.set_data(b_tensor, b_data.clone());
 
     let mut rng = SmallRng::seed_from_u64(42);
-    rt = cx.search_options(rt, SearchOptions::new(5), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(5), &mut rng);
 
     // Execute with bucket 1 (s=1)
     cx.set_dim('s', 1);
@@ -297,15 +305,13 @@ fn test_bucket_multiple_executions_same_bucket() {
 
     let (mut cx, a, b) = build_dynamic_add_graph();
 
-    cx.set_dim_buckets('s', &[DimBucket::new(1, 8)]);
-
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(bucket_options(&[DimBucket::new(1, 8)]));
     let mut rt = CudaRuntime::initialize(stream);
 
     cx.set_dim('s', 1);
     rt.set_data(a, vec![1.0f32; 4]);
     let mut rng = SmallRng::seed_from_u64(42);
-    rt = cx.search_options(rt, SearchOptions::new(3), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(3), &mut rng);
 
     // Execute at different sizes within the same bucket
     for s in [1, 2, 4, 8] {
@@ -323,8 +329,7 @@ fn test_bucket_multiple_executions_same_bucket() {
 #[test]
 #[should_panic(expected = "Overlapping buckets")]
 fn test_bucket_overlapping_ranges_panics() {
-    let mut cx = Graph::default();
-    cx.set_dim_buckets('s', &[DimBucket::new(1, 4), DimBucket::new(3, 8)]);
+    let _ = bucket_options(&[DimBucket::new(1, 4), DimBucket::new(3, 8)]);
 }
 
 #[test]

--- a/crates/luminal_cuda_lite/src/tests/consumed_buffer_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/consumed_buffer_tests.rs
@@ -10,7 +10,7 @@ use crate::runtime::CudaRuntime;
 
 /// Helper: build search space and extract all possible kernel names across many random choices.
 fn extract_all_kernel_names(cx: &mut Graph) -> Vec<String> {
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let egraph = cx.egraph().expect("egraph not built");
     let ops = cx.egglog_ops().expect("ops not built");
     let custom_ops = &cx.custom_ops;
@@ -199,7 +199,7 @@ fn test_scatter_execution_correctness() {
 
     let result = src.scatter(indexes, dest).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let egraph = cx.egraph().expect("egraph not built");
     let ops = cx.egglog_ops().expect("ops not built");
 
@@ -298,7 +298,7 @@ fn test_scatter_kv_cache_roundtrip() {
     // Return cache for round-trip
     let cache_output = cache_out.output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let mut rt = CudaRuntime::initialize(stream.clone());
 
@@ -307,7 +307,7 @@ fn test_scatter_kv_cache_roundtrip() {
     rt.set_data(src, vec![10.0f32]);
     rt.set_data(indexes, vec![0i32]);
 
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
 
     // Print and verify which scatter variant was selected
     let scatter_names: Vec<_> = rt
@@ -415,7 +415,7 @@ fn test_scatter_dual_cache() {
     let k_cache_out = k_out.output();
     let v_cache_out = v_out.output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let mut rt = CudaRuntime::initialize(stream.clone());
 
@@ -427,7 +427,7 @@ fn test_scatter_dual_cache() {
 
     // Use seeded search for deterministic variant selection.
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(5), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(5), &mut rng);
 
     // Print and verify selected variants
     let scatter_names: Vec<_> = rt
@@ -535,7 +535,7 @@ fn test_scatter_rows_dynamic_prefill_roundtrip() {
     let gathered = gather_rows(updated, gather_idx, D).output();
     let cache_out = updated.output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     cx.set_dim('s', S);
 
     let mut rt = CudaRuntime::initialize(stream);
@@ -554,7 +554,7 @@ fn test_scatter_rows_dynamic_prefill_roundtrip() {
     rt.set_data(gather_idx, scatter);
     rt.set_data(cache, (0..SLOTS * D).map(|i| i as f32).collect::<Vec<_>>());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
 
     assert_eq!(rt.get_f32(gathered), expected_gather);
@@ -733,7 +733,7 @@ fn test_tiny_gqa_attention_batched_matches_sequential_prefill() {
 
     cx.set_dim('s', S);
     cx.set_dim('c', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let q_data: Vec<f32> = (0..S * Q_DIM)
         .map(|i| ((i as f32 + 1.0) * 0.031).sin())
@@ -763,7 +763,7 @@ fn test_tiny_gqa_attention_batched_matches_sequential_prefill() {
     rt.set_data(k_cache, zero_k.clone());
     rt.set_data(v_cache, zero_v.clone());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let batched_attn = rt.get_f32(attn_out);
     let batched_k = rt.get_f32(k_out);
@@ -844,7 +844,7 @@ fn test_original_gqa_attention_batched_matches_sequential_prefill() {
 
     cx.set_dim('s', S);
     cx.set_dim('p', 0);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let q_data: Vec<f32> = (0..S * Q_DIM)
         .map(|i| ((i as f32 + 1.0) * 0.031).sin())
@@ -865,7 +865,7 @@ fn test_original_gqa_attention_batched_matches_sequential_prefill() {
     rt.set_data(k_cache, zero_k.clone());
     rt.set_data(v_cache, zero_v.clone());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let batched_attn = rt.get_f32(attn_out);
     let batched_k = rt.get_f32(k_out);
@@ -925,7 +925,7 @@ fn test_dynamic_expanded_causal_mask_softmax() {
 
     cx.set_dim('s', S);
     cx.set_dim('c', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let mut mask_data = vec![0.0f32; S * S];
     for row in 0..S {
@@ -937,7 +937,7 @@ fn test_dynamic_expanded_causal_mask_softmax() {
     let mut rt = CudaRuntime::initialize(stream);
     rt.set_data(mask, mask_data);
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_f32(weights);
 
@@ -991,7 +991,7 @@ fn test_tiny_gqa_value_matmul_with_expanded_kv() {
 
     cx.set_dim('s', S);
     cx.set_dim('c', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let v_data: Vec<f32> = (0..S * KV_DIM)
         .map(|i| ((i as f32 + 5.0) * 0.029).sin())
@@ -1007,7 +1007,7 @@ fn test_tiny_gqa_value_matmul_with_expanded_kv() {
     rt.set_data(v_full, v_data.clone());
     rt.set_data(mask, mask_data);
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_f32(out);
 
@@ -1055,7 +1055,7 @@ fn test_broadcast_merge_gqa_value_matmul_matches_cpu() {
 
     cx.set_dim('s', S);
     cx.set_dim('c', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let v_data: Vec<f32> = (0..N_KV_HEADS * S * HEAD_DIM)
         .map(|i| ((i as f32 + 5.0) * 0.029).sin())
@@ -1073,7 +1073,7 @@ fn test_broadcast_merge_gqa_value_matmul_matches_cpu() {
     rt.set_data(v_full, v_data.clone());
     rt.set_data(weights, weights_data);
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_f32(out);
 
@@ -1115,7 +1115,7 @@ fn test_transpose_merge_split_roundtrip_matches_cpu() {
     let roundtrip = flat.split_dims(1, D).transpose(0, 1).output();
 
     cx.set_dim('s', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let x_data: Vec<f32> = (0..H * S * D)
         .map(|i| ((i as f32 + 0.75) * 0.051).sin())
@@ -1124,7 +1124,7 @@ fn test_transpose_merge_split_roundtrip_matches_cpu() {
     let mut rt = CudaRuntime::initialize(stream);
     rt.set_data(x, x_data.clone());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_f32(roundtrip);
 
@@ -1158,7 +1158,7 @@ fn test_batched_moe_x_expand_matmul_matches_cpu() {
         .output();
 
     cx.set_dim('s', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let x_data: Vec<f32> = (0..S * H)
         .map(|i| ((i as f32 + 0.5) * 0.137).sin())
@@ -1171,7 +1171,7 @@ fn test_batched_moe_x_expand_matmul_matches_cpu() {
     rt.set_data(x, x_data.clone());
     rt.set_data(w, w_data.clone());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_f32(out);
 
@@ -1211,7 +1211,7 @@ fn test_batched_topk_axis1_matches_cpu() {
     let topk = routing.topk_indexes(K, 1).output();
 
     cx.set_dim('s', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let routing_data: Vec<f32> = (0..S * E)
         .map(|i| ((i as f32 + 3.25) * 0.113).sin() + ((i as f32 + 7.0) * 0.019).cos() * 0.1)
@@ -1220,7 +1220,7 @@ fn test_batched_topk_axis1_matches_cpu() {
     let mut rt = CudaRuntime::initialize(stream);
     rt.set_data(routing, routing_data.clone());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_i32(topk);
 
@@ -1250,7 +1250,7 @@ fn test_batched_argsort_axis1_matches_cpu() {
     let argsort = routing.argsort(1, true).output();
 
     cx.set_dim('s', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let routing_data: Vec<f32> = (0..S * E)
         .map(|i| ((i as f32 + 3.25) * 0.113).sin() + ((i as f32 + 7.0) * 0.019).cos() * 0.1)
@@ -1259,7 +1259,7 @@ fn test_batched_argsort_axis1_matches_cpu() {
     let mut rt = CudaRuntime::initialize(stream);
     rt.set_data(routing, routing_data.clone());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_i32(argsort);
 
@@ -1290,7 +1290,7 @@ fn test_dynamic_3d_sum_axis1_matches_cpu() {
     let out = input.sum(1).output();
 
     cx.set_dim('s', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let data: Vec<f32> = (0..S * A * B)
         .map(|i| ((i as f32 + 4.0) * 0.031).sin())
@@ -1299,7 +1299,7 @@ fn test_dynamic_3d_sum_axis1_matches_cpu() {
     let mut rt = CudaRuntime::initialize(stream);
     rt.set_data(input, data.clone());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_f32(out);
 
@@ -1347,7 +1347,7 @@ fn test_batched_argsort_ranks_axis1_matches_cpu() {
         .output();
 
     cx.set_dim('s', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let routing_data: Vec<f32> = (0..S * E)
         .map(|i| ((i as f32 + 3.25) * 0.113).sin() + ((i as f32 + 7.0) * 0.019).cos() * 0.1)
@@ -1356,7 +1356,7 @@ fn test_batched_argsort_ranks_axis1_matches_cpu() {
     let mut rt = CudaRuntime::initialize(stream);
     rt.set_data(routing, routing_data.clone());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_i32(ranks);
 
@@ -1391,11 +1391,11 @@ fn test_dynamic_3d_flat_index_iota_rows() {
         .output();
 
     cx.set_dim('s', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let mut rt = CudaRuntime::initialize(stream);
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_i32(idx);
 
@@ -1431,14 +1431,14 @@ fn test_dynamic_2d_to_3d_gather_rows() {
     let out = data.gather(idx).output();
 
     cx.set_dim('s', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let data_values: Vec<i32> = (0..S * E).map(|i| ((i * 17 + 5) % 1000) as i32).collect();
 
     let mut rt = CudaRuntime::initialize(stream);
     rt.set_data(data, data_values.clone());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_i32(out);
 
@@ -1479,7 +1479,7 @@ fn test_batched_gather_experts_matches_cpu() {
     let out = weights.gather(exp_base + exp_within).output();
 
     cx.set_dim('s', S);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let topk_data: Vec<i32> = (0..S * K).map(|i| ((i * 5 + 3) % E) as i32).collect();
     let weights_data: Vec<f32> = (0..E * D1 * D2)
@@ -1490,7 +1490,7 @@ fn test_batched_gather_experts_matches_cpu() {
     rt.set_data(topk, topk_data.clone());
     rt.set_data(weights, weights_data.clone());
     let mut rng = rand::rngs::SmallRng::seed_from_u64(0);
-    rt = cx.search_options(rt, SearchOptions::new(10), &mut rng);
+    rt = cx.search_with_rng(rt, CompileOptions::new(10), &mut rng);
     rt.execute(&cx.dyn_map);
     let got = rt.get_f32(out);
 

--- a/crates/luminal_cuda_lite/src/tests/conv2d_rewrite.rs
+++ b/crates/luminal_cuda_lite/src/tests/conv2d_rewrite.rs
@@ -132,7 +132,7 @@ fn conv2d_matmul_without_conv_output_shape(
 #[test]
 fn generic_conv2d_rewrite_matches_unfold_matmul_bias() {
     let (mut cx, _, _, _, _) = build_conv_graph();
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let egraph = cx.egraph().expect("search space should have an e-graph");
 
     assert!(
@@ -148,7 +148,7 @@ fn generic_conv2d_rewrite_matches_unfold_matmul_bias() {
 #[test]
 fn generic_conv2d_rewrite_matches_conv1x1_matmul_bias() {
     let (mut cx, _, _, _, _) = build_conv1x1_graph();
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let egraph = cx.egraph().expect("search space should have an e-graph");
 
     assert!(
@@ -165,7 +165,7 @@ fn generic_conv2d_rewrite_requires_conv_output_shape() {
     let bias = cx.tensor(3usize);
     conv2d_matmul_without_conv_output_shape(x, weight, bias, 3, 2).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let egraph = cx.egraph().expect("search space should have an e-graph");
 
     assert!(
@@ -181,7 +181,7 @@ fn generic_conv2d_candidate_executes_unfold_matmul_bias() {
     };
 
     let (mut cx, x, weight, bias, out) = build_conv_graph();
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let llir = extract_forced_kernel_llir(&mut cx, "GenericConv2D");
 
     let input: Vec<f32> = (0..2 * 5 * 6).map(|i| i as f32 * 0.03 - 0.4).collect();
@@ -222,7 +222,7 @@ fn generic_conv2d_candidate_executes_conv1x1_matmul_bias() {
     };
 
     let (mut cx, x, weight, bias, out) = build_conv1x1_graph();
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let llir = extract_forced_kernel_llir(&mut cx, "GenericConv2D");
 
     let input: Vec<f32> = (0..2 * 4 * 5).map(|i| i as f32 * 0.07 - 1.0).collect();
@@ -261,7 +261,7 @@ fn generic_conv2d_candidate_executes_padded_unfold_matmul_bias() {
     };
 
     let (mut cx, x, weight, bias, out) = build_padded_conv_graph();
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let llir = extract_forced_kernel_llir(&mut cx, "GenericConv2D");
 
     let input: Vec<f32> = (0..2 * 4 * 5).map(|i| i as f32 * 0.05 - 0.5).collect();
@@ -302,7 +302,7 @@ fn generic_conv2d_candidate_executes_upsample_view_input() {
     };
 
     let (mut cx, x, weight, bias, out) = build_upsample_conv_graph();
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let llir = extract_forced_kernel_llir(&mut cx, "GenericConv2D");
 
     let input: Vec<f32> = (0..2 * 3 * 4).map(|i| i as f32 * 0.09 - 0.8).collect();

--- a/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
@@ -481,7 +481,7 @@ fn cublaslt_cleanup_prunes_flux2_broadcast_mul_fallback() {
     let k = cx.tensor((8usize, 4usize));
     let _out = q.matmul(k.t()).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let egraph = cx.egraph().expect("search space should have an e-graph");
     assert!(
         !cublaslt_ir_nodes(egraph).is_empty(),
@@ -1027,7 +1027,7 @@ fn cublaslt_fp8_scaled_candidate_reaches_fused_output_scale_consumer() {
     let scaled_out = scaled_a.matmul(b).cast(DType::F32) * (a_scale * b_scale).expand_rhs((m, n));
     (scaled_out * side).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let egraph = cx.egraph().expect("search space should have an e-graph");
 
     assert!(
@@ -1061,7 +1061,7 @@ fn cublaslt_fp8_scaled_candidates_reach_fused_mlp_consumer() {
         * (up_input_scale * up_weight_scale).expand_rhs((m, n));
     (gate.swish() * up).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let egraph = cx.egraph().expect("search space should have an e-graph");
 
     assert!(
@@ -2936,7 +2936,7 @@ fn extract_forced_cublaslt_llir_where(
     case_name: &str,
     matches: impl Fn(&LLIRGraph) -> bool,
 ) -> LLIRGraph {
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let egraph = cx.egraph().expect("search space should have an e-graph");
     let ops = cx
@@ -2991,7 +2991,7 @@ fn assert_no_forced_cublaslt_llir_where(
     case_name: &str,
     matches: impl Fn(&LLIRGraph) -> bool,
 ) {
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let egraph = cx.egraph().expect("search space should have an e-graph");
     let ops = cx
@@ -3040,7 +3040,7 @@ fn assert_no_cublaslt_llir_where(
     case_name: &str,
     matches: impl Fn(&LLIRGraph) -> bool,
 ) {
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let egraph = cx.egraph().expect("search space should have an e-graph");
     let ops = cx

--- a/crates/luminal_cuda_lite/src/tests/flashinfer.rs
+++ b/crates/luminal_cuda_lite/src/tests/flashinfer.rs
@@ -83,13 +83,13 @@ fn run_reference_attention(
     let (mut cx, q_t, k_t, v_t, out_t) = build_attention_graph();
     cx.set_dim('s', batch_size);
     cx.set_dim('c', context_len);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let mut rt = CudaRuntime::initialize(stream.clone());
     rt.set_data(q_t, q.to_vec());
     rt.set_data(k_t, k.to_vec());
     rt.set_data(v_t, v.to_vec());
-    rt = cx.search(rt, 3);
+    rt = cx.search(rt, CompileOptions::new(3));
 
     rt.set_data(q_t, q.to_vec());
     rt.set_data(k_t, k.to_vec());
@@ -779,7 +779,7 @@ fn flashinfer_extraction_reachable_from_search_space() {
     cx.set_dim('s', 1usize);
     cx.set_dim('c', 16usize);
     cx.set_dim('r', 2usize);
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
 
     let egraph = cx
         .egraph()

--- a/crates/luminal_cuda_lite/src/tests/fusion.rs
+++ b/crates/luminal_cuda_lite/src/tests/fusion.rs
@@ -293,7 +293,7 @@ struct FusedRegion {
 /// Helper: collect every distinct fused region reachable across many random
 /// extractions of the search space.
 fn extract_all_fused_regions(cx: &mut Graph) -> Vec<FusedRegion> {
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let egraph = cx.egraph().expect("egraph not built");
     let ops = cx.egglog_ops().expect("ops not built");
     let custom_ops = &cx.custom_ops;

--- a/crates/luminal_cuda_lite/src/tests/generic_matmul_rewrite.rs
+++ b/crates/luminal_cuda_lite/src/tests/generic_matmul_rewrite.rs
@@ -24,7 +24,7 @@ fn generic_matmul_covers_noncontiguous_merged_head_projection() {
     let merged = attn.transpose(0, 1).merge_dims(1, 2);
     merged.matmul(weight.t()).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let llir = extract_forced_kernel_llir(&mut cx, "GenericMatmul");
     let names = llir_kernel_names(&llir);
 
@@ -52,7 +52,7 @@ fn generic_matmul_executes_noncontiguous_merged_head_projection() {
     let merged = attn.transpose(0, 1).merge_dims(1, 2);
     let output = merged.matmul(weight.t()).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let stream = get_cuda_stream().expect("CUDA device required for GenericMatmul execution test");
     let mut rt = CudaRuntime::initialize(stream);
 
@@ -61,7 +61,7 @@ fn generic_matmul_executes_noncontiguous_merged_head_projection() {
     rt.set_data(attn, attn_data.as_slice());
     rt.set_data(weight, weight_data.as_slice());
 
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     assert!(
         rt.kernel_names().contains(&"GenericMatmul"),
         "expected GenericMatmul to be selected, kernels: {:?}",

--- a/crates/luminal_cuda_lite/src/tests/model_fuzz.rs
+++ b/crates/luminal_cuda_lite/src/tests/model_fuzz.rs
@@ -83,7 +83,7 @@ fn fuzz_mlp(seq: usize, hidden: usize, intermediate: usize, seed: u64) {
     let w_down = cx.tensor((hidden, intermediate));
     let out = swiglu_mlp(input, w_gate, w_up, w_down).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream.clone());
 
     let input_data = random_f32_vec(seq * hidden, seed, -0.5, 0.5);
@@ -95,7 +95,7 @@ fn fuzz_mlp(seq: usize, hidden: usize, intermediate: usize, seed: u64) {
     rt.set_data(w_gate, gate_data.clone());
     rt.set_data(w_up, up_data.clone());
     rt.set_data(w_down, down_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
     let result = rt.get_f32(out);
 
@@ -143,7 +143,7 @@ fn fuzz_norm_proj(seq: usize, hidden: usize, proj_dim: usize, eps: f32, seed: u6
     let proj_w = cx.tensor((proj_dim, hidden));
     let out = rms_norm(input, norm_w, eps).matmul(proj_w.t()).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream.clone());
 
     let input_data = random_f32_vec(seq * hidden, seed, -0.5, 0.5);
@@ -156,7 +156,7 @@ fn fuzz_norm_proj(seq: usize, hidden: usize, proj_dim: usize, eps: f32, seed: u6
     rt.set_data(input, input_data.clone());
     rt.set_data(norm_w, norm_data.clone());
     rt.set_data(proj_w, proj_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
     let result = rt.get_f32(out);
 
@@ -219,7 +219,7 @@ fn fuzz_layer_no_attn(
     let mlp_out = swiglu_mlp(mlp_normed, w_gate, w_up, w_down);
     let out = (x + mlp_out).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream.clone());
 
     let input_data = random_f32_vec(seq * hidden, seed, -0.5, 0.5);
@@ -245,7 +245,7 @@ fn fuzz_layer_no_attn(
     rt.set_data(w_gate, gate_data.clone());
     rt.set_data(w_up, up_data.clone());
     rt.set_data(w_down, down_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
     let result = rt.get_f32(out);
 
@@ -318,7 +318,7 @@ fn fuzz_mlp_hlir_only(seq: usize, hidden: usize, intermediate: usize, seed: u64)
     let w_down = cx.tensor((hidden, intermediate));
     let out = swiglu_mlp(input, w_gate, w_up, w_down).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream.clone());
 
     let input_data = random_f32_vec(seq * hidden, seed, -0.5, 0.5);
@@ -330,7 +330,7 @@ fn fuzz_mlp_hlir_only(seq: usize, hidden: usize, intermediate: usize, seed: u64)
     rt.set_data(w_gate, gate_data.clone());
     rt.set_data(w_up, up_data.clone());
     rt.set_data(w_down, down_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
     let result = rt.get_f32(out);
 
@@ -481,7 +481,7 @@ mod gemma {
         let mlp_normed = rms_norm(mlp_out, post_ff_norm_w, EPS);
         let out = (x + mlp_normed).output();
 
-        cx.build_search_space::<CudaRuntime>();
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
         let mut rt = CudaRuntime::initialize(stream.clone());
 
         let seed = 800u64;
@@ -518,7 +518,7 @@ mod gemma {
         rt.set_data(w_gate, gate_data.clone());
         rt.set_data(w_up, up_data.clone());
         rt.set_data(w_down, down_data.clone());
-        rt = cx.search(rt, 5);
+        rt = cx.search(rt, CompileOptions::new(5));
         rt.execute(&cx.dyn_map);
         let result = rt.get_f32(out);
 
@@ -641,7 +641,7 @@ mod qwen {
         let embedding = cx.tensor((VOCAB, HIDDEN));
         let out = rms_norm(input, norm_w, EPS).matmul(embedding.t()).output();
 
-        cx.build_search_space::<CudaRuntime>();
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
         let mut rt = CudaRuntime::initialize(stream.clone());
 
         let seed = 1300u64;
@@ -655,7 +655,7 @@ mod qwen {
         rt.set_data(input, input_data.clone());
         rt.set_data(norm_w, norm_data.clone());
         rt.set_data(embedding, emb_data.clone());
-        rt = cx.search(rt, 5);
+        rt = cx.search(rt, CompileOptions::new(5));
         rt.execute(&cx.dyn_map);
         let result = rt.get_f32(out);
 

--- a/crates/luminal_cuda_lite/src/tests/op_functional_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/op_functional_tests.rs
@@ -256,10 +256,10 @@ fn run_argsort_test(rows: usize, cols: usize, seed: u64) {
     let ctx = CudaContext::new(0).unwrap();
     ctx.bind_to_thread().unwrap();
     let stream = ctx.default_stream();
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream);
     rt.set_data(input, data);
-    rt = cx.search(rt, 10);
+    rt = cx.search(rt, CompileOptions::new(10));
     rt.execute(&cx.dyn_map);
     let out_dim0 = rt.get_i32(sorted_dim0.id);
     let out_dim1 = rt.get_i32(sorted_dim1.id);
@@ -424,7 +424,7 @@ fn fuzz_test_cuda_genomes_impl(seed: u64) {
     let e = (d + c).relu();
     let out = e.output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let egraph = cx.egraph().unwrap();
     let ops = cx.egglog_ops().unwrap();
 
@@ -592,7 +592,7 @@ fn run_embed_test(vocab_size: usize, embed_dim: usize, seq_len: usize, seed: u64
         )
         .output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream.clone());
 
     let token_data: Vec<i32> = random_i32_vec(seq_len, seed, 0, vocab_size as i32 - 1);
@@ -600,7 +600,7 @@ fn run_embed_test(vocab_size: usize, embed_dim: usize, seq_len: usize, seed: u64
 
     rt.set_data(token_ids, token_data.clone());
     rt.set_data(embed_table, embed_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
 
     let result = rt.get_f32(output);

--- a/crates/luminal_cuda_lite/src/tests/performance_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/performance_tests.rs
@@ -27,11 +27,11 @@ pub fn kernel_add_bandwidth_test() {
     ctx.bind_to_thread().unwrap();
     let stream = ctx.default_stream();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream.clone());
     rt.set_data(a, data_a.clone());
     rt.set_data(b, data_b.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
 
     // Warm up
     rt.execute(&cx.dyn_map);

--- a/crates/luminal_cuda_lite/src/tests/qwen3_moe_rewrite.rs
+++ b/crates/luminal_cuda_lite/src/tests/qwen3_moe_rewrite.rs
@@ -208,11 +208,13 @@ fn run_qwen_moe(include_glumoe: bool) -> Vec<f32> {
     let mut model = build_qwen_moe_graph();
     model.graph.set_dim('s', SEQ);
     if include_glumoe {
-        model.graph.build_search_space::<CudaRuntime>();
+        model
+            .graph
+            .build_search_space::<CudaRuntime>(CompileOptions::default());
     } else {
         model
             .graph
-            .build_search_space_exclude_ops::<CudaRuntime, GLUMoE>();
+            .build_search_space_exclude_ops::<CudaRuntime, GLUMoE>(CompileOptions::default());
     }
 
     let x_data = random_f32_vec(SEQ * HIDDEN, 11, -0.15, 0.15);
@@ -231,7 +233,7 @@ fn run_qwen_moe(include_glumoe: bool) -> Vec<f32> {
     rt.set_data(model.router, router_data);
     rt.set_data(model.gate_up_weights, gate_up_data);
     rt.set_data(model.down_weights, down_data);
-    rt = model.graph.search(rt, 10);
+    rt = model.graph.search(rt, CompileOptions::new(10));
     rt.execute(&model.graph.dyn_map);
 
     rt.get_f32(model.output.id)
@@ -245,11 +247,13 @@ fn run_gemma_moe(include_glumoe: bool) -> Vec<f32> {
     let mut model = build_gemma_moe_graph();
     model.graph.set_dim('s', SEQ);
     if include_glumoe {
-        model.graph.build_search_space::<CudaRuntime>();
+        model
+            .graph
+            .build_search_space::<CudaRuntime>(CompileOptions::default());
     } else {
         model
             .graph
-            .build_search_space_exclude_ops::<CudaRuntime, GLUMoE>();
+            .build_search_space_exclude_ops::<CudaRuntime, GLUMoE>(CompileOptions::default());
     }
 
     let router_input_data = random_f32_vec(SEQ * HIDDEN, 21, -0.15, 0.15);
@@ -274,7 +278,7 @@ fn run_gemma_moe(include_glumoe: bool) -> Vec<f32> {
     rt.set_data(model.per_expert_scale, per_expert_scale_data);
     rt.set_data(model.gate_up_weights, gate_up_data);
     rt.set_data(model.down_weights, down_data);
-    rt = model.graph.search(rt, 10);
+    rt = model.graph.search(rt, CompileOptions::new(10));
     rt.execute(&model.graph.dyn_map);
 
     rt.get_f32(model.output.id)
@@ -288,7 +292,9 @@ fn test_glumoe_matches_qwen_swiglu_pattern() {
 
     let mut model = build_qwen_moe_graph();
     model.graph.set_dim('s', SEQ);
-    model.graph.build_search_space::<CudaRuntime>();
+    model
+        .graph
+        .build_search_space::<CudaRuntime>(CompileOptions::default());
     assert_glumoe_in_search_space(&model.graph);
 }
 
@@ -300,7 +306,9 @@ fn test_glumoe_matches_gemma_gelu_pattern() {
 
     let mut model = build_gemma_moe_graph();
     model.graph.set_dim('s', SEQ);
-    model.graph.build_search_space::<CudaRuntime>();
+    model
+        .graph
+        .build_search_space::<CudaRuntime>(CompileOptions::default());
     assert_glumoe_in_search_space(&model.graph);
 }
 

--- a/crates/luminal_cuda_lite/src/tests/rope_test.rs
+++ b/crates/luminal_cuda_lite/src/tests/rope_test.rs
@@ -1,5 +1,8 @@
 use cudarc::driver::CudaContext;
-use luminal::{graph::Graph, op::Runtime};
+use luminal::{
+    graph::{CompileOptions, Graph},
+    op::Runtime,
+};
 
 use crate::{kernel::apply_rope, runtime::CudaRuntime};
 
@@ -42,12 +45,12 @@ fn rope_matches_cpu_reference() {
     let ctx = CudaContext::new(0).unwrap();
     ctx.bind_to_thread().unwrap();
     let stream = ctx.default_stream();
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream);
     rt.set_data(x, x_data.clone());
     rt.set_data(cos, cos_data.clone());
     rt.set_data(sin, sin_data.clone());
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.execute(&cx.dyn_map);
     let got = rt.get_f32(y.id);
 
@@ -90,12 +93,12 @@ fn rope_flux2_shape() {
     let ctx = CudaContext::new(0).unwrap();
     ctx.bind_to_thread().unwrap();
     let stream = ctx.default_stream();
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream);
     rt.set_data(x, x_data.clone());
     rt.set_data(cos, cos_data.clone());
     rt.set_data(sin, sin_data.clone());
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.execute(&cx.dyn_map);
     let got = rt.get_f32(y.id);
 

--- a/crates/luminal_cuda_lite/src/tests/search_equivalence_fuzz.rs
+++ b/crates/luminal_cuda_lite/src/tests/search_equivalence_fuzz.rs
@@ -92,7 +92,7 @@ fn llama_architecture_search_space_equivalence_fuzz() {
         .samples(SEARCH_EQUIV_SAMPLES)
         .generation_size(8)
         .mutations(3)
-        .build_options(BuildSearchSpaceOptions::new().max_memory_mib(512))
+        .build_options(CompileOptions::default().max_memory_mib(512))
         .output_f32(logits.id, "logits", 5e-2, 5e-2);
     for (layer, (k_out, v_out)) in cache_outputs.into_iter().enumerate() {
         let k_out = k_out.output();
@@ -168,7 +168,7 @@ fn gemma_architecture_search_space_equivalence_fuzz() {
         .samples(SEARCH_EQUIV_SAMPLES)
         .generation_size(8)
         .mutations(3)
-        .build_options(BuildSearchSpaceOptions::new().max_memory_mib(512))
+        .build_options(CompileOptions::default().max_memory_mib(512))
         .input_f32(input.id, random_f32_vec(SEQ * HIDDEN, 101, -0.15, 0.15))
         .input_f32(attn_norm_w.id, random_f32_vec(HIDDEN, 102, 0.7, 1.3))
         .input_f32(post_attn_norm_w.id, random_f32_vec(HIDDEN, 103, 0.7, 1.3))
@@ -263,7 +263,7 @@ fn moe_architecture_search_space_equivalence_fuzz() {
         .samples(SEARCH_EQUIV_SAMPLES)
         .generation_size(8)
         .mutations(3)
-        .build_options(BuildSearchSpaceOptions::new().max_memory_mib(512))
+        .build_options(CompileOptions::default().max_memory_mib(512))
         .input_f32(
             router_input.id,
             random_f32_vec(SEQ * HIDDEN, 201, -0.15, 0.15),
@@ -353,7 +353,7 @@ fn moe_architecture_native_reference_fuzz() {
         .samples(SEARCH_EQUIV_SAMPLES)
         .generation_size(8)
         .mutations(3)
-        .build_options(BuildSearchSpaceOptions::new().max_memory_mib(512))
+        .build_options(CompileOptions::default().max_memory_mib(512))
         .native_reference()
         .input_f32(input.id, random_f32_vec(SEQ * HIDDEN, 301, -0.15, 0.15))
         .input_f32(

--- a/crates/luminal_cuda_lite/src/tests/transformer.rs
+++ b/crates/luminal_cuda_lite/src/tests/transformer.rs
@@ -267,7 +267,7 @@ fn test_mini_transformer_layer() {
     let layer = MiniTransformerLayer::init(&mut cx);
     let out = layer.forward(input).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream);
 
     let input_data = random_f32_vec(SEQ * HIDDEN, 42, -0.5, 0.5);
@@ -280,7 +280,7 @@ fn test_mini_transformer_layer() {
 
     // Use minimal search iterations to avoid excessive graph rewriting
     // which can cause float drift through softmax/RMSNorm reordering
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.execute(&cx.dyn_map);
     let result = rt.get_f32(out);
 
@@ -303,7 +303,7 @@ fn test_mini_transformer_two_layers() {
     let x = layer1.forward(input);
     let out = layer2.forward(x).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream);
 
     let input_data = random_f32_vec(SEQ * HIDDEN, 42, -0.5, 0.5);
@@ -316,7 +316,7 @@ fn test_mini_transformer_two_layers() {
         rt.set_data(*tensor, data.clone());
     }
 
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.execute(&cx.dyn_map);
     let result = rt.get_f32(out);
 
@@ -361,7 +361,7 @@ fn test_transformer_multi_seed() {
         let layer = MiniTransformerLayer::init(&mut cx);
         let out = layer.forward(input).output();
 
-        cx.build_search_space::<CudaRuntime>();
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
         let mut rt = CudaRuntime::initialize(stream.clone());
 
         let input_data = random_f32_vec(SEQ * HIDDEN, seed, -0.5, 0.5);
@@ -372,7 +372,7 @@ fn test_transformer_multi_seed() {
             rt.set_data(*tensor, data.clone());
         }
 
-        rt = cx.search(rt, 1);
+        rt = cx.search(rt, CompileOptions::new(1));
         rt.execute(&cx.dyn_map);
         let result = rt.get_f32(out);
 
@@ -394,7 +394,7 @@ fn test_rms_norm_cuda() {
     let weight = cx.tensor(HIDDEN);
     let out = rms_norm(input, weight, 1e-5).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream);
 
     let input_data = random_f32_vec(SEQ * HIDDEN, 1, -0.5, 0.5);
@@ -404,7 +404,7 @@ fn test_rms_norm_cuda() {
         .collect();
     rt.set_data(input, input_data.clone());
     rt.set_data(weight, weight_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
     let result = rt.get_f32(out);
 
@@ -433,7 +433,7 @@ fn test_self_attention_cuda() {
     let wo = cx.tensor((HIDDEN, HIDDEN));
     let out = self_attention(input, wq, wk, wv, wo).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream);
 
     let input_data = random_f32_vec(SEQ * HIDDEN, 10, -0.5, 0.5);
@@ -447,7 +447,7 @@ fn test_self_attention_cuda() {
     rt.set_data(wk, wk_data.clone());
     rt.set_data(wv, wv_data.clone());
     rt.set_data(wo, wo_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
     let result = rt.get_f32(out);
 
@@ -479,7 +479,7 @@ fn test_swiglu_mlp_cuda() {
     let w_down = cx.tensor((HIDDEN, INTERMEDIATE));
     let out = swiglu_mlp(input, w_gate, w_up, w_down).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream);
 
     let input_data = random_f32_vec(SEQ * HIDDEN, 20, -0.5, 0.5);
@@ -491,7 +491,7 @@ fn test_swiglu_mlp_cuda() {
     rt.set_data(w_gate, gate_data.clone());
     rt.set_data(w_up, up_data.clone());
     rt.set_data(w_down, down_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
     let result = rt.get_f32(out);
 
@@ -526,11 +526,11 @@ fn test_rolled_chained_scalar_muls() {
     let chained = ((x * 2.0_f32) * 3.0_f32) * 5.0_f32;
     let out = (chained + x).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream);
     let x_data = random_f32_vec(4 * 32, 101, -0.5, 0.5);
     rt.set_data(x, x_data.clone());
-    rt = cx.search(rt, 3);
+    rt = cx.search(rt, CompileOptions::new(3));
     rt.execute(&cx.dyn_map);
 
     let result = rt.get_f32(out);

--- a/crates/luminal_cuda_lite/src/tests/utilities.rs
+++ b/crates/luminal_cuda_lite/src/tests/utilities.rs
@@ -184,7 +184,7 @@ pub struct SearchEquivalenceFuzzConfig {
     pub generation_size: usize,
     pub mutations: usize,
     pub max_attempts: usize,
-    pub build_options: BuildSearchSpaceOptions,
+    pub build_options: CompileOptions,
     pub reference: SearchEquivalenceReference,
 }
 
@@ -202,7 +202,7 @@ impl Default for SearchEquivalenceFuzzConfig {
             generation_size: 16,
             mutations: 2,
             max_attempts: 1_000,
-            build_options: BuildSearchSpaceOptions::default(),
+            build_options: CompileOptions::default(),
             reference: SearchEquivalenceReference::FirstCudaExtraction,
         }
     }
@@ -258,7 +258,7 @@ impl<'a> CudaSearchEquivalenceFuzzer<'a> {
         self
     }
 
-    pub fn build_options(mut self, build_options: BuildSearchSpaceOptions) -> Self {
+    pub fn build_options(mut self, build_options: CompileOptions) -> Self {
         self.config.build_options = build_options;
         self
     }
@@ -327,11 +327,11 @@ pub fn fuzz_cuda_search_space_equivalence(
 
     let native_reference_outputs = if config.reference == SearchEquivalenceReference::NativeRuntime
     {
-        cx.build_search_space::<NativeRuntime>();
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
         let mut native_rng = StdRng::seed_from_u64(config.seed);
-        let mut native_rt = cx.search_options(
+        let mut native_rt = cx.search_with_rng(
             NativeRuntime::default(),
-            SearchOptions::new(1),
+            CompileOptions::new(1),
             &mut native_rng,
         );
         for input in inputs {
@@ -348,7 +348,7 @@ pub fn fuzz_cuda_search_space_equivalence(
         None
     };
 
-    cx.build_search_space_with_options::<CudaRuntime>(config.build_options);
+    cx.build_search_space::<CudaRuntime>(config.build_options);
 
     let egraph = cx.egraph().expect("search space should be built");
     let ops = cx.egglog_ops().expect("search ops should be built");
@@ -696,12 +696,12 @@ pub fn test_unary_cuda<T: TestDType>(
     let a = cx.tensor(shape.clone());
     let b = func(a).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream.clone());
 
     let input_data = generator(n_elements, seed);
     rt.set_data(a, input_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
 
     let result = T::get_from_runtime(&rt, b.id);
@@ -769,14 +769,14 @@ pub fn test_binary_cuda<T: TestDType>(
     let b = cx.tensor(b_shape.clone());
     let c = func(a, b).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream.clone());
 
     let a_data = a_generator(a_elements, seed);
     let b_data = b_generator(b_elements, seed.wrapping_add(1));
     rt.set_data(a, a_data.clone());
     rt.set_data(b, b_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
 
     let result = T::get_from_runtime(&rt, c.id);
@@ -836,7 +836,7 @@ pub fn test_mod(
     let b = cx.tensor(b_shape.clone());
     let c = func(a, b).output();
 
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     let mut rt = CudaRuntime::initialize(stream.clone());
 
     let a_data = random_f32_vec(a_elements, seed, -0.5, 0.5);
@@ -844,7 +844,7 @@ pub fn test_mod(
     let b_data = random_f32_vec(b_elements, seed.wrapping_add(1), 0.1, 0.5);
     rt.set_data(a, a_data.clone());
     rt.set_data(b, b_data.clone());
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.execute(&cx.dyn_map);
 
     let result = rt.get_f32(c);

--- a/crates/luminal_metal/examples/llama_1b.rs
+++ b/crates/luminal_metal/examples/llama_1b.rs
@@ -1,7 +1,7 @@
 use hf_hub::api::sync::Api;
 use luminal::{
     dtype::DType,
-    graph::{BuildSearchSpaceOptions, DimBucket, Graph},
+    graph::{CompileOptions, DimBucket, Graph},
     prelude::{F32Pow, GraphTensor, Runtime},
 };
 use luminal_metal::MetalRuntime;
@@ -449,12 +449,34 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     cx.set_dim('s', 1);
     cx.set_dim('c', 1);
+    let max_prefill = (prompt_tokens.len() + 16)
+        .next_power_of_two()
+        .min(MAX_SEQ_LEN);
+    let max_context = (prompt_tokens.len() + GEN_TOKENS + 1)
+        .next_power_of_two()
+        .min(MAX_SEQ_LEN);
+    let search_s = 16.min(max_prefill).max(2);
+    let search_c = 16.min(max_context).max(2);
+    let build_options = CompileOptions::default()
+        .max_memory_mib(SEARCH_MEMORY_MIB)
+        .dim_buckets(
+            's',
+            &[
+                DimBucket::new(1, 1),
+                DimBucket::new(2, max_prefill).representative(search_s),
+            ],
+        )
+        .dim_buckets(
+            'c',
+            &[
+                DimBucket::new(1, 1),
+                DimBucket::new(2, max_context).representative(search_c),
+            ],
+        );
 
     println!("Building E-Graph...");
     let egraph_start = Instant::now();
-    cx.build_search_space_with_options::<MetalRuntime>(
-        BuildSearchSpaceOptions::new().max_memory_mib(SEARCH_MEMORY_MIB),
-    );
+    cx.build_search_space::<MetalRuntime>(build_options);
     println!(
         "  E-Graph build: {:.2} s",
         egraph_start.elapsed().as_secs_f64()
@@ -474,28 +496,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     println!("Compiling...");
     let compile_start = Instant::now();
-    let max_prefill = (prompt_tokens.len() + 16)
-        .next_power_of_two()
-        .min(MAX_SEQ_LEN);
-    let max_context = (prompt_tokens.len() + GEN_TOKENS + 1)
-        .next_power_of_two()
-        .min(MAX_SEQ_LEN);
-    let search_s = 16.min(max_prefill).max(2);
-    let search_c = 16.min(max_context).max(2);
-    cx.set_dim_buckets(
-        's',
-        &[
-            DimBucket::new(1, 1),
-            DimBucket::new(2, max_prefill).representative(search_s),
-        ],
-    );
-    cx.set_dim_buckets(
-        'c',
-        &[
-            DimBucket::new(1, 1),
-            DimBucket::new(2, max_context).representative(search_c),
-        ],
-    );
     cx.set_dim('s', search_s);
     cx.set_dim('c', search_c);
     runtime.set_data(input, vec![1; search_s]);
@@ -503,7 +503,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     runtime.set_data(scatter_idx_t, (0..search_s as i32).collect::<Vec<_>>());
     runtime.set_data(gather_idx_t, (0..search_c as i32).collect::<Vec<_>>());
     runtime.set_data(attn_mask_t, vec![0.0f32; search_s * search_c]);
-    runtime = cx.search(runtime, SEARCH_GRAPHS);
+    runtime = cx.search(runtime, CompileOptions::new(SEARCH_GRAPHS));
     println!(
         "  Search/compile: {:.2} s",
         compile_start.elapsed().as_secs_f64()

--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -55,7 +55,7 @@ pub type MetalOps = (
 );
 
 fn compile_shader(device: &Device, source: &str, function_name: &str) -> ComputePipelineState {
-    let options = metal::CompileOptions::default();
+    let options = metal::CompileOptions::new();
     options.set_language_version(MTLLanguageVersion::V2_4);
     let library = device
         .new_library_with_source(source, &options)

--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -55,7 +55,7 @@ pub type MetalOps = (
 );
 
 fn compile_shader(device: &Device, source: &str, function_name: &str) -> ComputePipelineState {
-    let options = metal::CompileOptions::new();
+    let options = metal::CompileOptions::default();
     options.set_language_version(MTLLanguageVersion::V2_4);
     let library = device
         .new_library_with_source(source, &options)

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -326,7 +326,7 @@ impl Runtime for MetalRuntime {
 
     fn late_egglog_passes(
         ops: &[std::sync::Arc<Box<dyn luminal::op::EgglogOp>>],
-        options: &luminal::graph::BuildSearchSpaceOptions,
+        options: &luminal::graph::CompileOptions,
         dyn_map: &FxHashMap<char, usize>,
     ) -> Vec<luminal::egglog_utils::LateEgglogPass> {
         vec![crate::memory_analysis::metal_memory_analysis_pass(

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -41,7 +41,7 @@ fn bytes_of<T: bytemuck::NoUninit>(values: &[T]) -> Vec<u8> {
 
 fn search_candidates(cx: &mut Graph, rt: MetalRuntime, limit: usize) -> MetalRuntime {
     let mut rng = StdRng::seed_from_u64(0);
-    cx.search_options(rt, SearchOptions::new(limit), &mut rng)
+    cx.search_with_rng(rt, CompileOptions::new(limit), &mut rng)
 }
 
 fn egraph_has_op(cx: &Graph, op_name: &str) -> bool {
@@ -297,11 +297,11 @@ fn dynamic_dim_sum_reduce_runs() {
     let input = cx.tensor(('a', 2));
     let output = input.sum(0).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(input, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
 
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -315,13 +315,14 @@ fn metal_bucketed_dynamic_dim_dispatches_correct_graph() {
     let input = cx.tensor(('s', 4));
     let output = (input + input).output();
 
-    cx.set_dim_buckets('s', &[DimBucket::new(1, 1), DimBucket::new(2, 4)]);
     cx.set_dim('s', 1);
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(
+        CompileOptions::default().dim_buckets('s', &[DimBucket::new(1, 1), DimBucket::new(2, 4)]),
+    );
 
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(input, vec![1.0f32; 4]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
 
     cx.set_dim('s', 1);
     let s1_input = vec![1.0, 2.0, 3.0, 4.0];
@@ -346,10 +347,10 @@ fn metal_int_arithmetic_preserves_large_values() {
     let large_index = (token * 1024) + 123;
     let mod_output = (large_index % 65_537).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(token, &[16_385i32]);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -368,11 +369,11 @@ proptest! {
         let input = cx.tensor(len);
         let output = (input + input).output();
 
-        cx.build_search_space::<MetalRuntime>();
+        cx.build_search_space::<MetalRuntime>(CompileOptions::default());
         let mut rt = MetalRuntime::initialize(());
         let input_values: Vec<f32> = values.into_iter().take(len).collect();
         rt.set_data(input, &input_values);
-        rt = cx.search(rt, 5);
+        rt = cx.search(rt, CompileOptions::new(5));
         rt.allocate_intermediate_buffers(&cx.dyn_map);
         rt.execute(&cx.dyn_map);
 
@@ -390,11 +391,11 @@ proptest! {
         let input = cx.tensor(len);
         let output = (input * input).output();
 
-        cx.build_search_space::<MetalRuntime>();
+        cx.build_search_space::<MetalRuntime>(CompileOptions::default());
         let mut rt = MetalRuntime::initialize(());
         let input_values: Vec<f32> = values.into_iter().take(len).collect();
         rt.set_data(input, &input_values);
-        rt = cx.search(rt, 5);
+        rt = cx.search(rt, CompileOptions::new(5));
         rt.allocate_intermediate_buffers(&cx.dyn_map);
         rt.execute(&cx.dyn_map);
 
@@ -412,11 +413,11 @@ proptest! {
         let input = cx.tensor(len);
         let output = input.exp2().output();
 
-        cx.build_search_space::<MetalRuntime>();
+        cx.build_search_space::<MetalRuntime>(CompileOptions::default());
         let mut rt = MetalRuntime::initialize(());
         let input_values: Vec<f32> = values.into_iter().take(len).collect();
         rt.set_data(input, &input_values);
-        rt = cx.search(rt, 5);
+        rt = cx.search(rt, CompileOptions::new(5));
         rt.allocate_intermediate_buffers(&cx.dyn_map);
         rt.execute(&cx.dyn_map);
 
@@ -433,9 +434,7 @@ fn metal_build_search_space_accepts_memory_budget() {
     let b = cx.tensor(4);
     (a * b).output();
 
-    cx.build_search_space_with_options::<MetalRuntime>(
-        BuildSearchSpaceOptions::new().max_memory_mib(1),
-    );
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default().max_memory_mib(1));
 }
 
 /// Simple deterministic test for add
@@ -446,11 +445,11 @@ fn metal_simple_add() {
     let b = cx.tensor(4);
     let output = (a + b).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(a, &[1.0, 2.0, 3.0, 4.0]);
     rt.set_data(b, &[5.0, 6.0, 7.0, 8.0]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -466,11 +465,11 @@ fn metal_simple_mul() {
     let b = cx.tensor(4);
     let output = (a * b).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(a, &[1.0, 2.0, 3.0, 4.0]);
     rt.set_data(b, &[5.0, 6.0, 7.0, 8.0]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -485,10 +484,10 @@ fn metal_simple_exp2() {
     let input = cx.tensor(4);
     let output = input.exp2().output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(input, &[0.0, 1.0, 2.0, 3.0]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -502,10 +501,10 @@ fn metal_simple_log2() {
     let input = cx.tensor(4);
     let output = input.log2().output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(input, &[1.0, 2.0, 4.0, 8.0]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -519,7 +518,7 @@ fn metal_simple_sin() {
     let input = cx.tensor(4);
     let output = input.sin().output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(
         input,
@@ -530,7 +529,7 @@ fn metal_simple_sin() {
             3.0 * std::f32::consts::FRAC_PI_2,
         ],
     );
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -544,10 +543,10 @@ fn metal_simple_sqrt() {
     let input = cx.tensor(4);
     let output = input.sqrt().output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(input, &[1.0, 4.0, 9.0, 16.0]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -561,10 +560,10 @@ fn metal_simple_recip() {
     let input = cx.tensor(4);
     let output = input.reciprocal().output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(input, &[1.0, 2.0, 4.0, 5.0]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -579,11 +578,11 @@ fn metal_simple_mod() {
     let b = cx.tensor(4);
     let output = (a % b).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(a, &[7.0, 10.0, 15.0, 8.5]);
     rt.set_data(b, &[3.0, 4.0, 6.0, 2.5]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -598,11 +597,11 @@ fn metal_simple_less_than() {
     let b = cx.tensor(4);
     let output = a.lt(b).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(a, &[1.0, 5.0, 3.0, 4.0]);
     rt.set_data(b, &[2.0, 3.0, 3.0, 5.0]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -618,11 +617,11 @@ fn metal_simple_sum_reduce() {
     // sum over axis 1
     let output = input.sum(1).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     // [[1,2,3,4], [5,6,7,8]] -> [10, 26]
     rt.set_data(input, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -637,11 +636,11 @@ fn metal_simple_max_reduce() {
     // max over axis 1
     let output = input.max(1).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     // [[1,4,2,3], [8,5,7,6]] -> [4, 8]
     rt.set_data(input, &[1.0, 4.0, 2.0, 3.0, 8.0, 5.0, 7.0, 6.0]);
-    rt = cx.search(rt, 5);
+    rt = cx.search(rt, CompileOptions::new(5));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -655,10 +654,10 @@ fn metal_f16_cast_roundtrip() {
     let input = cx.tensor(4);
     let output = input.cast(DType::F16).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(input, &[1.0, -2.5, 3.25, 4.75]);
-    rt = cx.search(rt, 3);
+    rt = cx.search(rt, CompileOptions::new(3));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -675,11 +674,11 @@ fn metal_f16_intermediate_add_roundtrip() {
         .cast(DType::F32)
         .output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(a, &[1.0, 2.0, -3.0, 4.5]);
     rt.set_data(b, &[0.5, -1.0, 3.0, 0.25]);
-    rt = cx.search(rt, 3);
+    rt = cx.search(rt, CompileOptions::new(3));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -694,7 +693,7 @@ fn metal_specialized_matmul() {
     let b = cx.tensor((TRANSFORMER_HIDDEN, TRANSFORMER_HIDDEN));
     let output = a.matmul(b).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
 
     let a_data = seeded_data(TRANSFORMER_SEQ * TRANSFORMER_HIDDEN, 1.0, -0.5);
@@ -734,7 +733,7 @@ fn metal_regular_tiled_matmul_path() {
     let b = cx.tensor((k, n));
     let output = a.matmul(b).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     assert_matmul_options(&cx, "MPSMatmul");
     let mut rt = MetalRuntime::initialize(());
 
@@ -769,7 +768,7 @@ fn metal_mps_matmul_transposed_rhs_weight_layout() {
     let weight = cx.tensor((n, k));
     let output = a.matmul(weight.t()).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     assert_matmul_options(&cx, "MPSMatmul");
     let mut rt = MetalRuntime::initialize(());
 
@@ -804,7 +803,7 @@ fn metal_mps_matmul_transposed_lhs_layout() {
     let rhs = cx.tensor((k, n));
     let output = lhs_storage.t().matmul(rhs).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     assert_matmul_options(&cx, "MPSMatmul");
     let mut rt = MetalRuntime::initialize(());
 
@@ -843,7 +842,7 @@ fn metal_mps_batched_matmul_row_row_layout() {
     let b = cx.tensor((batch, k, n));
     let output = a.matmul(b).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     assert_matmul_options(&cx, "MPSBatchedMatmul");
     let mut rt = MetalRuntime::initialize(());
 
@@ -887,7 +886,7 @@ fn metal_generic_matmul_covers_noncontiguous_merged_head_projection() {
     let merged = attn.transpose(0, 1).merge_dims(1, 2);
     let output = merged.matmul(weight.t()).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     assert!(
         egraph_has_op(&cx, "GenericMatmul"),
         "expected GenericMatmul rewrite option in e-graph"
@@ -946,7 +945,7 @@ fn metal_mps_batched_matmul_transposed_rhs_layout() {
     let weight = cx.tensor((batch, n, k));
     let output = a.matmul(weight.permute((0, 2, 1))).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     assert_matmul_options(&cx, "MPSBatchedMatmul");
     let mut rt = MetalRuntime::initialize(());
 
@@ -987,7 +986,7 @@ fn metal_mps_matmul_f16_transposed_rhs_weight_layout() {
     let weight = cx.tensor((n, k)).as_dtype(DType::F16);
     let output = a.matmul(weight.t()).cast(DType::F32).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     assert_matmul_options(&cx, "MPSMatmul");
     let mut rt = MetalRuntime::initialize(());
 
@@ -1019,7 +1018,7 @@ fn metal_rms_norm() {
     let weight = cx.tensor(TRANSFORMER_HIDDEN);
     let output = rms_norm(input, weight, 1e-5).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
 
     let input_data = seeded_data(TRANSFORMER_SEQ * TRANSFORMER_HIDDEN, 1.0, -0.5);
@@ -1027,7 +1026,7 @@ fn metal_rms_norm() {
 
     rt.set_data(input, &input_data);
     rt.set_data(weight, &weight_data);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1053,7 +1052,7 @@ fn metal_self_attention() {
     let wo = cx.tensor((TRANSFORMER_HIDDEN, TRANSFORMER_HIDDEN));
     let output = self_attention(input, wq, wk, wv, wo).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
 
     let input_data = seeded_data(TRANSFORMER_SEQ * TRANSFORMER_HIDDEN, 1.0, -0.5);
@@ -1067,7 +1066,7 @@ fn metal_self_attention() {
     rt.set_data(wk, &wk_data);
     rt.set_data(wv, &wv_data);
     rt.set_data(wo, &wo_data);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1112,7 +1111,7 @@ fn metal_self_attention_f16_weights() {
         .cast(DType::F32)
         .output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
 
     let input_data = seeded_data(TRANSFORMER_SEQ * TRANSFORMER_HIDDEN, 1.0, -0.5);
@@ -1126,7 +1125,7 @@ fn metal_self_attention_f16_weights() {
     rt.set_data(wk, to_f16_vec(&wk_data));
     rt.set_data(wv, to_f16_vec(&wv_data));
     rt.set_data(wo, to_f16_vec(&wo_data));
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1158,7 +1157,7 @@ fn metal_swiglu_mlp() {
     let w_down = cx.tensor((TRANSFORMER_HIDDEN, TRANSFORMER_INTERMEDIATE));
     let output = swiglu_mlp(input, w_gate, w_up, w_down).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
 
     let input_data = seeded_data(TRANSFORMER_SEQ * TRANSFORMER_HIDDEN, 1.0, -0.5);
@@ -1170,7 +1169,7 @@ fn metal_swiglu_mlp() {
     rt.set_data(w_gate, &gate_data);
     rt.set_data(w_up, &up_data);
     rt.set_data(w_down, &down_data);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1210,7 +1209,7 @@ fn metal_mini_transformer_layer() {
     let layer = MiniTransformerLayer::init(&mut cx);
     let output = layer.forward(input).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
 
     let input_data = seeded_data(TRANSFORMER_SEQ * TRANSFORMER_HIDDEN, 1.0, -0.5);
@@ -1220,7 +1219,7 @@ fn metal_mini_transformer_layer() {
     for (tensor, data) in &weight_data {
         rt.set_data(*tensor, data);
     }
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1276,7 +1275,7 @@ fn metal_mini_transformer_layer_f16_intermediate() {
     .cast(DType::F32);
     let output = (x + mlp_out).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
 
     let input_data = seeded_data(TRANSFORMER_SEQ * TRANSFORMER_HIDDEN, 1.0, -0.5);
@@ -1286,7 +1285,7 @@ fn metal_mini_transformer_layer_f16_intermediate() {
     for (tensor, data) in &weight_data {
         rt.set_data(*tensor, data);
     }
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1323,12 +1322,12 @@ fn test_scatter_basic() {
     let dest = cx.tensor(5);
     let result = src.scatter(indexes, dest).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(src, &[10.0, 20.0, 30.0]);
     rt.set_data(indexes, &[1.0, 3.0, 4.0]);
     rt.set_data(dest, &[0.0, 0.0, 0.0, 0.0, 0.0]);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1345,12 +1344,12 @@ fn test_scatter_buffer_roundtrip() {
     let cache_out = src.scatter(indexes, cache);
     let read = cache_out.output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(src, &[0.0]);
     rt.set_data(indexes, &[0.0]);
     rt.set_zeros(cache, 4 * std::mem::size_of::<f32>());
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
 
     for (pos, value, expected) in [
         (0, 10.0, [10.0, 0.0, 0.0, 0.0]),
@@ -1379,12 +1378,12 @@ fn test_load_safetensors_f32_survives_search_and_overrides_input_data() {
     let tensors = [("weights", Dtype::F32, vec![3], bytes_of(&weight_values))];
     let path = write_test_safetensors(&tensors);
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(weights, &[99.0, 99.0, 99.0]);
     rt.set_data(bias, &[0.5, 1.0, -1.5]);
     rt.load_safetensors(&cx, path.to_str().unwrap());
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1446,10 +1445,10 @@ fn test_load_safetensors_converts_supported_float_dtypes() {
     ];
     let path = write_test_safetensors(&tensors);
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.load_safetensors(&cx, path.to_str().unwrap());
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1469,14 +1468,14 @@ fn test_gather_noncontiguous_data_uses_data_shape() {
     let indexes = cx.tensor((2, 2)).as_dtype(DType::Int);
     let out = data.gather(indexes).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(
         input,
         &[0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0],
     );
     rt.set_data(indexes, &[0.0, 3.0, 4.0, 7.0]);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1491,12 +1490,12 @@ fn test_scatter_into_nonzero_dest() {
     let dest = cx.tensor(5);
     let result = src.scatter(indexes, dest).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(src, &[99.0]);
     rt.set_data(indexes, &[2f32]);
     rt.set_data(dest, &[1.0, 2.0, 3.0, 4.0, 5.0]);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     let kernels = rt.debug_kernel_ops();
     assert!(
         kernels.iter().any(|k| k.contains("MetalScatterNoCopy")),
@@ -1518,12 +1517,12 @@ fn test_scatter_no_copy_remove_buffer_aliases_dest() {
     let dest = cx.tensor(5);
     let result = src.scatter(indexes, dest).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(src, &[7.0, 8.0]);
     rt.set_data(indexes, &[1.0, 3.0]);
     rt.set_data(dest, &[10.0, 20.0, 30.0, 40.0, 50.0]);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1547,12 +1546,12 @@ fn test_scatter_no_copy_handles_2d_destination() {
     let dest = cx.tensor((2, 3));
     let result = src.scatter(indexes, dest).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(src, &[9.0, 8.0]);
     rt.set_data(indexes, &[2.0, 4.0]);
     rt.set_data(dest, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     let kernels = rt.debug_kernel_ops();
     assert!(
         kernels.iter().any(|k| k.contains("MetalScatterNoCopy")),
@@ -1574,12 +1573,12 @@ fn test_scatter_no_copy_not_selected_when_dest_has_another_consumer() {
     let scatter = src.scatter(indexes, dest).output();
     let dest_plus_one = (dest + 1.0).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(src, &[99.0]);
     rt.set_data(indexes, &[1.0]);
     rt.set_data(dest, &[10.0, 20.0, 30.0, 40.0]);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     let kernels = rt.debug_kernel_ops();
     assert!(
         !kernels.iter().any(|k| k.contains("MetalScatterNoCopy")),
@@ -1601,12 +1600,12 @@ fn test_scatter_all_positions() {
     let dest = cx.tensor(4);
     let result = src.scatter(indexes, dest).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(src, &[40.0, 30.0, 20.0, 10.0]);
     rt.set_data(indexes, &[3.0, 2.0, 1.0, 0.0]);
     rt.set_data(dest, &[1.0, 2.0, 3.0, 4.0]);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 
@@ -1621,11 +1620,11 @@ fn test_gather_preserves_data_dtype() {
     let indexes = cx.tensor(1).as_dtype(DType::Int);
     let out = data.gather(indexes).output();
 
-    cx.build_search_space::<MetalRuntime>();
+    cx.build_search_space::<MetalRuntime>(CompileOptions::default());
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(data, &[1.25, 2.5]);
     rt.set_data(indexes, &[1.0]);
-    rt = cx.search(rt, 1);
+    rt = cx.search(rt, CompileOptions::new(1));
     rt.allocate_intermediate_buffers(&cx.dyn_map);
     rt.execute(&cx.dyn_map);
 

--- a/crates/luminal_nn/src/attention.rs
+++ b/crates/luminal_nn/src/attention.rs
@@ -166,8 +166,8 @@ mod tests {
         let indices = cx.tensor(3).as_dtype(DType::Int);
         let result = gather_rows(data, indices, 3).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         // data = [[1,2,3], [4,5,6], [7,8,9], [10,11,12]]
         rt.set_data(
@@ -192,8 +192,8 @@ mod tests {
         let dest = cx.tensor((4, 3));
         let result = scatter_rows(src, indices, dest, 3).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         rt.set_data(src.id, vec![10., 20., 30., 40., 50., 60.]);
         rt.set_data(indices.id, vec![1, 3]);
@@ -218,8 +218,8 @@ mod tests {
         let updated_cache = scatter_rows(kv_new, scatter_idx, cache, 4);
         let gathered = gather_rows(updated_cache, gather_idx, 4).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         rt.set_data(kv_new.id, vec![1., 2., 3., 4., 5., 6., 7., 8.]);
         rt.set_data(scatter_idx.id, vec![1, 4]); // Write to slots 1 and 4
@@ -271,8 +271,8 @@ mod tests {
         let k_cache_new = k_cache_new.output();
         let v_cache_new = v_cache_new.output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         // Q = [1, 0, 1, 0] → head0=[1,0], head1=[1,0]
         rt.set_data(q.id, vec![1., 0., 1., 0.]);
@@ -344,8 +344,8 @@ mod tests {
         );
         let attn_out = attn_out.output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         // Setup: 1 cached token at slot 0, 1 new token written to slot 1
         // K cached at slot 0: [1, 0]
@@ -416,8 +416,8 @@ mod tests {
         );
         let attn_out = attn_out.output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         // Cache has 1 token at slot 0
         let mut k_cache_data = vec![0.; num_slots * kv_dim];

--- a/crates/luminal_nn/src/moe.rs
+++ b/crates/luminal_nn/src/moe.rs
@@ -183,8 +183,8 @@ mod tests {
         };
         let output = moe.forward(input).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         let input_data = vec![1.0, 2.0, 3.0];
         // Router strongly favors expert 0
@@ -238,8 +238,8 @@ mod tests {
         };
         let output = moe.forward(input).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         let input_data = vec![1.0, 1.0];
         // Nearly-equal routing to all experts (slight differences to avoid argsort ties)
@@ -292,8 +292,8 @@ mod tests {
         };
         let output = moe.forward(input).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         let input_data = vec![
             1.0, 0.0, 0.0, // batch 0: routes to expert via feature 0
@@ -349,8 +349,8 @@ mod tests {
         };
         let output = moe.forward(input).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         let input_data = random_vec(in_dim);
         let router_data = random_vec(in_dim * n_experts);
@@ -394,8 +394,8 @@ mod tests {
         };
         let output = moe.forward(input).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         let input_data = random_vec(batch * in_dim);
         let router_data = random_vec(in_dim * n_experts);

--- a/examples/flux2/src/main.rs
+++ b/examples/flux2/src/main.rs
@@ -37,7 +37,7 @@ use std::fs::File;
 use std::io::BufWriter;
 use std::time::Instant;
 
-use luminal::graph::BuildSearchSpaceOptions;
+use luminal::graph::CompileOptions;
 use luminal::prelude::*;
 use luminal_cuda_lite::{cudarc::driver::CudaContext, runtime::CudaRuntime};
 use rand::{Rng, SeedableRng, rngs::StdRng};
@@ -159,11 +159,9 @@ fn run_text_encoder(prompt: &str) -> Result<Vec<f32>, Box<dyn std::error::Error>
         s.parse::<usize>()
             .map_err(|_| std::env::VarError::NotPresent)
     }) {
-        cx.build_search_space_with_options::<CudaRuntime>(
-            BuildSearchSpaceOptions::new().max_memory_gib(g),
-        );
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default().max_memory_gib(g));
     } else {
-        cx.build_search_space::<CudaRuntime>();
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     }
 
     let ctx = CudaContext::new(0).unwrap();
@@ -189,7 +187,7 @@ fn run_text_encoder(prompt: &str) -> Result<Vec<f32>, Box<dyn std::error::Error>
 
     println!("Compiling text encoder...");
     let t0 = Instant::now();
-    runtime = cx.search(runtime, env_usize("SEARCH_ITERS", 5));
+    runtime = cx.search(runtime, CompileOptions::new(env_usize("SEARCH_ITERS", 5)));
     println!("  compile done in {:.1}s", t0.elapsed().as_secs_f64());
 
     println!("Encoding prompt...");
@@ -301,11 +299,9 @@ fn run_full_pipeline(
         s.parse::<usize>()
             .map_err(|_| std::env::VarError::NotPresent)
     }) {
-        cx.build_search_space_with_options::<CudaRuntime>(
-            BuildSearchSpaceOptions::new().max_memory_gib(g),
-        );
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default().max_memory_gib(g));
     } else {
-        cx.build_search_space::<CudaRuntime>();
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     }
 
     let ctx = CudaContext::new(0).unwrap();
@@ -349,10 +345,10 @@ fn run_full_pipeline(
     {
         use rand::SeedableRng;
         let mut rng = rand::rngs::SmallRng::seed_from_u64(seed);
-        let opts = luminal::graph::SearchOptions::new(env_usize("SEARCH_ITERS", 5));
-        runtime = cx.search_options(runtime, opts, &mut rng);
+        let opts = luminal::graph::CompileOptions::new(env_usize("SEARCH_ITERS", 5));
+        runtime = cx.search_with_rng(runtime, opts, &mut rng);
     } else {
-        runtime = cx.search(runtime, env_usize("SEARCH_ITERS", 5));
+        runtime = cx.search(runtime, CompileOptions::new(env_usize("SEARCH_ITERS", 5)));
     }
     println!("  compile done in {:.1}s", t0.elapsed().as_secs_f64());
 
@@ -409,11 +405,9 @@ fn run_full_pipeline(
         s.parse::<usize>()
             .map_err(|_| std::env::VarError::NotPresent)
     }) {
-        cx.build_search_space_with_options::<CudaRuntime>(
-            BuildSearchSpaceOptions::new().max_memory_gib(g),
-        );
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default().max_memory_gib(g));
     } else {
-        cx.build_search_space::<CudaRuntime>();
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     }
 
     let ctx = CudaContext::new(0).unwrap();
@@ -421,7 +415,7 @@ fn run_full_pipeline(
     let mut runtime = CudaRuntime::initialize(stream);
     runtime.load_safetensors(&cx, vae_path.to_str().unwrap());
     runtime.set_data(latent_in, vae_input);
-    runtime = cx.search(runtime, env_usize("SEARCH_ITERS", 5));
+    runtime = cx.search(runtime, CompileOptions::new(env_usize("SEARCH_ITERS", 5)));
     runtime.execute(&cx.dyn_map);
     let img = runtime.get_f32(out);
     // VaeDecoder output is in roughly [-1, 1] range. Diffusers'

--- a/examples/flux2/src/vae.rs
+++ b/examples/flux2/src/vae.rs
@@ -746,8 +746,8 @@ mod tests {
             },
         );
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         rt.set_data(input_t, input);
         rt.set_data(weight_t, weight);
         rt.set_data(bias_t, bias);
@@ -765,8 +765,8 @@ mod tests {
         let input: Vec<f32> = (0..2 * 3 * 4).map(|i| i as f32 - 11.0).collect();
         let expected = reference_nearest_upsample_2x(&input, 2, 3, 4);
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         rt.set_data(input_t, input);
         rt.execute(&cx.dyn_map);
 
@@ -787,10 +787,10 @@ mod tests {
         let input: Vec<f32> = (0..2 * 3 * 4).map(|i| i as f32 - 11.0).collect();
         let expected = reference_nearest_upsample_2x(&input, 2, 3, 4);
 
-        cx.build_search_space::<CudaRuntime>();
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
         let mut rt = CudaRuntime::initialize(ctx.default_stream());
         rt.set_data(input_t, input);
-        rt = cx.search(rt, 1);
+        rt = cx.search(rt, CompileOptions::new(1));
         rt.execute(&cx.dyn_map);
 
         assert_close(&rt.get_f32(out.id), &expected);
@@ -820,8 +820,8 @@ mod tests {
             },
         );
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         rt.set_data(input_t, input);
         rt.set_data(weight_t, weight);
         rt.set_data(bias_t, bias);
@@ -859,12 +859,12 @@ mod tests {
             },
         );
 
-        cx.build_search_space::<CudaRuntime>();
+        cx.build_search_space::<CudaRuntime>(CompileOptions::default());
         let mut rt = CudaRuntime::initialize(ctx.default_stream());
         rt.set_data(input_t, input);
         rt.set_data(weight_t, weight);
         rt.set_data(bias_t, bias);
-        rt = cx.search(rt, 1);
+        rt = cx.search(rt, CompileOptions::new(1));
         rt.execute(&cx.dyn_map);
 
         assert_close(&rt.get_f32(out.id), &expected);

--- a/examples/gemma/src/main.rs
+++ b/examples/gemma/src/main.rs
@@ -53,9 +53,20 @@ fn main() {
         k_out.output();
         v_out.output();
     }
+    let max_prefill = (prompt_tokens.len() + 16)
+        .next_power_of_two()
+        .min(max_seq_len);
+    let search_s = 16.min(max_prefill).max(2);
+    let build_options = CompileOptions::default().dim_buckets(
+        's',
+        &[
+            DimBucket::new(1, 1),
+            DimBucket::new(2, max_prefill).representative(search_s),
+        ],
+    );
 
     println!("Building E-Graph...");
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(build_options);
 
     println!("Loading weights...");
     let mut runtime = CudaRuntime::initialize(stream);
@@ -69,22 +80,11 @@ fn main() {
     }
 
     println!("Compiling...");
-    let max_prefill = (prompt_tokens.len() + 16)
-        .next_power_of_two()
-        .min(max_seq_len);
-    let search_s = 16.min(max_prefill).max(2);
-    cx.set_dim_buckets(
-        's',
-        &[
-            DimBucket::new(1, 1),
-            DimBucket::new(2, max_prefill).representative(search_s),
-        ],
-    );
     cx.set_dim('s', search_s);
     cx.set_dim('p', 0);
     runtime.set_data(input, vec![1; search_s]);
     runtime.set_data(token_ids, (0..search_s as i32).collect::<Vec<_>>());
-    runtime = cx.search(runtime, search_graphs);
+    runtime = cx.search(runtime, CompileOptions::new(search_graphs));
 
     for i in 0..LAYERS {
         runtime.set_zeros(kv_cache.k_caches[i], cache_bytes);

--- a/examples/gemma4_moe/src/main.rs
+++ b/examples/gemma4_moe/src/main.rs
@@ -49,9 +49,20 @@ fn main() {
         k_out.output();
         v_out.output();
     }
+    let max_prefill = (prompt_tokens.len() + 16)
+        .next_power_of_two()
+        .min(max_seq_len);
+    let search_s = 16.min(max_prefill).max(2);
+    let build_options = CompileOptions::default().dim_buckets(
+        's',
+        &[
+            DimBucket::new(1, 1),
+            DimBucket::new(2, max_prefill).representative(search_s),
+        ],
+    );
 
     println!("Building E-Graph...");
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(build_options);
 
     println!("Loading weights...");
     let mut runtime = CudaRuntime::initialize(stream);
@@ -65,25 +76,14 @@ fn main() {
     }
 
     println!("Compiling...");
-    let max_prefill = (prompt_tokens.len() + 16)
-        .next_power_of_two()
-        .min(max_seq_len);
-    let search_s = 16.min(max_prefill).max(2);
-    cx.set_dim_buckets(
-        's',
-        &[
-            DimBucket::new(1, 1),
-            DimBucket::new(2, max_prefill).representative(search_s),
-        ],
-    );
     cx.set_dim('s', search_s);
     cx.set_dim('p', 0);
     runtime.set_data(input, vec![1; search_s]);
     runtime.set_data(pos_ids, (0..search_s as i32).collect::<Vec<_>>());
     let mut rng = SmallRng::seed_from_u64(SEARCH_SEED);
-    runtime = cx.search_options(
+    runtime = cx.search_with_rng(
         runtime,
-        SearchOptions::new(search_graphs).profile_timeout(Duration::from_secs(2)),
+        CompileOptions::new(search_graphs).profile_timeout(Duration::from_secs(2)),
         &mut rng,
     );
 

--- a/examples/llama/src/main.rs
+++ b/examples/llama/src/main.rs
@@ -290,12 +290,21 @@ fn main() {
 
     cx.set_dim('s', 1);
     cx.set_dim('c', 1);
+    let max_prefill = (prompt_len + 16).next_power_of_two().min(MAX_SEQ_LEN);
+    let search_s = 16.min(max_prefill).max(2);
+    let build_options = CompileOptions::default()
+        .max_memory_mib(SEARCH_MEMORY_MIB)
+        .dim_buckets(
+            's',
+            &[
+                DimBucket::new(1, 1),
+                DimBucket::new(2, max_prefill).representative(search_s),
+            ],
+        );
 
     println!("Building E-Graph...");
     let egraph_start = std::time::Instant::now();
-    cx.build_search_space_with_options::<CudaRuntime>(
-        BuildSearchSpaceOptions::new().max_memory_mib(SEARCH_MEMORY_MIB),
-    );
+    cx.build_search_space::<CudaRuntime>(build_options);
     println!(
         "  E-Graph build: {:.2} s",
         egraph_start.elapsed().as_secs_f64()
@@ -318,15 +327,6 @@ fn main() {
 
     println!("Compiling...");
     let compile_start = std::time::Instant::now();
-    let max_prefill = (prompt_len + 16).next_power_of_two().min(MAX_SEQ_LEN);
-    let search_s = 16.min(max_prefill).max(2);
-    cx.set_dim_buckets(
-        's',
-        &[
-            DimBucket::new(1, 1),
-            DimBucket::new(2, max_prefill).representative(search_s),
-        ],
-    );
     cx.set_dim('s', search_s);
     cx.set_dim('c', search_s);
     runtime.set_data(input, vec![1; search_s]);
@@ -338,9 +338,9 @@ fn main() {
     println!("  Search trials: {SEARCH_TRIALS}");
     println!("  Search keep-best: {SEARCH_KEEP_BEST}");
     let mut rng = StdRng::seed_from_u64(SEARCH_SEED);
-    runtime = cx.search_options(
+    runtime = cx.search_with_rng(
         runtime,
-        SearchOptions::new(SEARCH_GRAPHS)
+        CompileOptions::new(SEARCH_GRAPHS)
             .trials(SEARCH_TRIALS)
             .keep_best(SEARCH_KEEP_BEST),
         &mut rng,

--- a/examples/paged_llama/src/main.rs
+++ b/examples/paged_llama/src/main.rs
@@ -204,9 +204,20 @@ fn main() {
         k_out.output();
         v_out.output();
     }
+    // Bucket s=1 (decode) vs s>1 (prefill/mixed). Each bucket gets its own
+    // optimized compilation — decode can select warp-parallel kernels while
+    // prefill can select tiled matmul / cuBLAS.
+    let max_prefill = (tokens_a.len().max(tokens_b.len()) + 16).next_power_of_two();
+    let build_options = CompileOptions::default().dim_buckets(
+        's',
+        &[
+            DimBucket::new(1, 1),
+            DimBucket::new(2, max_prefill).representative(16),
+        ],
+    );
 
     println!("Building E-Graph...");
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(build_options);
 
     println!("Loading weights...");
     let mut runtime = CudaRuntime::initialize(stream);
@@ -220,18 +231,6 @@ fn main() {
     }
 
     println!("Compiling...");
-    // Bucket s=1 (decode) vs s>1 (prefill/mixed). Each bucket gets its own
-    // optimized compilation — decode can select warp-parallel kernels while
-    // prefill can select tiled matmul / cuBLAS.
-    let max_prefill = (tokens_a.len().max(tokens_b.len()) + 16).next_power_of_two();
-    cx.set_dim_buckets(
-        's',
-        &[
-            DimBucket::new(1, 1),
-            DimBucket::new(2, max_prefill).representative(16),
-        ],
-    );
-
     // Dummy data sized for the largest representative (s=16, c=16)
     let search_s = 16;
     let search_c = 16;
@@ -242,7 +241,7 @@ fn main() {
     runtime.set_data(scatter_idx_t, vec![0i32; search_s]);
     runtime.set_data(gather_idx_t, vec![0i32; search_c]);
     runtime.set_data(attn_mask_t, vec![0.0f32; search_s * search_c]);
-    runtime = cx.search(runtime, search_graphs);
+    runtime = cx.search(runtime, CompileOptions::new(search_graphs));
 
     // Re-initialize KV cache after search (search consumes buffers)
     let cache_bytes = num_slots * KV_DIM * std::mem::size_of::<f32>();

--- a/examples/qwen/src/lib.rs
+++ b/examples/qwen/src/lib.rs
@@ -147,26 +147,11 @@ where
         k_out.output();
         v_out.output();
     }
-
-    println!("Building E-Graph...");
-    cx.build_search_space::<R>();
-
-    println!("Loading weights...");
-    let weights_path = model_dir.join("model_combined.safetensors");
-    runtime.load_safetensors(&cx, weights_path.to_str().unwrap());
-
-    let cache_bytes = N_KV_HEADS * config.max_seq_len * HEAD_DIM * std::mem::size_of::<f32>();
-    for i in 0..config.layers {
-        runtime.set_zeros(kv_cache.k_caches[i].id, cache_bytes);
-        runtime.set_zeros(kv_cache.v_caches[i].id, cache_bytes);
-    }
-
-    println!("Compiling...");
     let max_prefill = (prompt_tokens.len() + 16)
         .next_power_of_two()
         .min(config.max_seq_len);
     let search_s = 16.min(max_prefill).max(2);
-    cx.set_dim_buckets(
+    let mut compile_options = CompileOptions::default().dim_buckets(
         's',
         &[
             DimBucket::new(1, 1),
@@ -183,12 +168,27 @@ where
             DimBucket::new(1, max_decode_p).representative(decode_p_representative),
         ]
     };
-    cx.set_dim_buckets('p', &p_buckets);
+    compile_options = compile_options.dim_buckets('p', &p_buckets);
+
+    println!("Building E-Graph...");
+    cx.build_search_space::<R>(compile_options);
+
+    println!("Loading weights...");
+    let weights_path = model_dir.join("model_combined.safetensors");
+    runtime.load_safetensors(&cx, weights_path.to_str().unwrap());
+
+    let cache_bytes = N_KV_HEADS * config.max_seq_len * HEAD_DIM * std::mem::size_of::<f32>();
+    for i in 0..config.layers {
+        runtime.set_zeros(kv_cache.k_caches[i].id, cache_bytes);
+        runtime.set_zeros(kv_cache.v_caches[i].id, cache_bytes);
+    }
+
+    println!("Compiling...");
     cx.set_dim('s', search_s);
     cx.set_dim('p', 0);
     runtime.set_i32_data(input.id, vec![1; search_s]);
     runtime.set_i32_data(token_ids.id, (0..search_s as i32).collect::<Vec<_>>());
-    runtime = cx.search(runtime, config.search_graphs);
+    runtime = cx.search(runtime, CompileOptions::new(config.search_graphs));
 
     for i in 0..config.layers {
         runtime.set_zeros(kv_cache.k_caches[i].id, cache_bytes);

--- a/examples/qwen3_moe/src/main.rs
+++ b/examples/qwen3_moe/src/main.rs
@@ -50,9 +50,20 @@ fn main() {
         k_out.output();
         v_out.output();
     }
+    let max_prefill = (prompt_tokens.len() + 16)
+        .next_power_of_two()
+        .min(max_seq_len);
+    let search_s = 16.min(max_prefill).max(2);
+    let build_options = CompileOptions::default().dim_buckets(
+        's',
+        &[
+            DimBucket::new(1, 1),
+            DimBucket::new(2, max_prefill).representative(search_s),
+        ],
+    );
 
     println!("Building E-Graph...");
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(build_options);
 
     println!("Loading weights...");
     let mut runtime = CudaRuntime::initialize(stream);
@@ -66,23 +77,12 @@ fn main() {
     }
 
     println!("Compiling...");
-    let max_prefill = (prompt_tokens.len() + 16)
-        .next_power_of_two()
-        .min(max_seq_len);
-    let search_s = 16.min(max_prefill).max(2);
-    cx.set_dim_buckets(
-        's',
-        &[
-            DimBucket::new(1, 1),
-            DimBucket::new(2, max_prefill).representative(search_s),
-        ],
-    );
     cx.set_dim('s', search_s);
     cx.set_dim('p', 0);
     runtime.set_data(input, vec![1; search_s]);
     runtime.set_data(pos_ids, (0..search_s as i32).collect::<Vec<_>>());
     let mut rng = SmallRng::seed_from_u64(SEARCH_SEED);
-    runtime = cx.search_options(runtime, SearchOptions::new(search_graphs), &mut rng);
+    runtime = cx.search_with_rng(runtime, CompileOptions::new(search_graphs), &mut rng);
 
     for i in 0..LAYERS {
         runtime.set_zeros(kv_cache.k_caches[i], cache_bytes);

--- a/examples/simple/src/main.rs
+++ b/examples/simple/src/main.rs
@@ -11,8 +11,8 @@ fn main() {
     display_graph(&cx);
 
     // Compile
-    cx.build_search_space::<NativeRuntime>();
-    let mut rt = cx.search(NativeRuntime::default(), 1);
+    cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+    let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
     // Set input tensors
     rt.set_data(a, vec![1.0, 2.0, 3.0]);

--- a/examples/whisper/src/main.rs
+++ b/examples/whisper/src/main.rs
@@ -63,9 +63,18 @@ fn main() {
         k_out.output();
         v_out.output();
     }
+    let prompt: Vec<u32> = vec![TOKEN_SOT, TOKEN_NO_TIMESTAMPS];
+    let max_prefill = prompt.len().max(2);
+    let build_options = CompileOptions::default().dim_buckets(
+        's',
+        &[
+            DimBucket::new(1, 1),
+            DimBucket::new(2, max_prefill).representative(max_prefill),
+        ],
+    );
 
     println!("Building E-Graph...");
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(build_options);
 
     println!("Loading weights...");
     let mut runtime = CudaRuntime::initialize(stream);
@@ -82,22 +91,12 @@ fn main() {
     // Set the mel spectrogram once.
     runtime.set_data(mel_tensor, mel_data.clone());
 
-    let prompt: Vec<u32> = vec![TOKEN_SOT, TOKEN_NO_TIMESTAMPS];
-
     println!("Compiling...");
-    let max_prefill = prompt.len().max(2);
-    cx.set_dim_buckets(
-        's',
-        &[
-            DimBucket::new(1, 1),
-            DimBucket::new(2, max_prefill).representative(max_prefill),
-        ],
-    );
     cx.set_dim('s', max_prefill);
     cx.set_dim('p', 0);
     runtime.set_data(input, vec![1i32; max_prefill]);
     runtime.set_data(pos_ids, (0..max_prefill as i32).collect::<Vec<_>>());
-    runtime = cx.search(runtime, search_graphs);
+    runtime = cx.search(runtime, CompileOptions::new(search_graphs));
 
     // Reset the KV caches and re-set the mel after search (which executes test runs).
     for i in 0..N_TEXT_LAYER {

--- a/examples/yolo_v11/src/main.rs
+++ b/examples/yolo_v11/src/main.rs
@@ -318,7 +318,7 @@ fn main() {
 
     println!("Building E-Graph...");
     let t0 = Instant::now();
-    cx.build_search_space::<CudaRuntime>();
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
     println!("  built E-Graph in {:?}", t0.elapsed());
 
     println!("Loading weights...");
@@ -335,7 +335,7 @@ fn main() {
 
     println!("Compiling (search_graphs={search_graphs})...");
     let t0 = Instant::now();
-    runtime = cx.search(runtime, search_graphs);
+    runtime = cx.search(runtime, CompileOptions::new(search_graphs));
     println!("  search took {:?}", t0.elapsed());
 
     // Re-set anchors/strides/dfl/img after search (search may consume the inputs)

--- a/src/dyn_backend.rs
+++ b/src/dyn_backend.rs
@@ -13,7 +13,7 @@ use petgraph::stable_graph::NodeIndex;
 use rustc_hash::FxHashMap;
 
 use crate::dtype::DType;
-use crate::graph::Graph;
+use crate::graph::{CompileOptions, Graph};
 use crate::hlir::{NativeData, NativeRuntime, Output};
 use crate::op::Runtime;
 
@@ -133,7 +133,7 @@ pub fn compile_backend<Rt: Runtime + 'static>(
     // survives cross-binary type identity mismatches with external plugins).
     let label_map = build_label_map(graph);
 
-    graph.build_search_space::<Rt>();
+    graph.build_search_space::<Rt>(CompileOptions::default());
 
     let mut rt = init()?;
 
@@ -162,7 +162,7 @@ pub fn compile_backend<Rt: Runtime + 'static>(
     }
 
     // Search
-    let mut rt = graph.search(rt, args.search_iters);
+    let mut rt = graph.search(rt, CompileOptions::new(args.search_iters));
 
     // Rebuild label map after search (graph may have changed)
     let label_map = build_label_map(graph);

--- a/src/egglog_utils/base.rs
+++ b/src/egglog_utils/base.rs
@@ -2,6 +2,7 @@ use std::sync::LazyLock;
 
 use super::api::*;
 use crate::shape::{self, ToShape};
+use rustc_hash::FxHashSet;
 
 // ---- Sort classes (pub const) ----
 
@@ -54,6 +55,12 @@ pub fn peq(a: Term, b: Term) -> Term {
 }
 pub fn pneq(a: Term, b: Term) -> Term {
     neq(a, b)
+}
+pub fn interval_lower(e: Term) -> Term {
+    app(&func("lower", &["expr"]), vec![e])
+}
+pub fn interval_upper(e: Term) -> Term {
+    app(&func("upper", &["expr"]), vec![e])
 }
 
 // ---- Egglog function applications ----
@@ -412,6 +419,38 @@ pub fn dtype(e: Term) -> Term {
     app(&func("dtype", &["inp"]), vec![e])
 }
 
+pub fn interval_facts_egglog(
+    intervals: &shape::DynDimIntervals,
+    vars: impl IntoIterator<Item = char>,
+) -> String {
+    let mut all_vars = FxHashSet::default();
+    all_vars.extend(intervals.keys().copied());
+    all_vars.extend(vars);
+
+    let mut all_vars = all_vars.into_iter().collect::<Vec<_>>();
+    all_vars.sort_unstable();
+
+    let mut out = String::new();
+    for var in all_vars {
+        let interval = intervals
+            .get(&var)
+            .copied()
+            .unwrap_or_else(shape::DimInterval::unbounded);
+        let var_expr = mvar(str(&var.to_string()));
+        out.push_str(&format!(
+            "(set {} {})\n",
+            term_to_egglog(&interval_lower(var_expr.clone())),
+            interval.min
+        ));
+        out.push_str(&format!(
+            "(set {} {})\n",
+            term_to_egglog(&interval_upper(var_expr)),
+            interval.max
+        ));
+    }
+    out
+}
+
 // ---- Normalized Op helpers ----
 
 /// Build an `(Op kind inputs)` IR term.
@@ -460,11 +499,19 @@ pub fn new_op_call(kind_sort: &SortDef, input_names: &[&str]) -> (Args, Term) {
     (args, op)
 }
 
+pub fn base_expression_egglog() -> String {
+    base_expression_egglog_impl(false)
+}
+
+pub fn base_expression_egglog_with_intervals() -> String {
+    base_expression_egglog_impl(true)
+}
+
 /// Generate the egglog program equivalent to `base.egg`.
 ///
 /// This builds the Expression, EList, and DType datatypes along with all
 /// algebraic rewrites, replacement rules, and list helper functions.
-pub fn base_expression_egglog() -> String {
+fn base_expression_egglog_impl(use_interval_analysis: bool) -> String {
     let s = BaseSorts::new();
 
     // Build the program
@@ -475,12 +522,29 @@ pub fn base_expression_egglog() -> String {
 
     // Rulesets
     p.add_ruleset("expr");
+    if use_interval_analysis {
+        p.add_ruleset("interval_expr");
+    }
     p.add_ruleset("dtype_prop");
     p.add_ruleset("cleanup");
     p.add_ruleset("post_cleanup");
 
     // Register all sorts
     s.register(&mut p);
+    if use_interval_analysis {
+        p.add_function(FunctionDef {
+            name: "lower".to_string(),
+            args: vec![EXPRESSION.name.to_string()],
+            ret: I64.name.to_string(),
+            merge: Some("(max old new)".to_string()),
+        });
+        p.add_function(FunctionDef {
+            name: "upper".to_string(),
+            args: vec![EXPRESSION.name.to_string()],
+            ret: I64.name.to_string(),
+            merge: Some("(min old new)".to_string()),
+        });
+    }
 
     // ---- Algebraic rewrites ----
     // Commutativity
@@ -724,6 +788,182 @@ pub fn base_expression_egglog() -> String {
         )
         .ruleset("expr"),
     );
+
+    if use_interval_analysis {
+        // ---- Interval analysis and interval-guarded simplifications ----
+        p.add_rule(
+            Rule::new()
+                .fact(peq(v("?e"), num(v("?n"))))
+                .set(interval_lower(v("?e")), v("?n"))
+                .set(interval_upper(v("?e")), v("?n"))
+                .ruleset("interval_expr")
+                .name("interval-num-exact"),
+        );
+        p.add_rule(
+            Rule::new()
+                .facts(vec![
+                    peq(v("?e"), add(v("?a"), v("?b"))),
+                    peq(v("?lo_a"), interval_lower(v("?a"))),
+                    peq(v("?lo_b"), interval_lower(v("?b"))),
+                    peq(v("?sum"), padd(v("?lo_a"), v("?lo_b"))),
+                ])
+                .set(interval_lower(v("?e")), v("?sum"))
+                .when(vec![
+                    pgte(v("?lo_a"), i64(0)),
+                    pgte(v("?lo_b"), i64(0)),
+                    pgte(psub(i64(i64::MAX), v("?lo_b")), v("?lo_a")),
+                ])
+                .ruleset("interval_expr")
+                .name("interval-add-lower-nonnegative"),
+        );
+        p.add_rule(
+            Rule::new()
+                .facts(vec![
+                    peq(v("?e"), add(v("?a"), v("?b"))),
+                    peq(v("?hi_a"), interval_upper(v("?a"))),
+                    peq(v("?hi_b"), interval_upper(v("?b"))),
+                    peq(v("?sum"), padd(v("?hi_a"), v("?hi_b"))),
+                ])
+                .set(interval_upper(v("?e")), v("?sum"))
+                .when(vec![
+                    plt(v("?hi_a"), i64(i64::MAX)),
+                    plt(v("?hi_b"), i64(i64::MAX)),
+                    pgte(psub(i64(i64::MAX), v("?hi_b")), v("?hi_a")),
+                ])
+                .ruleset("interval_expr")
+                .name("interval-add-upper-finite"),
+        );
+        p.add_rule(
+            Rule::new()
+                .facts(vec![
+                    peq(v("?e"), min(v("?a"), v("?b"))),
+                    peq(v("?lo_a"), interval_lower(v("?a"))),
+                    peq(v("?lo_b"), interval_lower(v("?b"))),
+                ])
+                .set(interval_lower(v("?e")), pmin(v("?lo_a"), v("?lo_b")))
+                .ruleset("interval_expr")
+                .name("interval-min-lower"),
+        );
+        p.add_rule(
+            Rule::new()
+                .facts(vec![
+                    peq(v("?e"), min(v("?a"), v("?b"))),
+                    peq(v("?hi_a"), interval_upper(v("?a"))),
+                    peq(v("?hi_b"), interval_upper(v("?b"))),
+                ])
+                .set(interval_upper(v("?e")), pmin(v("?hi_a"), v("?hi_b")))
+                .ruleset("interval_expr")
+                .name("interval-min-upper"),
+        );
+        p.add_rule(
+            Rule::new()
+                .facts(vec![
+                    peq(v("?e"), max(v("?a"), v("?b"))),
+                    peq(v("?lo_a"), interval_lower(v("?a"))),
+                    peq(v("?lo_b"), interval_lower(v("?b"))),
+                ])
+                .set(interval_lower(v("?e")), pmax(v("?lo_a"), v("?lo_b")))
+                .ruleset("interval_expr")
+                .name("interval-max-lower"),
+        );
+        p.add_rule(
+            Rule::new()
+                .facts(vec![
+                    peq(v("?e"), max(v("?a"), v("?b"))),
+                    peq(v("?hi_a"), interval_upper(v("?a"))),
+                    peq(v("?hi_b"), interval_upper(v("?b"))),
+                ])
+                .set(interval_upper(v("?e")), pmax(v("?hi_a"), v("?hi_b")))
+                .ruleset("interval_expr")
+                .name("interval-max-upper"),
+        );
+        p.add_rule(
+            rewrite("interval-lt-true", lt(v("?x"), num(v("?n"))), num(i64(1)))
+                .when(vec![
+                    peq(v("?hi"), interval_upper(v("?x"))),
+                    plt(v("?hi"), v("?n")),
+                ])
+                .ruleset("interval_expr"),
+        );
+        p.add_rule(
+            rewrite("interval-lt-false", lt(v("?x"), num(v("?n"))), num(i64(0)))
+                .when(vec![
+                    peq(v("?lo"), interval_lower(v("?x"))),
+                    pgte(v("?lo"), v("?n")),
+                ])
+                .ruleset("interval_expr"),
+        );
+        p.add_rule(
+            rewrite("interval-gte-true", gte(v("?x"), num(v("?n"))), num(i64(1)))
+                .when(vec![
+                    peq(v("?lo"), interval_lower(v("?x"))),
+                    pgte(v("?lo"), v("?n")),
+                ])
+                .ruleset("interval_expr"),
+        );
+        p.add_rule(
+            rewrite(
+                "interval-gte-false",
+                gte(v("?x"), num(v("?n"))),
+                num(i64(0)),
+            )
+            .when(vec![
+                peq(v("?hi"), interval_upper(v("?x"))),
+                plt(v("?hi"), v("?n")),
+            ])
+            .ruleset("interval_expr"),
+        );
+        p.add_rule(
+            rewrite(
+                "interval-min-right-identity",
+                min(v("?x"), num(v("?n"))),
+                v("?x"),
+            )
+            .when(vec![
+                peq(v("?hi"), interval_upper(v("?x"))),
+                pgte(v("?n"), v("?hi")),
+            ])
+            .ruleset("interval_expr"),
+        );
+        p.add_rule(
+            rewrite(
+                "interval-max-right-identity",
+                max(v("?x"), num(v("?n"))),
+                v("?x"),
+            )
+            .when(vec![
+                peq(v("?lo"), interval_lower(v("?x"))),
+                pgte(v("?lo"), v("?n")),
+            ])
+            .ruleset("interval_expr"),
+        );
+        p.add_rule(
+            rewrite("interval-mod-small", modd(v("?x"), num(v("?n"))), v("?x"))
+                .when(vec![
+                    pgte(v("?n"), i64(1)),
+                    peq(v("?lo"), interval_lower(v("?x"))),
+                    peq(v("?hi"), interval_upper(v("?x"))),
+                    pgte(v("?lo"), i64(0)),
+                    plt(v("?hi"), v("?n")),
+                ])
+                .ruleset("interval_expr"),
+        );
+        p.add_rule(
+            rewrite(
+                "interval-div-small",
+                div(v("?x"), num(v("?n"))),
+                num(i64(0)),
+            )
+            .when(vec![
+                pgte(v("?n"), i64(1)),
+                peq(v("?lo"), interval_lower(v("?x"))),
+                peq(v("?hi"), interval_upper(v("?x"))),
+                pgte(v("?lo"), i64(0)),
+                plt(v("?hi"), v("?n")),
+            ])
+            .ruleset("interval_expr"),
+        );
+    }
 
     // `div-div`, restricted to nested constant divisors only. The original
     // unconstrained form `(a/b)/c → a/(b*c)` produces a new `div` whose

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -235,18 +235,26 @@ fn egglog_ruleset_declarations() -> String {
         .join("\n")
 }
 
-fn egglog_main_cycle_phases(cycle: usize) -> Vec<EgglogSchedulePhase> {
+fn expr_schedule(use_interval_analysis: bool) -> &'static str {
+    if use_interval_analysis {
+        "(saturate (seq expr interval_expr))"
+    } else {
+        "(saturate expr)"
+    }
+}
+
+fn egglog_main_cycle_phases(cycle: usize, use_interval_analysis: bool) -> Vec<EgglogSchedulePhase> {
     vec![EgglogSchedulePhase {
         name: format!("cycle {cycle:03} main"),
-        schedule: egglog_main_schedule(),
+        schedule: egglog_main_schedule(use_interval_analysis),
     }]
 }
 
-fn egglog_final_phases() -> Vec<EgglogSchedulePhase> {
+fn egglog_final_phases(use_interval_analysis: bool) -> Vec<EgglogSchedulePhase> {
     vec![
         EgglogSchedulePhase {
             name: "final expr".to_string(),
-            schedule: "(saturate expr)".to_string(),
+            schedule: expr_schedule(use_interval_analysis).to_string(),
         },
         EgglogSchedulePhase {
             name: "cleanup".to_string(),
@@ -263,14 +271,16 @@ fn egglog_final_phases() -> Vec<EgglogSchedulePhase> {
     ]
 }
 
-fn egglog_main_schedule() -> String {
+fn egglog_main_schedule(use_interval_analysis: bool) -> String {
+    let expr = expr_schedule(use_interval_analysis);
     // Producer rules create raw alternatives that downstream fusion consumes.
     // Fusion grow/merge only consumes Kernel*/FusionEnd alternatives, so keeping
     // producer discovery saturated before fusion reaches the same fixed point
     // while avoiding repeated expensive pair-discovery scans during growth.
-    "(saturate (seq
+    format!(
+        "(saturate (seq
         (saturate (seq
-            (saturate expr)
+            {expr}
             (saturate dtype_prop)
             (run matmul_flatten)
             (run kernel_lower)
@@ -282,19 +292,19 @@ fn egglog_main_schedule() -> String {
             (run fusion_pair)
         ))
         (saturate (seq
-            (saturate expr)
+            {expr}
             (saturate dtype_prop)
             (run fusion_grow)
             (run fusion_merge)
         ))
     ))"
-    .to_string()
+    )
 }
 
 fn egglog_schedule_program() -> String {
-    let mut schedules = vec![format!("(run-schedule {})", egglog_main_schedule())];
+    let mut schedules = vec![format!("(run-schedule {})", egglog_main_schedule(false))];
     schedules.extend(
-        egglog_final_phases()
+        egglog_final_phases(false)
             .into_iter()
             .map(|phase| format!("(run-schedule {})", phase.schedule)),
     );
@@ -302,9 +312,22 @@ fn egglog_schedule_program() -> String {
 }
 
 fn egglog_setup_with(program: &str, parts: &OpTextParts) -> String {
+    egglog_setup_with_options(program, parts, false)
+}
+
+fn egglog_setup_with_options(
+    program: &str,
+    parts: &OpTextParts,
+    use_interval_analysis: bool,
+) -> String {
+    let base_program = if use_interval_analysis {
+        base::base_expression_egglog_with_intervals()
+    } else {
+        base::base_expression_egglog()
+    };
     [
         egglog_ruleset_declarations(),
-        base::base_expression_egglog(),
+        base_program,
         parts.op_defs.clone(),
         parts.cleanups.clone(),
         base::base_cleanup_egglog(),
@@ -1130,6 +1153,19 @@ pub fn run_egglog_with_report_and_late_passes(
     run_egglog_with_report_parts(program, root, &op_parts)
 }
 
+#[tracing::instrument(skip_all)]
+pub fn run_egglog_with_report_late_passes_and_interval_analysis(
+    program: &str,
+    root: &str,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    cleanup: bool,
+    late_passes: &[LateEgglogPass],
+    use_interval_analysis: bool,
+) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
+    let op_parts = OpTextParts::new_with_late_passes(ops, cleanup, late_passes);
+    run_egglog_with_report_parts_impl(program, root, &op_parts, use_interval_analysis)
+}
+
 /// Same as [`run_egglog_with_report`], but takes pre-computed [`OpTextParts`].
 /// Useful when a caller runs many egglog invocations with the same op set
 /// and wants to factor the op-derived text work out of a parallel loop.
@@ -1139,6 +1175,15 @@ pub fn run_egglog_with_report_parts(
     program: &str,
     root: &str,
     op_parts: &OpTextParts,
+) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
+    run_egglog_with_report_parts_impl(program, root, op_parts, false)
+}
+
+fn run_egglog_with_report_parts_impl(
+    program: &str,
+    root: &str,
+    op_parts: &OpTextParts,
+    use_interval_analysis: bool,
 ) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
     #[cfg(debug_assertions)]
     {
@@ -1158,7 +1203,7 @@ pub fn run_egglog_with_report_parts(
 
     let full_start = std::time::Instant::now();
     let setup_text_start = std::time::Instant::now();
-    let setup_code = egglog_setup_with(program, op_parts);
+    let setup_code = egglog_setup_with_options(program, op_parts, use_interval_analysis);
     let setup_text_elapsed = setup_text_start.elapsed();
     let setup_lines = setup_code.lines().count();
     let mut egraph = egglog::EGraph::default();
@@ -1197,7 +1242,7 @@ pub fn run_egglog_with_report_parts(
     let mut reached_fixed_point = false;
     for cycle in 1..=MAIN_SCHEDULE_MAX_CYCLES {
         let mut cycle_updated = false;
-        for phase in egglog_main_cycle_phases(cycle) {
+        for phase in egglog_main_cycle_phases(cycle, use_interval_analysis) {
             cycle_updated |= run_schedule_phase(&mut egraph, &mut phases, &phase)?;
         }
         if egraph.num_tuples() > MAIN_SCHEDULE_MAX_TUPLES {
@@ -1217,7 +1262,7 @@ pub fn run_egglog_with_report_parts(
             "egglog saturation did not reach a fixed point within {MAIN_SCHEDULE_MAX_CYCLES} cycles"
         )));
     }
-    for phase in egglog_final_phases() {
+    for phase in egglog_final_phases(use_interval_analysis) {
         run_schedule_phase(&mut egraph, &mut phases, &phase)?;
     }
     for phase in &op_parts.late_phases {
@@ -1430,6 +1475,26 @@ pub fn run_egglog_with_late_passes(
 ) -> Result<SerializedEGraph, egglog::Error> {
     run_egglog_with_report_and_late_passes(program, root, ops, cleanup, late_passes)
         .map(|(egraph, _)| egraph)
+}
+
+#[tracing::instrument(skip_all)]
+pub fn run_egglog_with_late_passes_and_interval_analysis(
+    program: &str,
+    root: &str,
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    cleanup: bool,
+    late_passes: &[LateEgglogPass],
+    use_interval_analysis: bool,
+) -> Result<SerializedEGraph, egglog::Error> {
+    run_egglog_with_report_late_passes_and_interval_analysis(
+        program,
+        root,
+        ops,
+        cleanup,
+        late_passes,
+        use_interval_analysis,
+    )
+    .map(|(egraph, _)| egraph)
 }
 
 /// Same as [`run_egglog`] but takes pre-computed [`OpTextParts`], so the

--- a/src/frontend/binary.rs
+++ b/src/frontend/binary.rs
@@ -462,8 +462,8 @@ pub(super) mod tests {
         let b = cx.tensor(b_shape.clone());
         let c = func(a, b).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         let lhs_values = lhs_transform(random_vec(a_shape.iter().copied().product()));
         let rhs_values = rhs_transform(random_vec(b_shape.iter().copied().product()));

--- a/src/frontend/movement.rs
+++ b/src/frontend/movement.rs
@@ -967,8 +967,8 @@ mod tests {
         let values = cx.arange(6);
         let zeros = cx.iota(Expression::from(0usize), 6);
         let inv = values.scatter(perm, zeros).cast(DType::F32).output();
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         rt.set_data(data.id, vec![0., 1., 2., 3., 4., 5.]);
         rt.set_data(indexes.id, vec![5, 0, 3, 2]);
         rt.set_data(perm.id, vec![3, 2, 4, 1, 5, 0]);
@@ -984,8 +984,8 @@ mod tests {
         let indexes = cx.tensor(3).as_dtype(DType::Int);
         let dest = cx.tensor(5);
         let result = src.scatter(indexes, dest).output();
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         rt.set_data(src.id, vec![10., 20., 30.]);
         rt.set_data(indexes.id, vec![1, 3, 4]);
         rt.set_data(dest.id, vec![0., 0., 0., 0., 0.]);
@@ -1000,8 +1000,8 @@ mod tests {
         let indexes = cx.tensor(1).as_dtype(DType::Int);
         let dest = cx.tensor(5);
         let result = src.scatter(indexes, dest).output();
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         rt.set_data(src.id, vec![99.]);
         rt.set_data(indexes.id, vec![2]);
         rt.set_data(dest.id, vec![1., 2., 3., 4., 5.]);
@@ -1016,8 +1016,8 @@ mod tests {
         let indexes = cx.tensor(4).as_dtype(DType::Int);
         let dest = cx.tensor(4);
         let result = src.scatter(indexes, dest).output();
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         rt.set_data(src.id, vec![40., 30., 20., 10.]);
         rt.set_data(indexes.id, vec![3, 2, 1, 0]);
         rt.set_data(dest.id, vec![1., 2., 3., 4.]);
@@ -1044,8 +1044,8 @@ mod tests {
         let a = cx.tensor((2, 3));
         let repeated = (a.repeat((2, 2)) * 1.0).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         rt.set_data(a.id, vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
         rt.execute(&cx.dyn_map);
 

--- a/src/frontend/other.rs
+++ b/src/frontend/other.rs
@@ -125,8 +125,8 @@ mod tests {
         let mut cx = Graph::new();
         let b = func(&mut cx).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         rt.execute(&cx.dyn_map);
 
@@ -210,8 +210,8 @@ mod tests {
         let c = cx.tensor((2, 3));
         let stacked = cx.stack(&[a, b, c], 0).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         let a_data = random_vec(6);
         let b_data = random_vec(6);

--- a/src/frontend/unary.rs
+++ b/src/frontend/unary.rs
@@ -492,8 +492,8 @@ pub(super) mod tests {
         let a = cx.tensor(shape.clone());
         let b = func(a).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         let v = random_vec(shape.iter().copied().product());
         rt.set_data(a.id, v.clone());

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1,7 +1,8 @@
 use crate::egglog_utils::{
     count_choice_sets_up_to, egglog_to_llir, extract_generation, hash_choice_set, hlir_to_egglog,
-    random_initial_choice, run_egglog_with_late_passes,
+    random_initial_choice, run_egglog_with_late_passes_and_interval_analysis,
 };
+use crate::shape::{DimInterval, DynDimIntervals};
 use crate::{
     egglog_utils::SerializedEGraph,
     op::{EgglogOp, IntoEgglogOp, LLIROp},
@@ -74,12 +75,19 @@ struct RollingSearchReport {
     diagnostics: RollingSearchDiagnostics,
 }
 
+#[derive(Debug, Clone, Default)]
+struct SearchSpaceContext {
+    bucket_indices: FxHashMap<char, usize>,
+    representative_dyn_map: FxHashMap<char, usize>,
+    intervals: DynDimIntervals,
+}
+
 /// A compiled bucket: (bucket_indices, representative_dyn_map, stitched_llir).
 pub type BucketLLIR = (FxHashMap<char, usize>, FxHashMap<char, usize>, LLIRGraph);
 
 /// A bucket for a dynamic dimension, defining a range of valid values.
 /// For an exact value, use `min == max` (zero-length range).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DimBucket {
     pub min: usize,
     pub max: usize,
@@ -124,22 +132,61 @@ impl DimBucket {
     }
 }
 
-/// Options for building an e-graph search space.
+/// Options for building an e-graph search space and searching it.
 ///
-/// These options are attached to the built search space and used by search.
-#[derive(Debug, Clone, Copy, Default)]
-pub struct BuildSearchSpaceOptions {
+/// Use the builder pattern to configure search parameters:
+/// ```
+/// use luminal::prelude::CompileOptions;
+/// let opts = CompileOptions::new(5)
+///     .generation_size(50)
+///     .mutations(40)
+///     .trials(15);
+/// ```
+#[derive(Debug, Clone)]
+pub struct CompileOptions {
+    /// Maximum number of graphs to evaluate during search.
+    pub limit: usize,
     /// Optional maximum runtime-specific intermediate memory, in bytes.
     ///
     /// When this is `None`, search does not apply a memory cap. Runtimes that
     /// support memory estimates can use an explicitly provided limit to reject
     /// candidate graphs before profiling them.
     pub max_memory_bytes: Option<usize>,
+    /// Number of offspring per generation (default: 10)
+    pub generation_size: usize,
+    /// Number of mutations applied to each offspring (default: 10)
+    pub mutations: usize,
+    /// Number of profiling trials per candidate (default: 3)
+    pub trials: usize,
+    /// Number of best genomes to keep as parents per generation (default: 1)
+    pub keep_best: usize,
+    /// Per-candidate profiling timeout. If a profile call reaches this budget,
+    /// that candidate is discarded and search continues.
+    pub profile_timeout: Option<std::time::Duration>,
+    /// Optional per-group search timeout.
+    pub group_timeout: Option<std::time::Duration>,
+    /// Optional profiling dimension overrides.
+    pub profile_dims: FxHashMap<char, usize>,
+    /// Bucket definitions per dynamic dimension. Dimensions without buckets use
+    /// a single implicit bucket.
+    pub dim_buckets: FxHashMap<char, Vec<DimBucket>>,
 }
 
-impl BuildSearchSpaceOptions {
-    pub fn new() -> Self {
-        Self::default()
+impl CompileOptions {
+    /// Create compile options with the given search limit. Other fields use defaults.
+    pub fn new(limit: usize) -> Self {
+        Self {
+            limit,
+            max_memory_bytes: None,
+            generation_size: 10,
+            mutations: 10,
+            trials: 3,
+            keep_best: 1,
+            profile_timeout: Some(std::time::Duration::from_secs(1)),
+            group_timeout: None,
+            profile_dims: FxHashMap::default(),
+            dim_buckets: FxHashMap::default(),
+        }
     }
 
     /// Set a maximum intermediate memory budget in bytes.
@@ -156,53 +203,6 @@ impl BuildSearchSpaceOptions {
     /// Set a maximum intermediate memory budget in GiB.
     pub fn max_memory_gib(self, max_memory_gib: usize) -> Self {
         self.max_memory_bytes(max_memory_gib.saturating_mul(1024 * 1024 * 1024))
-    }
-}
-
-/// Options for controlling the genetic search algorithm.
-///
-/// Use the builder pattern to configure search parameters:
-/// ```
-/// use luminal::prelude::SearchOptions;
-/// let opts = SearchOptions::new(5)
-///     .generation_size(50)
-///     .mutations(40)
-///     .trials(15);
-/// ```
-#[derive(Debug, Clone)]
-pub struct SearchOptions {
-    /// Maximum number of graphs to evaluate
-    pub limit: usize,
-    /// Number of offspring per generation (default: 10)
-    pub generation_size: usize,
-    /// Number of mutations applied to each offspring (default: 10)
-    pub mutations: usize,
-    /// Number of profiling trials per candidate (default: 3)
-    pub trials: usize,
-    /// Number of best genomes to keep as parents per generation (default: 1)
-    pub keep_best: usize,
-    /// Per-candidate profiling timeout. If a profile call reaches this budget,
-    /// that candidate is discarded and search continues.
-    pub profile_timeout: Option<std::time::Duration>,
-    /// Optional per-group search timeout.
-    pub group_timeout: Option<std::time::Duration>,
-    /// Optional profiling dimension overrides.
-    pub profile_dims: FxHashMap<char, usize>,
-}
-
-impl SearchOptions {
-    /// Create new search options with the given limit. Other fields use defaults.
-    pub fn new(limit: usize) -> Self {
-        Self {
-            limit,
-            generation_size: 10,
-            mutations: 10,
-            trials: 3,
-            keep_best: 1,
-            profile_timeout: Some(std::time::Duration::from_secs(1)),
-            group_timeout: None,
-            profile_dims: FxHashMap::default(),
-        }
     }
 
     /// Set the number of offspring per generation.
@@ -245,6 +245,43 @@ impl SearchOptions {
     pub fn profile_dim(mut self, dim: char, value: usize) -> Self {
         self.profile_dims.insert(dim, value);
         self
+    }
+
+    /// Define buckets for a dynamic dimension.
+    ///
+    /// Bucketed compilation builds a separate search space and selected LLIR for
+    /// each bucket combination. Buckets must not overlap and must cover all
+    /// values that will be used at runtime.
+    pub fn dim_buckets(mut self, dimension: char, buckets: &[DimBucket]) -> Self {
+        validate_dim_buckets(dimension, buckets);
+        self.dim_buckets.insert(dimension, buckets.to_vec());
+        self
+    }
+}
+
+impl Default for CompileOptions {
+    fn default() -> Self {
+        Self::new(1)
+    }
+}
+
+fn validate_dim_buckets(dimension: char, buckets: &[DimBucket]) {
+    assert!(
+        !buckets.is_empty(),
+        "Buckets for dim '{dimension}' must not be empty"
+    );
+    for (i, a) in buckets.iter().enumerate() {
+        for b in buckets.iter().skip(i + 1) {
+            assert!(
+                a.max < b.min || b.max < a.min,
+                "Overlapping buckets for dim '{}': [{}, {}] and [{}, {}]",
+                dimension,
+                a.min,
+                a.max,
+                b.min,
+                b.max,
+            );
+        }
     }
 }
 
@@ -346,17 +383,18 @@ pub struct Graph {
     pub dyn_map: FxHashMap<char, usize>,
     /// Edge weights: (Input index, Output index, Input shape)
     pub graph: HLIRGraph,
-    /// E-Graph search space. Always exactly one e-graph; the `Vec` is kept
-    /// for the public `Graph::egraph()` accessor's `Option<&...>` shape.
+    /// E-Graph search spaces. Bucketed compilation stores one egraph per
+    /// bucket combination; unbucketed compilation stores one egraph.
     egraphs: Vec<SerializedEGraph>,
+    egraph_contexts: Vec<SearchSpaceContext>,
     /// Available ops
     pub ops: Option<Vec<Arc<Box<dyn EgglogOp>>>>,
     /// Custom ops
     pub custom_ops: Vec<Box<dyn CustomOp>>,
-    /// Bucket definitions per dynamic dimension. Dimensions without buckets use a
-    /// single implicit bucket (current behavior). When set, search compiles a
-    /// separate LLIR per bucket combination and runtime dispatches automatically.
-    pub dim_buckets: FxHashMap<char, Vec<DimBucket>>,
+    /// Bucket definitions used by the currently built search space.
+    search_space_dim_buckets: FxHashMap<char, Vec<DimBucket>>,
+    /// Optional graph-wide interval assumptions for dynamic dimensions.
+    pub dim_intervals: DynDimIntervals,
     /// Metadata for Input nodes: NodeIndex -> (label, dtype).
     /// Stored as plain data so it survives cross-binary type identity mismatches
     /// when external backend plugins are compiled separately.
@@ -708,29 +746,9 @@ impl Graph {
         self.dyn_map.insert(dimension, val);
     }
 
-    /// Define buckets for a dynamic dimension.
-    ///
-    /// When buckets are set, `search()` compiles a separate optimized LLIR graph
-    /// for each bucket combination. At runtime, `execute()` dispatches to the
-    /// appropriate compiled graph based on the current `dyn_map` values.
-    ///
-    /// Buckets must not overlap and must cover all values that will be used at runtime.
-    pub fn set_dim_buckets(&mut self, dimension: char, buckets: &[DimBucket]) {
-        // Validate no overlapping ranges
-        for (i, a) in buckets.iter().enumerate() {
-            for b in buckets.iter().skip(i + 1) {
-                assert!(
-                    a.max < b.min || b.max < a.min,
-                    "Overlapping buckets for dim '{}': [{}, {}] and [{}, {}]",
-                    dimension,
-                    a.min,
-                    a.max,
-                    b.min,
-                    b.max,
-                );
-            }
-        }
-        self.dim_buckets.insert(dimension, buckets.to_vec());
+    pub fn set_dim_interval(&mut self, dimension: char, min: i64, max: i64) {
+        self.dim_intervals
+            .insert(dimension, DimInterval::new(min, max));
     }
 
     /// Attempt to discover repeated HLIR regions and build explicit region
@@ -1102,64 +1120,100 @@ impl Graph {
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn build_search_space<Rt: Runtime + 'static>(&mut self) {
-        self.build_search_space_with_options::<Rt>(BuildSearchSpaceOptions::default());
-    }
-
-    #[tracing::instrument(skip_all)]
-    pub fn build_search_space_with_max_memory<Rt: Runtime + 'static>(
-        &mut self,
-        max_memory_bytes: usize,
-    ) {
-        self.build_search_space_with_options::<Rt>(
-            BuildSearchSpaceOptions::default().max_memory_bytes(max_memory_bytes),
-        );
-    }
-
-    #[tracing::instrument(skip_all)]
-    pub fn build_search_space_with_options<Rt: Runtime + 'static>(
-        &mut self,
-        options: BuildSearchSpaceOptions,
-    ) {
+    pub fn build_search_space<Rt: Runtime + 'static>(&mut self, options: CompileOptions) {
         self.run_auto_loop_rolling_prepass();
         let mut ops = Rt::Ops::into_vec();
         ops.extend(<crate::hlir::HLIROps as IntoEgglogOp>::into_vec());
         let cleanup_hlir = TypeId::of::<Rt>() != TypeId::of::<NativeRuntime>();
-        let memory_dyn_map = self.memory_limit_dyn_map();
+        let dim_buckets = options.dim_buckets.clone();
+        let memory_dyn_map = self.memory_limit_dyn_map(&dim_buckets);
         let late_passes = Rt::late_egglog_passes(&ops, &options, &memory_dyn_map);
 
         let (program, root) = hlir_to_egglog(self);
-        self.egraphs = vec![
-            run_egglog_with_late_passes(&program, &root, &ops, cleanup_hlir, &late_passes).unwrap(),
-        ];
+        let contexts = self.search_space_contexts(&dim_buckets);
+        self.egraphs = contexts
+            .iter()
+            .map(|context| {
+                let (contextual_program, use_interval_analysis) =
+                    self.egglog_program_with_interval_facts(&program, &context.intervals);
+                run_egglog_with_late_passes_and_interval_analysis(
+                    &contextual_program,
+                    &root,
+                    &ops,
+                    cleanup_hlir,
+                    &late_passes,
+                    use_interval_analysis,
+                )
+                .unwrap()
+            })
+            .collect();
+        self.egraph_contexts = contexts;
         self.ops = Some(ops);
         self.search_space_max_memory_bytes = options.max_memory_bytes;
+        self.search_space_dim_buckets = dim_buckets;
+    }
+
+    fn search_space_contexts(
+        &self,
+        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+    ) -> Vec<SearchSpaceContext> {
+        if dim_buckets.is_empty() {
+            return vec![SearchSpaceContext {
+                bucket_indices: FxHashMap::default(),
+                representative_dyn_map: self.dyn_map.clone(),
+                intervals: self.dim_intervals.clone(),
+            }];
+        }
+
+        self.bucket_combinations(dim_buckets)
+            .into_iter()
+            .map(|(bucket_indices, representative_dyn_map)| {
+                let mut intervals = self.dim_intervals.clone();
+                for (&dim, &idx) in &bucket_indices {
+                    let bucket = &dim_buckets[&dim][idx];
+                    let min = i64::try_from(bucket.min)
+                        .expect("DimBucket min must fit into i64 for interval analysis");
+                    let max = i64::try_from(bucket.max)
+                        .expect("DimBucket max must fit into i64 for interval analysis");
+                    let bucket_interval = DimInterval::new(min, max);
+                    intervals
+                        .entry(dim)
+                        .and_modify(|existing| {
+                            existing.min = existing.min.max(bucket_interval.min);
+                            existing.max = existing.max.min(bucket_interval.max);
+                            assert!(
+                                existing.min <= existing.max,
+                                "Bucket interval for dim '{dim}' does not overlap graph interval"
+                            );
+                        })
+                        .or_insert(bucket_interval);
+                }
+                SearchSpaceContext {
+                    bucket_indices,
+                    representative_dyn_map,
+                    intervals,
+                }
+            })
+            .collect()
+    }
+
+    fn egglog_program_with_interval_facts(
+        &self,
+        program: &str,
+        intervals: &DynDimIntervals,
+    ) -> (String, bool) {
+        let facts = crate::egglog_utils::base::interval_facts_egglog(intervals, []);
+        if facts.is_empty() {
+            (program.to_string(), false)
+        } else {
+            (format!("{facts}\n{program}"), true)
+        }
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn build_search_space_exclude_ops<Rt: Runtime + 'static, Ex: IntoEgglogOp>(&mut self) {
-        self.build_search_space_exclude_ops_with_options::<Rt, Ex>(
-            BuildSearchSpaceOptions::default(),
-        );
-    }
-
-    #[tracing::instrument(skip_all)]
-    pub fn build_search_space_exclude_ops_with_max_memory<
-        Rt: Runtime + 'static,
-        Ex: IntoEgglogOp,
-    >(
+    pub fn build_search_space_exclude_ops<Rt: Runtime + 'static, Ex: IntoEgglogOp>(
         &mut self,
-        max_memory_bytes: usize,
-    ) {
-        self.build_search_space_exclude_ops_with_options::<Rt, Ex>(
-            BuildSearchSpaceOptions::default().max_memory_bytes(max_memory_bytes),
-        );
-    }
-
-    #[tracing::instrument(skip_all)]
-    pub fn build_search_space_exclude_ops_with_options<Rt: Runtime + 'static, Ex: IntoEgglogOp>(
-        &mut self,
-        options: BuildSearchSpaceOptions,
+        options: CompileOptions,
     ) {
         self.run_auto_loop_rolling_prepass();
         let exclude_ops = Ex::into_vec()
@@ -1170,15 +1224,32 @@ impl Graph {
         ops.retain(|o| !exclude_ops.contains(&o.sort().name));
         ops.extend(<crate::hlir::HLIROps as IntoEgglogOp>::into_vec());
         let cleanup_hlir = TypeId::of::<Rt>() != TypeId::of::<NativeRuntime>();
-        let memory_dyn_map = self.memory_limit_dyn_map();
+        let dim_buckets = options.dim_buckets.clone();
+        let memory_dyn_map = self.memory_limit_dyn_map(&dim_buckets);
         let late_passes = Rt::late_egglog_passes(&ops, &options, &memory_dyn_map);
 
         let (program, root) = hlir_to_egglog(self);
-        self.egraphs = vec![
-            run_egglog_with_late_passes(&program, &root, &ops, cleanup_hlir, &late_passes).unwrap(),
-        ];
+        let contexts = self.search_space_contexts(&dim_buckets);
+        self.egraphs = contexts
+            .iter()
+            .map(|context| {
+                let (contextual_program, use_interval_analysis) =
+                    self.egglog_program_with_interval_facts(&program, &context.intervals);
+                run_egglog_with_late_passes_and_interval_analysis(
+                    &contextual_program,
+                    &root,
+                    &ops,
+                    cleanup_hlir,
+                    &late_passes,
+                    use_interval_analysis,
+                )
+                .unwrap()
+            })
+            .collect();
+        self.egraph_contexts = contexts;
         self.ops = Some(ops);
         self.search_space_max_memory_bytes = options.max_memory_bytes;
+        self.search_space_dim_buckets = dim_buckets;
     }
 
     /// Get a reference to the first e-graph search space (if built)
@@ -1191,37 +1262,68 @@ impl Graph {
         self.ops.as_ref()
     }
 
+    /// Build the search space and search it with one shared set of options.
+    ///
+    /// This is the usual compile entry point when runtime inputs such as
+    /// weights have already been loaded. Use `build_search_space` and `search`
+    /// directly when the two phases need to be separated.
     #[tracing::instrument(skip_all)]
-    pub fn search<R: Runtime + 'static>(&mut self, runtime: R, limit: usize) -> R {
+    pub fn compile<R: Runtime + 'static>(&mut self, runtime: R, options: CompileOptions) -> R {
         let mut rng = rand::rng();
-        self.search_options(runtime, SearchOptions::new(limit), &mut rng)
+        self.compile_with_rng(runtime, options, &mut rng)
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn search_options<R: Runtime + 'static, G: rand::Rng>(
+    pub fn compile_with_rng<R: Runtime + 'static, G: rand::Rng>(
         &mut self,
-        mut runtime: R,
-        options: SearchOptions,
+        runtime: R,
+        options: CompileOptions,
         rng: &mut G,
     ) -> R {
-        if self.dim_buckets.is_empty() {
+        self.build_search_space::<R>(options.clone());
+        self.search_with_rng(runtime, options, rng)
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn search<R: Runtime + 'static>(&mut self, runtime: R, options: CompileOptions) -> R {
+        let mut rng = rand::rng();
+        self.search_with_rng(runtime, options, &mut rng)
+    }
+
+    #[tracing::instrument(skip_all)]
+    pub fn search_with_rng<R: Runtime + 'static, G: rand::Rng>(
+        &mut self,
+        mut runtime: R,
+        options: CompileOptions,
+        rng: &mut G,
+    ) -> R {
+        assert!(
+            options.dim_buckets.is_empty() || options.dim_buckets == self.search_space_dim_buckets,
+            "dim buckets must be configured in CompileOptions before build_search_space; search cannot change buckets after build",
+        );
+
+        if self.search_space_dim_buckets.is_empty() {
             // No buckets: existing single-search path
             let stitched =
-                self.search_single(&mut runtime, &options, rng, &self.dyn_map.clone(), None);
+                self.search_single(&mut runtime, &options, rng, &self.dyn_map.clone(), None, 0);
 
             runtime.clear_intermediate_buffers();
             runtime.load_llir(&stitched);
             runtime
         } else {
             // Bucketed search: compile one LLIR per bucket combination
-            let bucket_combos = self.bucket_combinations();
-            let n_combos = bucket_combos.len();
+            let bucket_contexts = self.search_space_contexts(&self.search_space_dim_buckets);
+            let n_combos = bucket_contexts.len();
             let mut bucket_llirs: Vec<BucketLLIR> = Vec::with_capacity(n_combos);
+            assert!(
+                self.egraphs.len() == n_combos,
+                "dim buckets must be configured before build_search_space; search space has {} egraphs but current bucket configuration has {n_combos} combinations",
+                self.egraphs.len(),
+            );
 
-            for (combo_idx, (bucket_indices, representative_dyn_map)) in
-                bucket_combos.into_iter().enumerate()
-            {
-                let bucket_label = self.format_bucket_label(&bucket_indices);
+            for (combo_idx, context) in bucket_contexts.into_iter().enumerate() {
+                let bucket_label = self
+                    .format_bucket_label(&self.search_space_dim_buckets, &context.bucket_indices);
                 println!(
                     "   {:>6}  Group {}/{}: {}",
                     "Search".cyan().bold(),
@@ -1234,23 +1336,31 @@ impl Graph {
                     &mut runtime,
                     &options,
                     rng,
-                    &representative_dyn_map,
+                    &context.representative_dyn_map,
                     Some((combo_idx, n_combos)),
+                    combo_idx,
                 );
-                bucket_llirs.push((bucket_indices, representative_dyn_map, stitched));
+                bucket_llirs.push((
+                    context.bucket_indices,
+                    context.representative_dyn_map,
+                    stitched,
+                ));
             }
 
             runtime.clear_intermediate_buffers();
-            runtime.load_llir_buckets(&self.dim_buckets, &bucket_llirs);
+            runtime.load_llir_buckets(&self.search_space_dim_buckets, &bucket_llirs);
             runtime
         }
     }
 
     /// Compute cartesian product of all bucket combinations.
     /// Returns Vec of (bucket_indices, representative_dyn_map).
-    fn bucket_combinations(&self) -> Vec<(FxHashMap<char, usize>, FxHashMap<char, usize>)> {
+    fn bucket_combinations(
+        &self,
+        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+    ) -> Vec<(FxHashMap<char, usize>, FxHashMap<char, usize>)> {
         let mut dims: Vec<(char, &Vec<DimBucket>)> =
-            self.dim_buckets.iter().map(|(c, b)| (*c, b)).collect();
+            dim_buckets.iter().map(|(c, b)| (*c, b)).collect();
         dims.sort_by_key(|(c, _)| *c);
 
         let mut combos: Vec<(FxHashMap<char, usize>, FxHashMap<char, usize>)> =
@@ -1273,9 +1383,12 @@ impl Graph {
         combos
     }
 
-    fn memory_limit_dyn_map(&self) -> FxHashMap<char, usize> {
+    fn memory_limit_dyn_map(
+        &self,
+        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+    ) -> FxHashMap<char, usize> {
         let mut dyn_map = self.dyn_map.clone();
-        for (&dim, buckets) in &self.dim_buckets {
+        for (&dim, buckets) in dim_buckets {
             if let Some(max) = buckets.iter().map(|bucket| bucket.max).max() {
                 dyn_map.insert(dim, max);
             }
@@ -1284,12 +1397,16 @@ impl Graph {
     }
 
     /// Format a human-readable label for a bucket combination.
-    fn format_bucket_label(&self, bucket_indices: &FxHashMap<char, usize>) -> String {
+    fn format_bucket_label(
+        &self,
+        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        bucket_indices: &FxHashMap<char, usize>,
+    ) -> String {
         let mut parts: Vec<String> = Vec::new();
         let mut dims: Vec<_> = bucket_indices.iter().collect();
         dims.sort_by_key(|(c, _)| **c);
         for (dim, &idx) in dims {
-            let bucket = &self.dim_buckets[dim][idx];
+            let bucket = &dim_buckets[dim][idx];
             if bucket.min == bucket.max {
                 parts.push(format!("{}={}", dim, bucket.min));
             } else {
@@ -1311,10 +1428,11 @@ impl Graph {
     fn search_single<R: Runtime + 'static, G: rand::Rng>(
         &mut self,
         runtime: &mut R,
-        options: &SearchOptions,
+        options: &CompileOptions,
         rng: &mut G,
         dyn_map: &FxHashMap<char, usize>,
         bucket_progress: Option<(usize, usize)>,
+        egraph_index: usize,
     ) -> LLIRGraph {
         let mut profile_dyn_map = dyn_map.clone();
         for (&dim, &value) in &options.profile_dims {
@@ -1322,7 +1440,7 @@ impl Graph {
         }
         let limit = options.limit;
         let ops = self.ops.as_ref().unwrap();
-        let egraph = &self.egraphs[0];
+        let egraph = &self.egraphs[egraph_index];
         let search_limit = count_choice_sets_up_to(egraph, limit);
         let start = std::time::Instant::now();
 
@@ -2732,7 +2850,7 @@ mod tests {
         let mut cx = Graph::new();
         let _ = cx.tensor(1).output();
 
-        cx.build_search_space::<TestMemoryRuntime>();
+        cx.build_search_space::<TestMemoryRuntime>(CompileOptions::default());
 
         assert_eq!(cx.search_space_max_memory_bytes, None);
     }
@@ -2742,11 +2860,60 @@ mod tests {
     fn build_search_space_max_memory_rejects_candidates() {
         let mut cx = Graph::new();
         let _ = cx.tensor(1).output();
-        cx.build_search_space_with_options::<TestMemoryRuntime>(
-            BuildSearchSpaceOptions::new().max_memory_bytes(0),
+        cx.build_search_space::<TestMemoryRuntime>(CompileOptions::default().max_memory_bytes(0));
+
+        let _ = cx.search(TestMemoryRuntime, CompileOptions::new(1));
+    }
+
+    #[test]
+    fn compile_builds_search_space_and_searches_it() {
+        let mut cx = Graph::new();
+        let _ = cx.tensor(1).output();
+
+        let _ = cx.compile(TestMemoryRuntime, CompileOptions::new(1));
+
+        assert_eq!(cx.egraphs.len(), 1);
+        assert_eq!(cx.search_space_max_memory_bytes, None);
+    }
+
+    #[test]
+    fn bucketed_build_search_space_builds_one_egraph_per_bucket() {
+        let mut cx = Graph::new();
+        let _ = cx.tensor('s').output();
+
+        cx.build_search_space::<TestMemoryRuntime>(
+            CompileOptions::default()
+                .dim_buckets('s', &[DimBucket::new(1, 1), DimBucket::new(2, 4)]),
         );
 
-        let _ = cx.search(TestMemoryRuntime, 1);
+        assert_eq!(cx.egraphs.len(), 2);
+        assert_eq!(cx.egraph_contexts.len(), 2);
+        assert_eq!(
+            cx.egraph_contexts[0].intervals[&'s'],
+            DimInterval::new(1, 1)
+        );
+        assert_eq!(
+            cx.egraph_contexts[1].intervals[&'s'],
+            DimInterval::new(2, 4)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "search cannot change buckets after build")]
+    fn search_with_rng_dim_buckets_after_build_search_space_panics() {
+        let mut cx = Graph::new();
+        let _ = cx.tensor('s').output();
+
+        cx.build_search_space::<TestMemoryRuntime>(CompileOptions::default());
+        let mut rng = rand::rng();
+        let _ = cx.search_with_rng(
+            TestMemoryRuntime,
+            CompileOptions::new(1).dim_buckets(
+                's',
+                &[DimBucket::new(1, 1), DimBucket::new(2, 4).representative(4)],
+            ),
+            &mut rng,
+        );
     }
 
     #[test]
@@ -2851,8 +3018,8 @@ mod tests {
 
         let vals = random_vec(8);
         let mut rt = NativeRuntime::default();
-        cx.build_search_space::<NativeRuntime>();
-        rt = cx.search(rt, 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::new(1));
         rt.set_data(x.id, vals.clone());
         rt.execute(&cx.dyn_map);
 
@@ -2888,8 +3055,8 @@ mod tests {
 
         let vals = random_vec(8);
         let mut rt = NativeRuntime::default();
-        cx.build_search_space::<NativeRuntime>();
-        rt = cx.search(rt, 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        rt = cx.search(rt, CompileOptions::new(1));
         rt.set_data(x.id, vals.clone());
         rt.execute(&cx.dyn_map);
 

--- a/src/op.rs
+++ b/src/op.rs
@@ -18,7 +18,7 @@ pub trait Runtime {
     /// to Luminal core.
     fn late_egglog_passes(
         _ops: &[Arc<Box<dyn EgglogOp>>],
-        _options: &crate::graph::BuildSearchSpaceOptions,
+        _options: &crate::graph::CompileOptions,
         _dyn_map: &FxHashMap<char, usize>,
     ) -> Vec<crate::egglog_utils::LateEgglogPass>
     where

--- a/src/shape/expression.rs
+++ b/src/shape/expression.rs
@@ -20,12 +20,48 @@ type ExprBox = GenerationalBox<Vec<Term>, SyncStorage>;
 
 pub static EXPR_OWNER: OnceLock<Owner<SyncStorage>> = OnceLock::new();
 static SIMPLIFY_CACHE: OnceLock<Mutex<LruCache<Expression, Expression>>> = OnceLock::new();
+static INTERVAL_SIMPLIFY_CACHE: OnceLock<Mutex<LruCache<IntervalSimplifyKey, Expression>>> =
+    OnceLock::new();
 static EXPRESSION_INTERNER: OnceLock<RwLock<FxHashMap<Vec<Term>, ExprBox>>> = OnceLock::new();
 
 const MAX_CACHED_SIMPLIFICATIONS: usize = 10_000;
 
 pub fn expr(e: impl Into<Expression>) -> Expression {
     e.into()
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct DimInterval {
+    pub min: i64,
+    pub max: i64,
+}
+
+impl DimInterval {
+    pub fn new(min: i64, max: i64) -> Self {
+        assert!(min <= max, "DimInterval min ({min}) must be <= max ({max})");
+        Self { min, max }
+    }
+
+    pub fn unbounded() -> Self {
+        Self {
+            min: 0,
+            max: i64::MAX,
+        }
+    }
+}
+
+pub type DynDimIntervals = FxHashMap<char, DimInterval>;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+struct IntervalSimplifyKey {
+    expr: Expression,
+    intervals: Vec<(char, DimInterval)>,
+}
+
+fn canonical_intervals(intervals: &DynDimIntervals) -> Vec<(char, DimInterval)> {
+    let mut intervals = intervals.iter().map(|(&c, &i)| (c, i)).collect::<Vec<_>>();
+    intervals.sort_by_key(|(c, _)| *c);
+    intervals
 }
 
 #[derive(Copy, Clone)]
@@ -92,6 +128,9 @@ impl Expression {
         }
         // Also clear the simplify cache since it contains Expression keys
         if let Some(cache) = SIMPLIFY_CACHE.get() {
+            cache.lock().unwrap().clear();
+        }
+        if let Some(cache) = INTERVAL_SIMPLIFY_CACHE.get() {
             cache.lock().unwrap().clear();
         }
     }
@@ -384,6 +423,19 @@ impl Expression {
         }
 
         egglog_simplify(self)
+    }
+
+    /// Simplify the expression under dynamic-dimension interval assumptions.
+    ///
+    /// Rewrites using these bounds are only valid for assignments inside the
+    /// provided intervals, so this uses a cache distinct from unconstrained
+    /// simplification.
+    #[tracing::instrument(skip_all)]
+    pub fn simplify_with_intervals(self, intervals: &DynDimIntervals) -> Self {
+        if intervals.is_empty() {
+            return self.simplify();
+        }
+        egglog_simplify_with_intervals(self, intervals)
     }
     pub fn as_num(&self) -> Option<i64> {
         if let Term::Num(n) = self.terms.read()[0] {
@@ -1140,6 +1192,58 @@ fn egglog_simplify(e: Expression) -> Expression {
     simplified
 }
 
+#[tracing::instrument(skip_all)]
+fn egglog_simplify_with_intervals(e: Expression, intervals: &DynDimIntervals) -> Expression {
+    let key = IntervalSimplifyKey {
+        expr: e,
+        intervals: canonical_intervals(intervals),
+    };
+    let cache = INTERVAL_SIMPLIFY_CACHE.get_or_init(|| {
+        Mutex::new(LruCache::<IntervalSimplifyKey, Expression>::new(
+            NonZeroUsize::new(MAX_CACHED_SIMPLIFICATIONS).unwrap(),
+        ))
+    });
+
+    if let Some(out) = cache.lock().unwrap().get(&key).copied() {
+        return out;
+    }
+
+    let expr = e.to_egglog();
+    let interval_facts =
+        egglog_utils::base::interval_facts_egglog(intervals, e.dyn_vars().into_iter());
+    let mut program = String::new();
+    program.push_str(&egglog_utils::base::base_expression_egglog_with_intervals());
+    program.push('\n');
+    program.push_str(&egglog_utils::base::base_cleanup_egglog());
+    program.push('\n');
+    program.push_str(&interval_facts);
+    program.push('\n');
+    program.push_str(&format!("(let expr_root {expr})\n"));
+    program.push_str(
+        "(run-schedule
+            (repeat 5 (seq expr interval_expr))
+            (saturate base_cleanup)
+            (saturate cleanup)
+        )",
+    );
+    let mut egraph = egglog::EGraph::default();
+    let commands = egraph
+        .parser
+        .get_program_from_string(None, &program)
+        .unwrap();
+    egraph.run_program(commands).unwrap();
+    let (sort, value) = egraph.eval_expr(&var!("expr_root")).unwrap();
+    let serialized = SerializedEGraph::new(&egraph, vec![(sort, value)]);
+    let simplified = serialized.eclasses[serialized.roots.first().unwrap()]
+        .1
+        .iter()
+        .map(|root| extract_expr(&serialized, root, &mut FxHashMap::default()).unwrap_or(e))
+        .min_by_key(|e| e.len())
+        .unwrap();
+    cache.lock().unwrap().push(key, simplified);
+    simplified
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1194,6 +1298,27 @@ mod tests {
             (((z * 6 + 5) / 6) * 6 + ((z * 6 + 5) % 6)).simplify(),
             z * 6 + 5
         );
+    }
+
+    #[test]
+    fn test_interval_simplifications() {
+        let s = expr('s');
+        let intervals = [('s', DimInterval::new(0, 127))].into_iter().collect();
+
+        assert_eq!((s % 128).simplify_with_intervals(&intervals), s);
+        assert_eq!((s / 128).simplify_with_intervals(&intervals), expr(0));
+        assert_eq!(s.lt(128).simplify_with_intervals(&intervals), expr(1));
+        assert_eq!(s.gte(128).simplify_with_intervals(&intervals), expr(0));
+        assert_eq!(s.min(128).simplify_with_intervals(&intervals), s);
+    }
+
+    #[test]
+    fn test_interval_simplification_requires_proof() {
+        let s = expr('s');
+        let intervals = [('s', DimInterval::new(0, 256))].into_iter().collect();
+
+        assert_ne!((s % 128).simplify_with_intervals(&intervals), s);
+        assert_ne!(s.lt(128).simplify_with_intervals(&intervals), expr(1));
     }
 
     #[test]

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -23,8 +23,8 @@ proptest! {
         let a = (b * c + g).output();
         let d = (b * c / e).sin().output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
         rt.set_data(b.id, vals.clone());
         rt.set_data(c.id, vals.clone());
@@ -57,8 +57,8 @@ proptest! {
 
         let a = b.matmul(c).output();
 
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         let lhs = lhs.into_iter().take(m * k).collect::<Vec<f32>>();
         let rhs = rhs.into_iter().take(k * n).collect::<Vec<f32>>();
         rt.set_data(b.id, lhs.clone());
@@ -81,8 +81,8 @@ proptest! {
         let mut cx = Graph::new();
         let a = cx.tensor((2, 2));
         let b = (a.permute((1, 0)) * 1.0).output();
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         rt.set_data(a.id, values.clone());
         rt.execute(&cx.dyn_map);
 
@@ -98,8 +98,8 @@ proptest! {
         let kth_largest = a.gather(a.topk_indexes(k, 1).slice((.., (k - 1)..k)).squeeze(1));
         let mask = a.ge(kth_largest.expand_dim(1, cols)).cast(crate::dtype::DType::F32);
         let filtered = (a * mask).output();
-        cx.build_search_space::<NativeRuntime>();
-        let mut rt = cx.search(NativeRuntime::default(), 1);
+        cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+        let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
         let values = values.into_iter().take(rows * cols).collect::<Vec<f32>>();
         rt.set_data(a.id, values.clone());
         rt.execute(&cx.dyn_map);
@@ -191,7 +191,7 @@ fn fuzz_test_genome_validity() {
     let _out = f.output();
 
     // Build search space
-    cx.build_search_space::<NativeRuntime>();
+    cx.build_search_space::<NativeRuntime>(CompileOptions::default());
     let egraph = cx.egraph().unwrap();
     let ops = cx.egglog_ops().unwrap();
 
@@ -334,7 +334,7 @@ fn fuzz_test_genome_execution() {
     let b = cx.tensor((2, 3));
     let c = (a + b).relu().output();
 
-    cx.build_search_space::<NativeRuntime>();
+    cx.build_search_space::<NativeRuntime>(CompileOptions::default());
     let egraph = cx.egraph().unwrap();
     let ops = cx.egglog_ops().unwrap();
 
@@ -464,8 +464,8 @@ fn test_inputs_consumed_after_execute() {
     let mut cx = Graph::new();
     let a = cx.tensor(3);
     let _b = (a * 2.0).output();
-    cx.build_search_space::<NativeRuntime>();
-    let mut rt = cx.search(NativeRuntime::default(), 1);
+    cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+    let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
     rt.set_data(a.id, vec![1.0, 2.0, 3.0]);
     rt.execute(&cx.dyn_map);
     // Second execute should panic — input 'a' was consumed
@@ -480,8 +480,8 @@ fn test_passthrough_preserves_weights() {
     let y = (w * x).output();
     w.persist();
 
-    cx.build_search_space::<NativeRuntime>();
-    let mut rt = cx.search(NativeRuntime::default(), 1);
+    cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+    let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
 
     // Iteration 1
     rt.set_data(w.id, vec![1.0, 2.0, 3.0]);
@@ -502,8 +502,8 @@ fn test_only_outputs_remain() {
     let mut cx = Graph::new();
     let a = cx.tensor(3);
     let _b = (a * 2.0).output();
-    cx.build_search_space::<NativeRuntime>();
-    let mut rt = cx.search(NativeRuntime::default(), 1);
+    cx.build_search_space::<NativeRuntime>(CompileOptions::default());
+    let mut rt = cx.search(NativeRuntime::default(), CompileOptions::new(1));
     rt.set_data(a.id, vec![1.0, 2.0, 3.0]);
     rt.execute(&cx.dyn_map);
     let output_count = rt
@@ -555,8 +555,8 @@ fn integration_auto_loop_rolling_matches_reference_native_runtime() {
     let reference = repeated_block_reference(layers, &input, &weights);
 
     let (mut graph, input_id, weight_ids, output_id) = build_repeated_block_graph(layers, width);
-    graph.build_search_space::<NativeRuntime>();
-    let mut rt = graph.search(NativeRuntime::default(), 1);
+    graph.build_search_space::<NativeRuntime>(CompileOptions::default());
+    let mut rt = graph.search(NativeRuntime::default(), CompileOptions::new(1));
     rt.set_data(input_id, input);
     for (node, data) in weight_ids.iter().zip(weights.iter()) {
         rt.set_data(*node, data.clone());


### PR DESCRIPTION
## Summary
- Move dynamic-dimension bucket definitions into `CompileOptions` so bucketed compilation is configured at build time.
- Unify the public compile/search entry points so `build_search_space`, `compile`, and `search` all take `CompileOptions` directly.
- Remove the old `_options` variants and update CUDA, Metal, NN, bench, and example call sites to the new API.
- Keep bucketed dispatch behavior intact while enforcing that bucket configuration is fixed once the search space is built.

## Testing
- `cargo fmt`
- `cargo clippy -p luminal -- -D warnings`
- `cargo test -p luminal`
- `cargo test -p luminal_cuda_lite tests::bucket_tests`
- `cargo test -p luminal_cuda_lite --no-run`
- `cargo check -p llama -p gemma -p qwen --features cuda -p qwen3_moe -p gemma4_moe -p whisper -p paged_llama`
- `cargo check -p flux2`
- `cargo check -p luminal_nn`
- `cargo check -p yolo_v11`
- `cargo check -p simple`
- `cargo check -p luminal_bench`