### PR TITLE
Optimize llama on metal

### DIFF
--- a/crates/luminal_metal/Cargo.toml
+++ b/crates/luminal_metal/Cargo.toml
@@ -28,5 +28,8 @@ rustc-hash = "2.1"
 tokenizers = "0.22.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[features]
+debug = []
+
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy"))'] }
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(feature, values("cargo-clippy", "debug"))'] }

--- a/crates/luminal_metal/examples/llama_1b.rs
+++ b/crates/luminal_metal/examples/llama_1b.rs
@@ -207,6 +207,7 @@ impl Llama {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn forward(
         &self,
         input: GraphTensor,

--- a/crates/luminal_metal/examples/llama_1b.rs
+++ b/crates/luminal_metal/examples/llama_1b.rs
@@ -214,6 +214,7 @@ impl Llama {
         scatter_idx: GraphTensor,
         gather_idx: GraphTensor,
         attn_mask: GraphTensor,
+        last_idx: GraphTensor,
         kv_cache: &KVCache,
     ) -> (GraphTensor, Vec<(GraphTensor, GraphTensor)>) {
         let seq = input.dims1();
@@ -236,7 +237,9 @@ impl Llama {
             cache_outputs.push((k_out, v_out));
         }
 
-        let logits = self.lm_norm.forward(x).matmul(self.embedding.t());
+        // Only compute logits for the last query token (saves ~seq_len× lm_head compute)
+        let last_x = gather_rows(x, last_idx, HIDDEN);
+        let logits = self.lm_norm.forward(last_x).matmul(self.embedding.t());
         (logits, cache_outputs)
     }
 }
@@ -283,15 +286,18 @@ fn llama_rotary_embeddings(mut input: GraphTensor, pos_ids: GraphTensor) -> Grap
 
 #[allow(clippy::too_many_arguments)]
 fn attention(
-    q_rope: GraphTensor,
-    k_rope: GraphTensor,
+    q: GraphTensor,
+    k: GraphTensor,
     v: GraphTensor,
+    q_pos: GraphTensor,
     k_cache: GraphTensor,
     v_cache: GraphTensor,
     scatter_idx: GraphTensor,
     gather_idx: GraphTensor,
     attn_mask: GraphTensor,
 ) -> (GraphTensor, GraphTensor, GraphTensor) {
+    let q_rope = llama_rotary_embeddings(q, q_pos);
+    let k_rope = llama_rotary_embeddings(k, q_pos);
     let k_cache_out = scatter_rows(k_rope, scatter_idx, k_cache, KV_DIM);
     let v_cache_out = scatter_rows(v, scatter_idx, v_cache, KV_DIM);
 
@@ -330,13 +336,11 @@ impl LlamaLayer {
         let q = x_attn.matmul(self.q_proj.t());
         let k = x_attn.matmul(self.k_proj.t());
         let v = x_attn.matmul(self.v_proj.t());
-
-        let q_rope = llama_rotary_embeddings(q, q_pos);
-        let k_rope = llama_rotary_embeddings(k, q_pos);
         let (attn_out, k_cache_out, v_cache_out) = attention(
-            q_rope,
-            k_rope,
+            q,
+            k,
             v,
+            q_pos,
             k_cache,
             v_cache,
             scatter_idx,
@@ -361,6 +365,7 @@ fn run_model_step(
     scatter_idx_t: GraphTensor,
     gather_idx_t: GraphTensor,
     attn_mask_t: GraphTensor,
+    last_idx_t: GraphTensor,
     logits: GraphTensor,
     kv_cache: &KVCache,
     cache_outputs: &[(GraphTensor, GraphTensor)],
@@ -375,11 +380,11 @@ fn run_model_step(
     cx.set_dim('c', gather_idx.len());
 
     runtime.set_data(input, tokens.iter().map(|t| *t as i32).collect::<Vec<_>>());
-    runtime.set_data(q_pos_t, q_pos.to_vec());
-    runtime.set_data(scatter_idx_t, scatter_idx.to_vec());
-    runtime.set_data(gather_idx_t, gather_idx.to_vec());
-    runtime.set_data(attn_mask_t, attn_mask.to_vec());
-    runtime.allocate_intermediate_buffers(&cx.dyn_map);
+    runtime.set_data(q_pos_t, q_pos);
+    runtime.set_data(scatter_idx_t, scatter_idx);
+    runtime.set_data(gather_idx_t, gather_idx);
+    runtime.set_data(attn_mask_t, attn_mask);
+    runtime.set_data(last_idx_t, &[tokens.len() as i32 - 1]);
 
     let execute_start = Instant::now();
     runtime.execute(&cx.dyn_map);
@@ -392,8 +397,8 @@ fn run_model_step(
     let cache_start = Instant::now();
     for (layer_idx, (k_out, v_out)) in cache_outputs.iter().enumerate() {
         let k_buf = runtime.remove_buffer(*k_out);
-        let v_buf = runtime.remove_buffer(*v_out);
         runtime.set_buffer(kv_cache.k_caches[layer_idx], k_buf);
+        let v_buf = runtime.remove_buffer(*v_out);
         runtime.set_buffer(kv_cache.v_caches[layer_idx], v_buf);
     }
     let cache_roundtrip = cache_start.elapsed();
@@ -425,6 +430,12 @@ fn main() -> Result<(), Box<dyn Error>> {
         .map_err(|err| err as Box<dyn Error>)?
         .get_ids()
         .to_vec();
+    let max_prefill = (prompt_tokens.len() + 16)
+        .next_power_of_two()
+        .min(MAX_SEQ_LEN);
+    let max_context = (prompt_tokens.len() + GEN_TOKENS + 1)
+        .next_power_of_two()
+        .min(MAX_SEQ_LEN);
 
     let mut cx = Graph::default();
     let input = cx.named_tensor("input", 's').as_dtype(DType::Int);
@@ -432,13 +443,16 @@ fn main() -> Result<(), Box<dyn Error>> {
     let scatter_idx_t = cx.named_tensor("scatter_idx", 's').as_dtype(DType::Int);
     let gather_idx_t = cx.named_tensor("gather_idx", 'c').as_dtype(DType::Int);
     let attn_mask_t = cx.named_tensor("attn_mask", ('s', 'c'));
-    let kv_cache = KVCache::new(&mut cx, MAX_SEQ_LEN);
-    let (logits, cache_outputs) = Llama::init(&mut cx).forward(
+    let last_idx_t = cx.named_tensor("last_idx", 1).as_dtype(DType::Int);
+    let kv_cache = KVCache::new(&mut cx, max_context);
+    let model = Llama::init(&mut cx);
+    let (logits, cache_outputs) = model.forward(
         input,
         q_pos_t,
         scatter_idx_t,
         gather_idx_t,
         attn_mask_t,
+        last_idx_t,
         &kv_cache,
     );
     let logits = logits.output();
@@ -449,12 +463,6 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     cx.set_dim('s', 1);
     cx.set_dim('c', 1);
-    let max_prefill = (prompt_tokens.len() + 16)
-        .next_power_of_two()
-        .min(MAX_SEQ_LEN);
-    let max_context = (prompt_tokens.len() + GEN_TOKENS + 1)
-        .next_power_of_two()
-        .min(MAX_SEQ_LEN);
     let search_s = 16.min(max_prefill).max(2);
     let search_c = 16.min(max_context).max(2);
     let build_options = CompileOptions::default()
@@ -488,7 +496,7 @@ fn main() -> Result<(), Box<dyn Error>> {
     runtime.load_safetensors(&cx, model_dir.join("model.safetensors").to_str().unwrap());
     println!("  Weight load: {:.2} s", load_start.elapsed().as_secs_f64());
 
-    let cache_bytes = MAX_SEQ_LEN * KV_DIM * std::mem::size_of::<f32>();
+    let cache_bytes = max_context * KV_DIM * std::mem::size_of::<f32>();
     for i in 0..LAYERS {
         runtime.set_zeros(kv_cache.k_caches[i], cache_bytes);
         runtime.set_zeros(kv_cache.v_caches[i], cache_bytes);
@@ -503,12 +511,19 @@ fn main() -> Result<(), Box<dyn Error>> {
     runtime.set_data(scatter_idx_t, (0..search_s as i32).collect::<Vec<_>>());
     runtime.set_data(gather_idx_t, (0..search_c as i32).collect::<Vec<_>>());
     runtime.set_data(attn_mask_t, vec![0.0f32; search_s * search_c]);
+    runtime.set_data(last_idx_t, vec![search_s as i32 - 1]);
     let search_options = CompileOptions::default().search_graph_limit(SEARCH_GRAPHS);
     runtime = cx.search(runtime, search_options);
+
     println!(
         "  Search/compile: {:.2} s",
         compile_start.elapsed().as_secs_f64()
     );
+
+    cx.set_dim('s', prompt_tokens.len());
+    cx.set_dim('c', prompt_tokens.len());
+    cx.set_dim('s', 1);
+    cx.set_dim('c', prompt_tokens.len() + 1);
 
     for i in 0..LAYERS {
         runtime.set_zeros(kv_cache.k_caches[i], cache_bytes);
@@ -540,6 +555,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             scatter_idx_t,
             gather_idx_t,
             attn_mask_t,
+            last_idx_t,
             logits,
             &kv_cache,
             &cache_outputs,
@@ -587,6 +603,7 @@ fn main() -> Result<(), Box<dyn Error>> {
             scatter_idx_t,
             gather_idx_t,
             attn_mask_t,
+            last_idx_t,
             logits,
             &kv_cache,
             &cache_outputs,

--- a/crates/luminal_metal/src/kernel/fusion/attention.rs
+++ b/crates/luminal_metal/src/kernel/fusion/attention.rs
@@ -210,9 +210,9 @@ impl MetalFusedPostRopeAttention {
 
     fn decode_heads_per_group(&self) -> usize {
         let kv_group = self.n_heads / self.n_kv_heads;
-        if kv_group % 4 == 0 && self.max_context <= 512 && self.head_dim * 4 <= 256 {
+        if kv_group.is_multiple_of(4) && self.max_context <= 512 && self.head_dim * 4 <= 256 {
             4
-        } else if kv_group % 2 == 0 && self.head_dim * 2 <= 256 {
+        } else if kv_group.is_multiple_of(2) && self.head_dim * 2 <= 256 {
             2
         } else {
             1

--- a/crates/luminal_metal/src/kernel/fusion/attention.rs
+++ b/crates/luminal_metal/src/kernel/fusion/attention.rs
@@ -1,0 +1,716 @@
+use luminal::{
+    egglog_utils::{
+        SerializedEGraph,
+        api::{Rule, SortDef, sort},
+        base::{EXPRESSION, F64, OP_KIND},
+    },
+    op::*,
+    prelude::*,
+};
+use metal::{Buffer, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize};
+#[cfg(feature = "debug")]
+use objc::runtime::Object;
+
+use crate::kernel::{MetalEncodeContext, MetalKernelOp, ops::compile_shader};
+#[cfg(feature = "debug")]
+use crate::kernel::{pop_debug_group, push_debug_group, set_objc_label};
+
+fn single_dyn_var(expr: Expression) -> Option<char> {
+    let vars = expr.dyn_vars();
+    if vars.len() == 1 { Some(vars[0]) } else { None }
+}
+
+fn resolve_dim(expr: Expression, symbol: Option<char>, dyn_map: &FxHashMap<char, usize>) -> usize {
+    symbol
+        .and_then(|symbol| dyn_map.get(&symbol).copied())
+        .or_else(|| expr.exec(dyn_map))
+        .expect("FusedPostRopeAttention dynamic dimension not set")
+}
+
+#[derive(Debug, Clone, Default)]
+/// Fuses paged attention after Q/K have already been RoPE-rotated.
+/// q [seq, hidden], k_cache/v_cache [max_context, kv_dim] -> out [seq, hidden]
+/// scores = q @ k_cache[k_gather_idx].T * scale + mask
+/// out = softmax(scores) @ v_cache[v_gather_idx]
+pub struct MetalFusedPostRopeAttention {
+    seq: Expression,
+    context: Expression,
+    seq_symbol: Option<char>,
+    context_symbol: Option<char>,
+    hidden: usize,
+    kv_dim: usize,
+    n_heads: usize,
+    n_kv_heads: usize,
+    head_dim: usize,
+    max_context: usize,
+    scale: f32,
+    decode_attention_pipeline: std::sync::OnceLock<ComputePipelineState>,
+}
+
+impl MetalFusedPostRopeAttention {
+    #[allow(clippy::too_many_arguments)]
+    fn new(
+        seq: Expression,
+        context: Expression,
+        hidden: usize,
+        kv_dim: usize,
+        n_heads: usize,
+        n_kv_heads: usize,
+        head_dim: usize,
+        max_context: usize,
+        scale: f32,
+    ) -> Self {
+        let seq_symbol = single_dyn_var(seq);
+        let context_symbol = single_dyn_var(context);
+        Self {
+            seq,
+            context,
+            seq_symbol,
+            context_symbol,
+            hidden,
+            kv_dim,
+            n_heads,
+            n_kv_heads,
+            head_dim,
+            max_context,
+            scale,
+            decode_attention_pipeline: std::sync::OnceLock::new(),
+        }
+    }
+
+    fn seq_size_expr(&self) -> Expression {
+        self.seq_symbol.map(Expression::from).unwrap_or(self.seq)
+    }
+
+    fn resolved_dims(
+        &self,
+        dyn_map: &FxHashMap<char, usize>,
+    ) -> (u32, u32, u32, u32, u32, u32, u32) {
+        let seq = resolve_dim(self.seq, self.seq_symbol, dyn_map) as u32;
+        let context = resolve_dim(self.context, self.context_symbol, dyn_map) as u32;
+        assert!(
+            context as usize <= self.max_context,
+            "FusedPostRopeAttention context {context} exceeds compiled max_context {}",
+            self.max_context
+        );
+        (
+            seq,
+            context,
+            self.hidden as u32,
+            self.kv_dim as u32,
+            self.n_heads as u32,
+            self.n_kv_heads as u32,
+            self.head_dim as u32,
+        )
+    }
+
+    fn attention_source(&self) -> String {
+        let max_context = self.max_context;
+        let scale = self.scale;
+        format!(
+            r#"
+                #include <metal_stdlib>
+                using namespace metal;
+
+                #define THREADS_PER_GROUP 256
+                #define MAX_CONTEXT {max_context}
+                #define SCALE {scale:.9e}f
+
+                kernel void fused_attention(
+                    const device float *q [[buffer(0)]],
+                    const device float *k_cache [[buffer(1)]],
+                    const device float *v_cache [[buffer(2)]],
+                    const device int *k_gather_idx [[buffer(3)]],
+                    const device int *v_gather_idx [[buffer(4)]],
+                    const device float *attn_mask [[buffer(5)]],
+                    device float *out [[buffer(6)]],
+                    constant uint &seq [[buffer(7)]],
+                    constant uint &context_len [[buffer(8)]],
+                    constant uint &hidden [[buffer(9)]],
+                    constant uint &kv_dim [[buffer(10)]],
+                    constant uint &n_heads [[buffer(11)]],
+                    constant uint &n_kv_heads [[buffer(12)]],
+                    constant uint &head_dim [[buffer(13)]],
+                    uint2 gid [[threadgroup_position_in_grid]],
+                    uint tid [[thread_index_in_threadgroup]]
+                ) {{
+                    const uint head = gid.x;
+                    const uint token = gid.y;
+                    if (head >= n_heads || token >= seq || context_len > MAX_CONTEXT) {{
+                        return;
+                    }}
+
+                    threadgroup float scores[MAX_CONTEXT];
+                    threadgroup float partials[THREADS_PER_GROUP];
+
+                    const uint kv_group = n_heads / n_kv_heads;
+                    const uint kv_head = head / kv_group;
+                    const uint q_base = token * hidden + head * head_dim;
+
+                    float local_max = -INFINITY;
+                    for (uint j = tid; j < context_len; j += THREADS_PER_GROUP) {{
+                        const int flat = k_gather_idx[j * kv_dim];
+                        float score = -INFINITY;
+                        if (flat >= 0) {{
+                            const uint pos = uint(flat) / kv_dim;
+                            const uint k_base = pos * kv_dim + kv_head * head_dim;
+                            float dot = 0.0f;
+                            for (uint d = 0; d < head_dim; ++d) {{
+                                dot += q[q_base + d] * k_cache[k_base + d];
+                            }}
+                            score = dot * SCALE + attn_mask[token * context_len + j];
+                        }}
+                        scores[j] = score;
+                        local_max = max(local_max, score);
+                    }}
+
+                    partials[tid] = local_max;
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                    for (uint stride = THREADS_PER_GROUP / 2; stride > 0; stride >>= 1) {{
+                        if (tid < stride) {{
+                            partials[tid] = max(partials[tid], partials[tid + stride]);
+                        }}
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                    }}
+                    const float max_score = partials[0];
+
+                    float local_sum = 0.0f;
+                    for (uint j = tid; j < context_len; j += THREADS_PER_GROUP) {{
+                        const float w = exp2((scores[j] - max_score) * 1.4426950408889634f);
+                        scores[j] = w;
+                        local_sum += w;
+                    }}
+
+                    partials[tid] = local_sum;
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                    for (uint stride = THREADS_PER_GROUP / 2; stride > 0; stride >>= 1) {{
+                        if (tid < stride) {{
+                            partials[tid] += partials[tid + stride];
+                        }}
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                    }}
+                    const float inv_sum = 1.0f / partials[0];
+
+                    if (tid < head_dim) {{
+                        float acc = 0.0f;
+                        for (uint j = 0; j < context_len; ++j) {{
+                            const int flat = v_gather_idx[j * kv_dim];
+                            if (flat >= 0) {{
+                                const uint pos = uint(flat) / kv_dim;
+                                const uint v_base = pos * kv_dim + kv_head * head_dim;
+                                acc += scores[j] * inv_sum * v_cache[v_base + tid];
+                            }}
+                        }}
+                        out[head * seq * head_dim + token * head_dim + tid] = acc;
+                    }}
+                }}
+                "#
+        )
+    }
+
+    fn decode_heads_per_group(&self) -> usize {
+        let kv_group = self.n_heads / self.n_kv_heads;
+        if kv_group % 4 == 0 && self.max_context <= 512 && self.head_dim * 4 <= 256 {
+            4
+        } else if kv_group % 2 == 0 && self.head_dim * 2 <= 256 {
+            2
+        } else {
+            1
+        }
+    }
+
+    fn decode_attention_source(&self) -> String {
+        let max_context = self.max_context;
+        let hidden = self.hidden;
+        let kv_dim = self.kv_dim;
+        let n_heads = self.n_heads;
+        let n_kv_heads = self.n_kv_heads;
+        let head_dim = self.head_dim;
+        let kv_group = self.n_heads / self.n_kv_heads;
+        let heads_per_group = self.decode_heads_per_group();
+        let scale = self.scale;
+        format!(
+            r#"
+                #include <metal_stdlib>
+                using namespace metal;
+
+                #define THREADS_PER_GROUP 256
+                #define MAX_CONTEXT {max_context}
+                #define HIDDEN {hidden}
+                #define KV_DIM {kv_dim}
+                #define N_HEADS {n_heads}
+                #define N_KV_HEADS {n_kv_heads}
+                #define HEAD_DIM {head_dim}
+                #define KV_GROUP {kv_group}
+                #define HEADS_PER_GROUP {heads_per_group}
+                #define SCALE {scale:.9e}f
+
+                kernel void fused_decode_attention(
+                    const device float *q [[buffer(0)]],
+                    const device float *k_cache [[buffer(1)]],
+                    const device float *v_cache [[buffer(2)]],
+                    const device int *k_gather_idx [[buffer(3)]],
+                    const device int *v_gather_idx [[buffer(4)]],
+                    const device float *attn_mask [[buffer(5)]],
+                    device float *out [[buffer(6)]],
+                    constant uint &context_len [[buffer(7)]],
+                    uint gid [[threadgroup_position_in_grid]],
+                    uint tid [[thread_index_in_threadgroup]]
+                ) {{
+                    const uint base_head = gid * HEADS_PER_GROUP;
+                    if (base_head >= N_HEADS || context_len > MAX_CONTEXT) {{
+                        return;
+                    }}
+
+                    threadgroup float scores[HEADS_PER_GROUP * MAX_CONTEXT];
+                    threadgroup float partials[HEADS_PER_GROUP * THREADS_PER_GROUP];
+
+                    const uint kv_head = base_head / KV_GROUP;
+                    const uint out_lane_count = HEADS_PER_GROUP * HEAD_DIM;
+
+                    float local_max[HEADS_PER_GROUP];
+                    for (uint h = 0; h < HEADS_PER_GROUP; ++h) {{
+                        local_max[h] = -INFINITY;
+                    }}
+
+                    for (uint j = tid; j < context_len; j += THREADS_PER_GROUP) {{
+                        const int flat = k_gather_idx[j * KV_DIM];
+                        for (uint h = 0; h < HEADS_PER_GROUP; ++h) {{
+                            const uint head = base_head + h;
+                            float score = -INFINITY;
+                            if (head < N_HEADS && flat >= 0) {{
+                                const uint pos = uint(flat) / KV_DIM;
+                                const uint q_base = head * HEAD_DIM;
+                                const uint k_base = pos * KV_DIM + kv_head * HEAD_DIM;
+                                float dot = 0.0f;
+                                for (uint d = 0; d < HEAD_DIM; ++d) {{
+                                    dot += q[q_base + d] * k_cache[k_base + d];
+                                }}
+                                score = dot * SCALE + attn_mask[j];
+                            }}
+                            scores[h * MAX_CONTEXT + j] = score;
+                            local_max[h] = max(local_max[h], score);
+                        }}
+                    }}
+
+                    for (uint h = 0; h < HEADS_PER_GROUP; ++h) {{
+                        partials[h * THREADS_PER_GROUP + tid] = local_max[h];
+                    }}
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                    for (uint stride = THREADS_PER_GROUP / 2; stride > 0; stride >>= 1) {{
+                        if (tid < stride) {{
+                            for (uint h = 0; h < HEADS_PER_GROUP; ++h) {{
+                                partials[h * THREADS_PER_GROUP + tid] =
+                                    max(partials[h * THREADS_PER_GROUP + tid],
+                                        partials[h * THREADS_PER_GROUP + tid + stride]);
+                            }}
+                        }}
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                    }}
+
+                    float max_score[HEADS_PER_GROUP];
+                    for (uint h = 0; h < HEADS_PER_GROUP; ++h) {{
+                        max_score[h] = partials[h * THREADS_PER_GROUP];
+                    }}
+
+                    float local_sum[HEADS_PER_GROUP];
+                    for (uint h = 0; h < HEADS_PER_GROUP; ++h) {{
+                        local_sum[h] = 0.0f;
+                    }}
+
+                    for (uint j = tid; j < context_len; j += THREADS_PER_GROUP) {{
+                        for (uint h = 0; h < HEADS_PER_GROUP; ++h) {{
+                            const float w =
+                                exp2((scores[h * MAX_CONTEXT + j] - max_score[h]) *
+                                     1.4426950408889634f);
+                            scores[h * MAX_CONTEXT + j] = w;
+                            local_sum[h] += w;
+                        }}
+                    }}
+
+                    for (uint h = 0; h < HEADS_PER_GROUP; ++h) {{
+                        partials[h * THREADS_PER_GROUP + tid] = local_sum[h];
+                    }}
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                    for (uint stride = THREADS_PER_GROUP / 2; stride > 0; stride >>= 1) {{
+                        if (tid < stride) {{
+                            for (uint h = 0; h < HEADS_PER_GROUP; ++h) {{
+                                partials[h * THREADS_PER_GROUP + tid] +=
+                                    partials[h * THREADS_PER_GROUP + tid + stride];
+                            }}
+                        }}
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                    }}
+
+                    if (tid < out_lane_count) {{
+                        const uint h = tid / HEAD_DIM;
+                        const uint d = tid - h * HEAD_DIM;
+                        const uint head = base_head + h;
+                        if (head < N_HEADS) {{
+                            const float inv_sum =
+                                1.0f / partials[h * THREADS_PER_GROUP];
+                            float acc = 0.0f;
+                            for (uint j = 0; j < context_len; ++j) {{
+                                const int flat = v_gather_idx[j * KV_DIM];
+                                if (flat >= 0) {{
+                                    const uint pos = uint(flat) / KV_DIM;
+                                    const uint v_base =
+                                        pos * KV_DIM + kv_head * HEAD_DIM;
+                                    acc += scores[h * MAX_CONTEXT + j] * inv_sum *
+                                           v_cache[v_base + d];
+                                }}
+                            }}
+                            out[head * HEAD_DIM + d] = acc;
+                        }}
+                    }}
+                }}
+                "#
+        )
+    }
+}
+
+impl EgglogOp for MetalFusedPostRopeAttention {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "MetalFusedPostRopeAttention",
+            &[
+                ("num_qo_heads", EXPRESSION),
+                ("num_kv_heads", EXPRESSION),
+                ("head_dim", EXPRESSION),
+                ("hidden", EXPRESSION),
+                ("seq", EXPRESSION),
+                ("context", EXPRESSION),
+                ("max_context", EXPRESSION),
+                ("scale", F64),
+            ],
+        )
+    }
+
+    fn n_inputs(&self) -> usize {
+        6
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![Rule::raw(include_str!("post_rope_attention.egg"))]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        _list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::extract_expr;
+
+        let mut expr_at =
+            |idx: usize| extract_expr(egraph, kind_children[idx], expr_cache).unwrap();
+        let static_usize = |expr: Expression, name: &str| {
+            expr.exec(&FxHashMap::default())
+                .unwrap_or_else(|| panic!("MetalFusedPostRopeAttention {name} must be static"))
+        };
+        let n_heads = static_usize(expr_at(0), "num_qo_heads");
+        let n_kv_heads = static_usize(expr_at(1), "num_kv_heads");
+        let head_dim = static_usize(expr_at(2), "head_dim");
+        let hidden = static_usize(expr_at(3), "hidden");
+        let seq = expr_at(4);
+        let context = expr_at(5);
+        let max_context = static_usize(expr_at(6), "max_context");
+        let scale = egraph.enodes[kind_children[7]]
+            .0
+            .replace('\"', "")
+            .parse::<f32>()
+            .expect("MetalFusedPostRopeAttention scale must be a float");
+
+        (
+            LLIROp::new::<dyn MetalKernelOp>(Box::new(Self::new(
+                seq,
+                context,
+                hidden,
+                n_kv_heads * head_dim,
+                n_heads,
+                n_kv_heads,
+                head_dim,
+                max_context,
+                scale,
+            ))),
+            input_enodes,
+        )
+    }
+}
+
+impl MetalKernelOp for MetalFusedPostRopeAttention {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "FusedPostRopeAttention"
+    }
+
+    fn compile(
+        &self,
+        device: &Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<ComputePipelineState> {
+        assert_eq!(
+            output_dtype,
+            DType::F32,
+            "FusedPostRopeAttention output must be F32"
+        );
+        assert!(
+            input_dtypes.len() >= 6,
+            "FusedPostRopeAttention received too few inputs"
+        );
+        assert_eq!(
+            input_dtypes[0],
+            DType::F32,
+            "FusedPostRopeAttention q must be F32"
+        );
+        assert_eq!(
+            input_dtypes[1],
+            DType::F32,
+            "FusedPostRopeAttention k cache must be F32"
+        );
+        assert_eq!(
+            input_dtypes[2],
+            DType::F32,
+            "FusedPostRopeAttention v cache must be F32"
+        );
+        assert_eq!(
+            input_dtypes[3],
+            DType::Int,
+            "FusedPostRopeAttention k gather_idx must be Int"
+        );
+        assert_eq!(
+            input_dtypes[4],
+            DType::Int,
+            "FusedPostRopeAttention v gather_idx must be Int"
+        );
+        assert_eq!(
+            input_dtypes[5],
+            DType::F32,
+            "FusedPostRopeAttention mask must be F32"
+        );
+
+        Some(compile_shader(
+            device,
+            &self.attention_source(),
+            "fused_attention",
+        ))
+        .inspect(|_| {
+            let _ = self.decode_attention_pipeline.set(compile_shader(
+                device,
+                &self.decode_attention_source(),
+                "fused_decode_attention",
+            ));
+        })
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        DType::F32
+    }
+
+    fn output_size(&self) -> Expression {
+        self.seq_size_expr() * Expression::from(self.hidden)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn encode(
+        &self,
+        context: &mut MetalEncodeContext<'_>,
+        pipeline: Option<&ComputePipelineState>,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &FxHashMap<char, usize>,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        let pipeline = pipeline.expect("FusedPostRopeAttention compute pipeline not compiled");
+        let (seq, context_len, hidden, kv_dim, n_heads, n_kv_heads, head_dim) =
+            self.resolved_dims(dyn_map);
+
+        let encoder = context.command_buffer.new_compute_command_encoder();
+        #[cfg(feature = "debug")]
+        {
+            let label = self.label();
+            set_objc_label(encoder.as_ptr() as *mut Object, label);
+            push_debug_group(encoder.as_ptr() as *mut Object, label);
+        }
+        if seq == 1 {
+            let decode_pipeline = self
+                .decode_attention_pipeline
+                .get()
+                .expect("FusedPostRopeAttention decode pipeline not compiled");
+            self.encode_decode_attention(encoder, decode_pipeline, inputs, output, context_len);
+        } else {
+            self.encode_attention(
+                encoder,
+                pipeline,
+                inputs,
+                output,
+                seq,
+                context_len,
+                hidden,
+                kv_dim,
+                n_heads,
+                n_kv_heads,
+                head_dim,
+            );
+        }
+        #[cfg(feature = "debug")]
+        pop_debug_group(encoder.as_ptr() as *mut Object, self.label());
+        encoder.end_encoding();
+    }
+
+    fn encode_compute(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &FxHashMap<char, usize>,
+    ) {
+        let (seq, context, hidden, kv_dim, n_heads, n_kv_heads, head_dim) =
+            self.resolved_dims(dyn_map);
+        if seq == 1 {
+            let decode_pipeline = self
+                .decode_attention_pipeline
+                .get()
+                .expect("FusedPostRopeAttention decode pipeline not compiled");
+            self.encode_decode_attention(encoder, decode_pipeline, inputs, output, context);
+        } else {
+            self.encode_attention(
+                encoder, pipeline, inputs, output, seq, context, hidden, kv_dim, n_heads,
+                n_kv_heads, head_dim,
+            );
+        }
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let seq = self.seq.exec(dyn_map).unwrap_or(0);
+        let context = self.context.exec(dyn_map).unwrap_or(0);
+        let qk = seq * self.n_heads * context * self.head_dim * 2 * std::mem::size_of::<f32>();
+        let av = seq * self.n_heads * context * self.head_dim * std::mem::size_of::<f32>();
+        qk + av
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let seq = self.seq.exec(dyn_map).unwrap_or(0);
+        seq * self.hidden * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let seq = self.seq.exec(dyn_map).unwrap_or(0);
+        let context = self.context.exec(dyn_map).unwrap_or(0);
+        let qk = seq * self.n_heads * context * self.head_dim * 2;
+        let av = seq * self.n_heads * context * self.head_dim * 2;
+        let softmax = seq * self.n_heads * context * 4;
+        qk + av + softmax
+    }
+}
+
+impl MetalFusedPostRopeAttention {
+    #[allow(clippy::too_many_arguments)]
+    fn encode_attention(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        seq: u32,
+        context: u32,
+        hidden: u32,
+        kv_dim: u32,
+        n_heads: u32,
+        n_kv_heads: u32,
+        head_dim: u32,
+    ) {
+        let thread_group_size = MTLSize::new(256, 1, 1);
+
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(inputs[0]), 0); // Q, post-RoPE
+        encoder.set_buffer(1, Some(inputs[1]), 0); // K cache
+        encoder.set_buffer(2, Some(inputs[2]), 0); // V cache
+        encoder.set_buffer(3, Some(inputs[3]), 0); // K gather flat indices
+        encoder.set_buffer(4, Some(inputs[4]), 0); // V gather flat indices
+        encoder.set_buffer(5, Some(inputs[5]), 0); // additive mask
+        encoder.set_buffer(6, Some(output), 0);
+        let constants_start = 7;
+        encoder.set_bytes(
+            constants_start,
+            std::mem::size_of::<u32>() as u64,
+            &seq as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            constants_start + 1,
+            std::mem::size_of::<u32>() as u64,
+            &context as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            constants_start + 2,
+            std::mem::size_of::<u32>() as u64,
+            &hidden as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            constants_start + 3,
+            std::mem::size_of::<u32>() as u64,
+            &kv_dim as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            constants_start + 4,
+            std::mem::size_of::<u32>() as u64,
+            &n_heads as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            constants_start + 5,
+            std::mem::size_of::<u32>() as u64,
+            &n_kv_heads as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            constants_start + 6,
+            std::mem::size_of::<u32>() as u64,
+            &head_dim as *const u32 as *const _,
+        );
+        encoder.dispatch_thread_groups(
+            MTLSize::new(n_heads as u64, seq as u64, 1),
+            thread_group_size,
+        );
+    }
+
+    fn encode_decode_attention(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        context: u32,
+    ) {
+        let thread_group_size = MTLSize::new(256, 1, 1);
+        let heads_per_group = self.decode_heads_per_group() as u64;
+
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(inputs[0]), 0);
+        encoder.set_buffer(1, Some(inputs[1]), 0);
+        encoder.set_buffer(2, Some(inputs[2]), 0);
+        encoder.set_buffer(3, Some(inputs[3]), 0);
+        encoder.set_buffer(4, Some(inputs[4]), 0);
+        encoder.set_buffer(5, Some(inputs[5]), 0);
+        encoder.set_buffer(6, Some(output), 0);
+        encoder.set_bytes(
+            7,
+            std::mem::size_of::<u32>() as u64,
+            &context as *const u32 as *const _,
+        );
+        encoder.dispatch_thread_groups(
+            MTLSize::new((self.n_heads as u64).div_ceil(heads_per_group), 1, 1),
+            thread_group_size,
+        );
+    }
+}

--- a/crates/luminal_metal/src/kernel/fusion/llama_rope.egg
+++ b/crates/luminal_metal/src/kernel/fusion/llama_rope.egg
@@ -1,0 +1,488 @@
+; Recognize the full decomposed Llama RoPE materialization and
+                ; union it with a direct MetalLlamaRope kernel candidate.
+                (rule
+                    (
+                        (= ?one (MetalConstant 1.000000))
+                        (= ?neg_one (MetalConstant -1.000000))
+                        (= ?pi_half (MetalConstant 1.570796))
+                        (= ?log2e (MetalConstant 1.442695))
+                        (= ?theta_ln_const (MetalConstant ?theta_ln))
+
+                        ; Final materialization of the transposed+merged RoPE result.
+                        (= ?final (Op
+                            (MetalMul
+                                (ECons ?seq (ECons ?hidden (ENil)))
+                                ?final_rope_strides
+                                ?final_one_strides
+                                ?final_out_strides)
+                            (ICons ?rope_concat (ICons ?one (INil)))))
+
+                        ; concat_along(x0_out, x1_out, 2), before transpose/merge.
+                        (= ?rope_concat (Op
+                            (MetalAdd
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?concat_a_strides
+                                ?concat_b_strides
+                                ?concat_out_strides)
+                            (ICons ?x0_padded (ICons ?x1_padded (INil)))))
+
+                        (= ?x0_padded (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?x0_pad_data_strides
+                                ?x0_pad_mask_strides
+                                ?concat_a_strides)
+                            (ICons ?x0_pad_gather (ICons ?x0_pad_mask (INil)))))
+                        (= ?x1_padded (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?x1_pad_data_strides
+                                ?x1_pad_mask_strides
+                                ?concat_b_strides)
+                            (ICons ?x1_pad_gather (ICons ?x1_pad_mask (INil)))))
+                        (= ?x0_pad_gather
+                            (MetalGather
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?x0_pad_indexes
+                                ?x0_pad_index_strides
+                                ?x0_out
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?rot_out_strides
+                                ?x0_pad_gather_strides))
+                        (= ?x1_pad_gather
+                            (MetalGather
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?x1_pad_indexes
+                                ?x1_pad_index_strides
+                                ?x1_out
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?rot_out_strides
+                                ?x1_pad_gather_strides))
+
+                        ; x0_out = x0 * cos - x1 * sin
+                        (= ?x0_out (Op
+                            (MetalAdd
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x0_out_a_strides
+                                ?x0_out_b_strides
+                                ?rot_out_strides)
+                            (ICons ?x0_cos (ICons ?neg_x1_sin (INil)))))
+                        (= ?x0_cos (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x0_input_strides
+                                ?angle_broadcast_strides
+                                ?x0_out_a_strides)
+                            (ICons ?input (ICons ?cos (INil)))))
+                        (= ?neg_x1_sin (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x1_sin_strides
+                                ?neg_one_strides
+                                ?x0_out_b_strides)
+                            (ICons ?x1_sin (ICons ?neg_one (INil)))))
+                        (= ?x1_sin (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x1_read_strides
+                                ?angle_broadcast_strides
+                                ?x1_sin_strides)
+                            (ICons ?x1 (ICons ?sin (INil)))))
+
+                        ; x1_out = x1 * cos + x0 * sin
+                        (= ?x1_out (Op
+                            (MetalAdd
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x1_out_a_strides
+                                ?x1_out_b_strides
+                                ?rot_out_strides)
+                            (ICons ?x1_cos (ICons ?x0_sin (INil)))))
+                        (= ?x1_cos (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x1_read_strides
+                                ?angle_broadcast_strides
+                                ?x1_out_a_strides)
+                            (ICons ?x1 (ICons ?cos (INil)))))
+                        (= ?x0_sin (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x0_input_strides
+                                ?angle_broadcast_strides
+                                ?x1_out_b_strides)
+                            (ICons ?input (ICons ?sin (INil)))))
+
+                        ; x1 is the second half slice of the split head dimension.
+                        (= ?x1
+                            (MetalGather
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x1_indexes
+                                ?x1_index_strides
+                                ?input
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?input_strides
+                                ?x1_gather_out_strides))
+
+                        ; Shared sin/cos angle table.
+                        (= ?sin (Op
+                            (MetalSin
+                                (ECons ?seq (ECons ?half (ENil)))
+                                ?angle_strides
+                                ?angle_strides)
+                            (ICons ?angles (INil))))
+                        (= ?cos (Op
+                            (MetalSin
+                                (ECons ?seq (ECons ?half (ENil)))
+                                ?cos_arg_strides
+                                ?angle_strides)
+                            (ICons ?cos_arg (INil))))
+                        (= ?cos_arg (Op
+                            (MetalAdd
+                                (ECons ?seq (ECons ?half (ENil)))
+                                ?neg_angle_strides
+                                ?pi_half_strides
+                                ?cos_arg_strides)
+                            (ICons ?neg_angles (ICons ?pi_half (INil)))))
+                        (= ?neg_angles (Op
+                            (MetalMul
+                                (ECons ?seq (ECons ?half (ENil)))
+                                ?angle_strides
+                                ?neg_one_angle_strides
+                                ?neg_angle_strides)
+                            (ICons ?angles (ICons ?neg_one (INil)))))
+
+                        ; angles = cast(pos) @ reciprocal(exp(arange(0, hdim, 2) / hdim * ln(theta))).
+                        (= ?angles
+                            (GenericMatmul
+                                (ECons ?seq (ECons ?half (ENil)))
+                                ?angle_mul_shape
+                                ?angle_k
+                                ?pos_f32
+                                ?pos_f32_strides
+                                ?inv_freq
+                                ?inv_freq_matmul_strides
+                                ?angle_sum_strides
+                                ?angle_sum_iter_stride
+                                ?angle_strides))
+                        (= ?pos_f32 (MetalCast ?pos ?pos_cast_size (F32)))
+                        (= ?inv_freq (Op
+                            (MetalRecip
+                                (ECons ?half (ENil))
+                                ?freq_strides
+                                ?freq_strides)
+                            (ICons ?freq_exp (INil))))
+                        (= ?freq_exp (Op
+                            (MetalExp2
+                                (ECons ?half (ENil))
+                                ?freq_strides
+                                ?freq_strides)
+                            (ICons ?freq_log2 (INil))))
+                        (= ?freq_log2 (Op
+                            (MetalMul
+                                (ECons ?half (ENil))
+                                ?freq_ln_strides
+                                ?log2e_strides
+                                ?freq_strides)
+                            (ICons ?freq_ln (ICons ?log2e (INil)))))
+                        (= ?freq_ln (Op
+                            (MetalMul
+                                (ECons ?half (ENil))
+                                ?freq_norm_strides
+                                ?theta_ln_strides
+                                ?freq_ln_strides)
+                            (ICons ?freq_norm (ICons ?theta_ln_const (INil)))))
+                        (= ?freq_norm (Op
+                            (MetalMul
+                                (ECons ?half (ENil))
+                                ?freq_iota_strides
+                                ?inv_head_dim_strides
+                                ?freq_norm_strides)
+                            (ICons ?freq_iota_f32 (ICons ?inv_head_dim (INil)))))
+                        (= ?freq_iota_f32 (MetalCast ?freq_iota ?freq_cast_size (F32)))
+                        (= ?freq_iota (MetalIota ?freq_iota_expr ?half))
+                        (= ?inv_head_dim (MetalConstant ?inv_head_dim_value))
+                        (= (F32) (dtype ?final))
+                    )
+                    (
+                        (let ?rope (MetalLlamaRope
+                            (ECons ?seq (ECons ?hidden (ENil)))
+                            ?input
+                            ?pos
+                            ?nheads
+                            ?hdim
+                            ?theta_ln
+                            ?final_out_strides))
+                        (union ?final ?rope)
+                        (set (dtype ?rope) (F32))
+                    )
+                    :ruleset cleanup
+                    :name "metal-llama-rope-materialize"
+                )
+                
+
+                ; Once the direct MetalLlamaRope candidate exists, delete the
+                ; final multiply-by-one materialization of the decomposed RoPE
+                ; output so extraction cannot keep that wrapper.
+                (rule
+                    ((= ?final (Op
+                        (MetalMul
+                            (ECons ?seq (ECons ?hidden (ENil)))
+                            ?final_rope_strides
+                            ?final_one_strides
+                            ?final_out_strides)
+                        (ICons ?rope_concat (ICons ?one (INil)))))
+                     (= ?final (MetalLlamaRope
+                        (ECons ?seq (ECons ?hidden (ENil)))
+                        ?input
+                        ?pos
+                        ?nheads
+                        ?hdim
+                        ?theta_ln
+                        ?final_out_strides)))
+                    ((delete (Op
+                        (MetalMul
+                            (ECons ?seq (ECons ?hidden (ENil)))
+                            ?final_rope_strides
+                            ?final_one_strides
+                            ?final_out_strides)
+                        (ICons ?rope_concat (ICons ?one (INil))))))
+                    :ruleset cleanup
+                    :name "delete-final-rope-materialize-when-metal-rope-exists"
+                )
+
+                ; Some KV-cache paths consume the RoPE result while it is still
+                ; laid out as [heads, seq, head_dim], so there is no final
+                ; [seq, hidden] materialization for MetalLlamaRope to replace.
+                ; Recognize that 3D materialization directly.
+                (rule
+                    (
+                        (= ?one (MetalConstant 1.000000))
+                        (= ?neg_one (MetalConstant -1.000000))
+                        (= ?pi_half (MetalConstant 1.570796))
+                        (= ?log2e (MetalConstant 1.442695))
+                        (= ?theta_ln_const (MetalConstant ?theta_ln))
+
+                        (= ?rope_concat (Op
+                            (MetalAdd
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?concat_a_strides
+                                ?concat_b_strides
+                                ?concat_out_strides)
+                            (ICons ?x0_padded (ICons ?x1_padded (INil)))))
+
+                        (= ?x0_padded (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?x0_pad_data_strides
+                                ?x0_pad_mask_strides
+                                ?concat_a_strides)
+                            (ICons ?x0_pad_gather (ICons ?x0_pad_mask (INil)))))
+                        (= ?x1_padded (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?x1_pad_data_strides
+                                ?x1_pad_mask_strides
+                                ?concat_b_strides)
+                            (ICons ?x1_pad_gather (ICons ?x1_pad_mask (INil)))))
+                        (= ?x0_pad_gather
+                            (MetalGather
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?x0_pad_indexes
+                                ?x0_pad_index_strides
+                                ?x0_out
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?rot_out_strides
+                                ?x0_pad_gather_strides))
+                        (= ?x1_pad_gather
+                            (MetalGather
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?x1_pad_indexes
+                                ?x1_pad_index_strides
+                                ?x1_out
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?rot_out_strides
+                                ?x1_pad_gather_strides))
+
+                        (= ?x0_out (Op
+                            (MetalAdd
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x0_out_a_strides
+                                ?x0_out_b_strides
+                                ?rot_out_strides)
+                            (ICons ?x0_cos (ICons ?neg_x1_sin (INil)))))
+                        (= ?x0_cos (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?input_strides
+                                ?angle_broadcast_strides
+                                ?x0_out_a_strides)
+                            (ICons ?input (ICons ?cos (INil)))))
+                        (= ?neg_x1_sin (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x1_sin_strides
+                                ?neg_one_strides
+                                ?x0_out_b_strides)
+                            (ICons ?x1_sin (ICons ?neg_one (INil)))))
+                        (= ?x1_sin (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x1_read_strides
+                                ?angle_broadcast_strides
+                                ?x1_sin_strides)
+                            (ICons ?x1 (ICons ?sin (INil)))))
+
+                        (= ?x1_out (Op
+                            (MetalAdd
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x1_out_a_strides
+                                ?x1_out_b_strides
+                                ?rot_out_strides)
+                            (ICons ?x1_cos (ICons ?x0_sin (INil)))))
+                        (= ?x1_cos (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x1_read_strides
+                                ?angle_broadcast_strides
+                                ?x1_out_a_strides)
+                            (ICons ?x1 (ICons ?cos (INil)))))
+                        (= ?x0_sin (Op
+                            (MetalMul
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?input_strides
+                                ?angle_broadcast_strides
+                                ?x1_out_b_strides)
+                            (ICons ?input (ICons ?sin (INil)))))
+
+                        (= ?x1
+                            (MetalGather
+                                (ECons ?nheads (ECons ?seq (ECons ?half (ENil))))
+                                ?x1_indexes
+                                ?x1_index_strides
+                                ?input
+                                (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                                ?input_strides
+                                ?x1_gather_out_strides))
+
+                        (= ?sin (Op
+                            (MetalSin
+                                (ECons ?seq (ECons ?half (ENil)))
+                                ?angle_strides
+                                ?angle_strides)
+                            (ICons ?angles (INil))))
+                        (= ?cos (Op
+                            (MetalSin
+                                (ECons ?seq (ECons ?half (ENil)))
+                                ?cos_arg_strides
+                                ?angle_strides)
+                            (ICons ?cos_arg (INil))))
+                        (= ?cos_arg (Op
+                            (MetalAdd
+                                (ECons ?seq (ECons ?half (ENil)))
+                                ?neg_angle_strides
+                                ?pi_half_strides
+                                ?cos_arg_strides)
+                            (ICons ?neg_angles (ICons ?pi_half (INil)))))
+                        (= ?neg_angles (Op
+                            (MetalMul
+                                (ECons ?seq (ECons ?half (ENil)))
+                                ?angle_strides
+                                ?neg_one_angle_strides
+                                ?neg_angle_strides)
+                            (ICons ?angles (ICons ?neg_one (INil)))))
+
+                        (= ?angles
+                            (GenericMatmul
+                                (ECons ?seq (ECons ?half (ENil)))
+                                ?angle_mul_shape
+                                ?angle_k
+                                ?pos_f32
+                                ?pos_f32_strides
+                                ?inv_freq
+                                ?inv_freq_matmul_strides
+                                ?angle_sum_strides
+                                ?angle_sum_iter_stride
+                                ?angle_strides))
+                        (= ?pos_f32 (MetalCast ?pos ?pos_cast_size (F32)))
+                        (= ?inv_freq (Op
+                            (MetalRecip
+                                (ECons ?half (ENil))
+                                ?freq_strides
+                                ?freq_strides)
+                            (ICons ?freq_exp (INil))))
+                        (= ?freq_exp (Op
+                            (MetalExp2
+                                (ECons ?half (ENil))
+                                ?freq_strides
+                                ?freq_strides)
+                            (ICons ?freq_log2 (INil))))
+                        (= ?freq_log2 (Op
+                            (MetalMul
+                                (ECons ?half (ENil))
+                                ?freq_ln_strides
+                                ?log2e_strides
+                                ?freq_strides)
+                            (ICons ?freq_ln (ICons ?log2e (INil)))))
+                        (= ?freq_ln (Op
+                            (MetalMul
+                                (ECons ?half (ENil))
+                                ?freq_norm_strides
+                                ?theta_ln_strides
+                                ?freq_ln_strides)
+                            (ICons ?freq_norm (ICons ?theta_ln_const (INil)))))
+                        (= ?freq_norm (Op
+                            (MetalMul
+                                (ECons ?half (ENil))
+                                ?freq_iota_strides
+                                ?inv_head_dim_strides
+                                ?freq_norm_strides)
+                            (ICons ?freq_iota_f32 (ICons ?inv_head_dim (INil)))))
+                        (= ?freq_iota_f32 (MetalCast ?freq_iota ?freq_cast_size (F32)))
+                        (= ?freq_iota (MetalIota ?freq_iota_expr ?half))
+                        (= ?inv_head_dim (MetalConstant ?inv_head_dim_value))
+                        (= (F32) (dtype ?rope_concat))
+                    )
+                    (
+                        (let ?rope3d (MetalLlamaRope3D
+                            (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                            ?input
+                            ?pos
+                            ?input_strides
+                            ?nheads
+                            ?hdim
+                            ?theta_ln
+                            ?concat_out_strides))
+                        (union ?rope_concat ?rope3d)
+                        (set (dtype ?rope3d) (F32))
+                    )
+                    :ruleset cleanup
+                    :name "metal-llama-rope-3d-materialize"
+                )
+
+                (rule
+                    ((= ?rope_concat (Op
+                        (MetalAdd
+                            (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                            ?concat_a_strides
+                            ?concat_b_strides
+                            ?concat_out_strides)
+                        (ICons ?x0_padded (ICons ?x1_padded (INil)))))
+                     (= ?rope_concat (MetalLlamaRope3D
+                        (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                        ?input
+                        ?pos
+                        ?input_strides
+                        ?nheads
+                        ?hdim
+                        ?theta_ln
+                        ?concat_out_strides)))
+                    ((subsume (Op
+                        (MetalAdd
+                            (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                            ?concat_a_strides
+                            ?concat_b_strides
+                            ?concat_out_strides)
+                        (ICons ?x0_padded (ICons ?x1_padded (INil))))))
+                    :ruleset cleanup
+                    :name "metal-llama-rope-3d-subsumes-concat-add"
+                )

--- a/crates/luminal_metal/src/kernel/fusion/mod.rs
+++ b/crates/luminal_metal/src/kernel/fusion/mod.rs
@@ -1,0 +1,19 @@
+mod attention;
+mod rms_norm;
+mod rope;
+mod swiglu;
+
+pub use attention::MetalFusedPostRopeAttention;
+pub use rms_norm::MetalRmsNorm;
+pub use rope::{MetalLlamaRope, MetalLlamaRope3D, MetalLlamaRope3DScatter};
+pub use swiglu::{MetalFusedSwiGLUGemv, MetalSwiGLU};
+
+pub type Ops = (
+    MetalFusedPostRopeAttention,
+    MetalLlamaRope,
+    MetalLlamaRope3D,
+    MetalLlamaRope3DScatter,
+    MetalRmsNorm,
+    MetalSwiGLU,
+    MetalFusedSwiGLUGemv,
+);

--- a/crates/luminal_metal/src/kernel/fusion/post_rope_attention.egg
+++ b/crates/luminal_metal/src/kernel/fusion/post_rope_attention.egg
@@ -1,0 +1,475 @@
+; Match decomposed paged attention after Q/K have already been RoPE-rotated:
+;   scores = Q @ gathered(K cache).T * scale + mask
+;   weights = softmax(scores)
+;   output = weights @ gathered(V cache)
+; The gathered K/V rows are expanded from KV heads to query heads for GQA.
+; Union the final attention output with MetalFusedPostRopeAttention.
+(rule
+                (
+                    ; V projection: softmax(scores) @ V_context.
+                    (= ?mul2 (Op (Mul
+                        (ECons ?nheads (ECons ?seq (ECons ?hdim (ECons ?context (ENil)))))
+                        ?mul2_a_strides
+                        ?mul2_b_strides
+                        ?mul2_out_strides)
+                        (ICons ?soft (ICons ?v_gqa (INil)))))
+                    (= ?output (Op (Sum
+                        (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                        ?context
+                        ?out_in_strides
+                        (MIter)
+                        ?out_out_strides)
+                        (ICons ?mul2 (INil))))
+
+                    ; Softmax(scores + mask) over the context dimension.
+                    (= ?soft (Op (Mul
+                        (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                        ?soft_a_strides
+                        ?soft_b_strides
+                        ?soft_out_strides)
+                        (ICons ?exp (ICons ?inv_denom (INil)))))
+                    (= ?inv_denom (Op (Recip
+                        (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                        ?recip_in_strides
+                        ?recip_out_strides)
+                        (ICons ?denom (INil))))
+                    (= ?denom (Op (Sum
+                        (ECons ?nheads (ECons ?seq (ENil)))
+                        ?context
+                        ?denom_in_strides
+                        (MIter)
+                        ?denom_out_strides)
+                        (ICons ?exp (INil))))
+                    (= ?exp (Op (Exp2
+                        (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                        ?exp_in_strides
+                        ?exp_out_strides)
+                        (ICons ?exp_arg (INil))))
+                    (= ?log2e (Op (Constant 1.442695) (INil)))
+                    (= ?exp_arg (Op (Mul
+                        (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                        ?exp_arg_a_strides
+                        ?exp_arg_b_strides
+                        ?exp_arg_out_strides)
+                        (ICons ?centered (ICons ?log2e (INil)))))
+                    (= ?centered (Op (Add
+                        (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                        ?centered_a_strides
+                        ?centered_b_strides
+                        ?centered_out_strides)
+                        (ICons ?masked (ICons ?neg_max (INil)))))
+                    (= ?neg_one (Op (Constant -1.000000) (INil)))
+                    (= ?neg_max (Op (Mul
+                        (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                        ?neg_max_a_strides
+                        ?neg_max_b_strides
+                        ?neg_max_out_strides)
+                        (ICons ?max_scores (ICons ?neg_one (INil)))))
+                    (= ?max_scores (Op (Max
+                        (ECons ?nheads (ECons ?seq (ENil)))
+                        ?context
+                        ?max_in_strides
+                        (MIter)
+                        ?max_out_strides)
+                        (ICons ?masked (INil))))
+
+                    ; QK scores plus an additive mask broadcast over heads.
+                    (= ?masked (Op (Add
+                        (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                        ?mask_add_a_strides
+                        (ECons (MNum 0) (ECons (MMul (MIter) ?context) (ECons (MIter) (ENil))))
+                        ?mask_add_out_strides)
+                        (ICons ?scaled_qk (ICons ?mask (INil)))))
+                    (= ?scale_const (Op (Constant ?scale) (INil)))
+                    (= ?scaled_qk (Op (Mul
+                        (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                        ?scale_a_strides
+                        ?scale_b_strides
+                        ?scale_out_strides)
+                        (ICons ?qk (ICons ?scale_const (INil)))))
+
+                    ; Q @ K_context.
+                    (= ?q_mat_const (Op (Constant 1.000000) (INil)))
+                    (= ?q (Op (Mul
+                        (ECons ?seq (ECons ?hidden (ENil)))
+                        ?q_mat_a_strides
+                        ?q_mat_b_strides
+                        ?q_mat_out_strides)
+                        (ICons ?q_src (ICons ?q_mat_const (INil)))))
+                    (= ?mul1 (Op (Mul
+                        (ECons ?nheads (ECons ?seq (ECons ?context (ECons ?hdim (ENil)))))
+                        ?mul1_a_strides
+                        ?mul1_b_strides
+                        ?mul1_out_strides)
+                        (ICons ?q (ICons ?k_gqa (INil)))))
+                    (= ?qk (Op (Sum
+                        (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                        ?hdim
+                        ?qk_in_strides
+                        (MIter)
+                        ?qk_out_strides)
+                        (ICons ?mul1 (INil))))
+
+                    ; K rows gathered from a 2D cache and broadcast to query heads.
+                    (= ?k_gqa_const (Op (Constant 1.000000) (INil)))
+                    (= ?k_gqa (Op (Mul
+                        (ECons ?nheads (ECons ?hdim (ECons ?context (ENil))))
+                        ?k_gqa_a_strides
+                        (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
+                        ?k_gqa_out_strides)
+                        (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
+                    (= ?k_gathered (Op (Gather
+                        (ECons ?context (ECons ?kvdim (ENil)))
+                        (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil)))
+                        (ECons ?max_context (ECons ?kvdim (ENil)))
+                        (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil))))
+                        (ICons ?k_idx (ICons ?k_cache (INil)))))
+
+                    ; V rows gathered from a matching 2D cache and broadcast to query heads.
+                    (= ?v_gqa_const (Op (Constant 1.000000) (INil)))
+                    (= ?v_gqa (Op (Mul
+                        (ECons ?nheads (ECons ?context (ECons ?hdim (ENil))))
+                        ?v_gqa_a_strides
+                        (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
+                        ?v_gqa_out_strides)
+                        (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
+                    (= ?v_gathered (Op (Gather
+                        (ECons ?context (ECons ?kvdim (ENil)))
+                        (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil)))
+                        (ECons ?max_context (ECons ?kvdim (ENil)))
+                        (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil))))
+                        (ICons ?v_idx (ICons ?v_cache (INil)))))
+
+                    (= ?dt (dtype ?q))
+                    (= ?dt (dtype ?k_cache))
+                    (= ?dt (dtype ?v_cache))
+                    (= ?dt (dtype ?mask))
+                )
+                (
+                    (let ?fused (Op (MetalFusedPostRopeAttention
+                        ?nheads (MDiv ?kvdim ?hdim) ?hdim ?hidden ?seq ?context ?max_context ?scale)
+                        (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?v_idx (ICons ?mask (INil)))))))))
+                    (union ?output ?fused)
+                    (set (dtype ?fused) ?dt)
+                )
+                :ruleset kernel_lower
+                :name "metal fused post-rope paged attention"
+            )
+            
+
+                ; Once the fused post-RoPE attention candidate exists, delete
+                ; the final decomposed attention sum so extraction cannot keep
+                ; the old softmax-times-V reduction.
+                (rule
+                    ((= ?output (Op (Sum
+                        (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                        ?context
+                        ?out_in_strides
+                        (MIter)
+                        ?out_out_strides)
+                        (ICons ?mul2 (INil))))
+                     (= ?output (Op (MetalFusedPostRopeAttention
+                        ?nheads ?nkvheads ?hdim ?hidden ?seq ?context ?max_context ?scale)
+                        ?fused_inputs)))
+                    ((delete (Op (Sum
+                        (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                        ?context
+                        ?out_in_strides
+                        (MIter)
+                        ?out_out_strides)
+                        (ICons ?mul2 (INil)))))
+                    :ruleset cleanup
+                    :name "delete-post-rope-attention-sum-when-metal-fused-attention-exists"
+                )
+                
+
+                ; Prefer the fused post-RoPE attention op over the generic
+                ; matmul fallback for the final attention value.
+                (rule
+                    ((= ?output (GenericMatmul
+                        ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos))
+                     (= ?output (Op (MetalFusedPostRopeAttention
+                        ?nheads ?nkvheads ?hdim ?hidden ?seq ?context ?max_context ?scale)
+                        ?fused_inputs)))
+                    ((subsume (GenericMatmul
+                        ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos)))
+                    :ruleset cleanup
+                    :name "metal-fused-attention-subsumes-generic-matmul"
+                )
+                
+
+                ; Prefer the fused post-RoPE attention op over an MPS batched
+                ; matmul candidate for the same attention output.
+                (rule
+                    ((= ?output (MPSBatchedMatmul
+                        ?b ?m ?n ?k ?lhs ?lhsbs ?lhsrs ?rhs ?rhsbs ?rhsrs ?obs ?ors ?tl ?tr))
+                     (= ?output (Op (MetalFusedPostRopeAttention
+                        ?nheads ?nkvheads ?hdim ?hidden ?seq ?context ?max_context ?scale)
+                        ?fused_inputs)))
+                    ((subsume (MPSBatchedMatmul
+                        ?b ?m ?n ?k ?lhs ?lhsbs ?lhsrs ?rhs ?rhsbs ?rhsrs ?obs ?ors ?tl ?tr)))
+                    :ruleset cleanup
+                    :name "metal-fused-attention-subsumes-mps-batched-matmul"
+                )
+                
+
+                ; Prefer the fused post-RoPE attention op over a plain MPS
+                ; matmul candidate for the same attention output.
+                (rule
+                    ((= ?output (MPSMatmul
+                        ?m ?n ?k ?lhs ?lhsrs ?rhs ?rhsrs ?ors ?tl ?tr))
+                     (= ?output (Op (MetalFusedPostRopeAttention
+                        ?nheads ?nkvheads ?hdim ?hidden ?seq ?context ?max_context ?scale)
+                        ?fused_inputs)))
+                    ((subsume (MPSMatmul
+                        ?m ?n ?k ?lhs ?lhsrs ?rhs ?rhsrs ?ors ?tl ?tr)))
+                    :ruleset cleanup
+                    :name "metal-fused-attention-subsumes-mps-matmul"
+                )
+
+                ; Delete the now-dead decomposed attention subtree once the
+                ; fused op is available. Keep the fused inputs themselves
+                ; (post-RoPE Q, cache buffers, gather indices, and mask).
+                (rule
+                    (
+                        (= ?output (Op (MetalFusedPostRopeAttention
+                            ?nheads (MDiv ?kvdim ?hdim) ?hdim ?hidden ?seq ?context ?max_context ?scale)
+                            (ICons ?q (ICons ?k_cache (ICons ?v_cache (ICons ?k_idx (ICons ?v_idx (ICons ?mask (INil)))))))))
+
+                        (= ?mul2 (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?hdim (ECons ?context (ENil)))))
+                            ?mul2_a_strides
+                            ?mul2_b_strides
+                            ?mul2_out_strides)
+                            (ICons ?soft (ICons ?v_gqa (INil)))))
+                        (= ?output (Op (Sum
+                            (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                            ?context
+                            ?out_in_strides
+                            (MIter)
+                            ?out_out_strides)
+                            (ICons ?mul2 (INil))))
+
+                        (= ?soft (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?soft_a_strides
+                            ?soft_b_strides
+                            ?soft_out_strides)
+                            (ICons ?exp (ICons ?inv_denom (INil)))))
+                        (= ?inv_denom (Op (Recip
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?recip_in_strides
+                            ?recip_out_strides)
+                            (ICons ?denom (INil))))
+                        (= ?denom (Op (Sum
+                            (ECons ?nheads (ECons ?seq (ENil)))
+                            ?context
+                            ?denom_in_strides
+                            (MIter)
+                            ?denom_out_strides)
+                            (ICons ?exp (INil))))
+                        (= ?exp (Op (Exp2
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?exp_in_strides
+                            ?exp_out_strides)
+                            (ICons ?exp_arg (INil))))
+                        (= ?log2e (Op (Constant 1.442695) (INil)))
+                        (= ?exp_arg (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?exp_arg_a_strides
+                            ?exp_arg_b_strides
+                            ?exp_arg_out_strides)
+                            (ICons ?centered (ICons ?log2e (INil)))))
+                        (= ?centered (Op (Add
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?centered_a_strides
+                            ?centered_b_strides
+                            ?centered_out_strides)
+                            (ICons ?masked (ICons ?neg_max (INil)))))
+                        (= ?neg_one (Op (Constant -1.000000) (INil)))
+                        (= ?neg_max (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?neg_max_a_strides
+                            ?neg_max_b_strides
+                            ?neg_max_out_strides)
+                            (ICons ?max_scores (ICons ?neg_one (INil)))))
+                        (= ?max_scores (Op (Max
+                            (ECons ?nheads (ECons ?seq (ENil)))
+                            ?context
+                            ?max_in_strides
+                            (MIter)
+                            ?max_out_strides)
+                            (ICons ?masked (INil))))
+
+                        (= ?masked (Op (Add
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?mask_add_a_strides
+                            (ECons (MNum 0) (ECons (MMul (MIter) ?context) (ECons (MIter) (ENil))))
+                            ?mask_add_out_strides)
+                            (ICons ?scaled_qk (ICons ?mask (INil)))))
+                        (= ?scale_const (Op (Constant ?scale) (INil)))
+                        (= ?scaled_qk (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?scale_a_strides
+                            ?scale_b_strides
+                            ?scale_out_strides)
+                            (ICons ?qk (ICons ?scale_const (INil)))))
+
+                        (= ?mul1 (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ECons ?hdim (ENil)))))
+                            ?mul1_a_strides
+                            ?mul1_b_strides
+                            ?mul1_out_strides)
+                            (ICons ?q (ICons ?k_gqa (INil)))))
+                        (= ?qk (Op (Sum
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?hdim
+                            ?qk_in_strides
+                            (MIter)
+                            ?qk_out_strides)
+                            (ICons ?mul1 (INil))))
+
+                        (= ?k_gqa_const (Op (Constant 1.000000) (INil)))
+                        (= ?k_gqa (Op (Mul
+                            (ECons ?nheads (ECons ?hdim (ECons ?context (ENil))))
+                            ?k_gqa_a_strides
+                            (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
+                            ?k_gqa_out_strides)
+                            (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
+                        (= ?k_gathered (Op (Gather
+                            (ECons ?context (ECons ?kvdim (ENil)))
+                            (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil)))
+                            (ECons ?max_context (ECons ?kvdim (ENil)))
+                            (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil))))
+                            (ICons ?k_idx (ICons ?k_cache (INil)))))
+
+                        (= ?v_gqa_const (Op (Constant 1.000000) (INil)))
+                        (= ?v_gqa (Op (Mul
+                            (ECons ?nheads (ECons ?context (ECons ?hdim (ENil))))
+                            ?v_gqa_a_strides
+                            (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
+                            ?v_gqa_out_strides)
+                            (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
+                        (= ?v_gathered (Op (Gather
+                            (ECons ?context (ECons ?kvdim (ENil)))
+                            (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil)))
+                            (ECons ?max_context (ECons ?kvdim (ENil)))
+                            (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil))))
+                            (ICons ?v_idx (ICons ?v_cache (INil)))))
+
+                    )
+                    (
+                        (delete (Op (Sum
+                            (ECons ?nheads (ECons ?seq (ECons ?hdim (ENil))))
+                            ?context
+                            ?out_in_strides
+                            (MIter)
+                            ?out_out_strides)
+                            (ICons ?mul2 (INil))))
+                        (delete (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?hdim (ECons ?context (ENil)))))
+                            ?mul2_a_strides
+                            ?mul2_b_strides
+                            ?mul2_out_strides)
+                            (ICons ?soft (ICons ?v_gqa (INil)))))
+                        (delete (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?soft_a_strides
+                            ?soft_b_strides
+                            ?soft_out_strides)
+                            (ICons ?exp (ICons ?inv_denom (INil)))))
+                        (delete (Op (Recip
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?recip_in_strides
+                            ?recip_out_strides)
+                            (ICons ?denom (INil))))
+                        (delete (Op (Sum
+                            (ECons ?nheads (ECons ?seq (ENil)))
+                            ?context
+                            ?denom_in_strides
+                            (MIter)
+                            ?denom_out_strides)
+                            (ICons ?exp (INil))))
+                        (delete (Op (Exp2
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?exp_in_strides
+                            ?exp_out_strides)
+                            (ICons ?exp_arg (INil))))
+                        (delete (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?exp_arg_a_strides
+                            ?exp_arg_b_strides
+                            ?exp_arg_out_strides)
+                            (ICons ?centered (ICons ?log2e (INil)))))
+                        (delete (Op (Add
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?centered_a_strides
+                            ?centered_b_strides
+                            ?centered_out_strides)
+                            (ICons ?masked (ICons ?neg_max (INil)))))
+                        (delete (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?neg_max_a_strides
+                            ?neg_max_b_strides
+                            ?neg_max_out_strides)
+                            (ICons ?max_scores (ICons ?neg_one (INil)))))
+                        (delete (Op (Max
+                            (ECons ?nheads (ECons ?seq (ENil)))
+                            ?context
+                            ?max_in_strides
+                            (MIter)
+                            ?max_out_strides)
+                            (ICons ?masked (INil))))
+                        (delete (Op (Add
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?mask_add_a_strides
+                            (ECons (MNum 0) (ECons (MMul (MIter) ?context) (ECons (MIter) (ENil))))
+                            ?mask_add_out_strides)
+                            (ICons ?scaled_qk (ICons ?mask (INil)))))
+                        (delete (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?scale_a_strides
+                            ?scale_b_strides
+                            ?scale_out_strides)
+                            (ICons ?qk (ICons ?scale_const (INil)))))
+                        (delete (Op (Sum
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ENil))))
+                            ?hdim
+                            ?qk_in_strides
+                            (MIter)
+                            ?qk_out_strides)
+                            (ICons ?mul1 (INil))))
+                        (delete (Op (Mul
+                            (ECons ?nheads (ECons ?seq (ECons ?context (ECons ?hdim (ENil)))))
+                            ?mul1_a_strides
+                            ?mul1_b_strides
+                            ?mul1_out_strides)
+                            (ICons ?q (ICons ?k_gqa (INil)))))
+                        (delete (Op (Mul
+                            (ECons ?nheads (ECons ?hdim (ECons ?context (ENil))))
+                            ?k_gqa_a_strides
+                            (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
+                            ?k_gqa_out_strides)
+                            (ICons ?k_gathered (ICons ?k_gqa_const (INil)))))
+                        (delete (Op (Gather
+                            (ECons ?context (ECons ?kvdim (ENil)))
+                            (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil)))
+                            (ECons ?max_context (ECons ?kvdim (ENil)))
+                            (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil))))
+                            (ICons ?k_idx (ICons ?k_cache (INil)))))
+                        (delete (Op (Mul
+                            (ECons ?nheads (ECons ?context (ECons ?hdim (ENil))))
+                            ?v_gqa_a_strides
+                            (ECons (MNum 0) (ECons (MNum 0) (ECons (MNum 0) (ENil))))
+                            ?v_gqa_out_strides)
+                            (ICons ?v_gathered (ICons ?v_gqa_const (INil)))))
+                        (delete (Op (Gather
+                            (ECons ?context (ECons ?kvdim (ENil)))
+                            (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil)))
+                            (ECons ?max_context (ECons ?kvdim (ENil)))
+                            (ECons (MMul (MIter) ?kvdim) (ECons (MIter) (ENil))))
+                            (ICons ?v_idx (ICons ?v_cache (INil)))))
+                    )
+                    :ruleset cleanup
+                    :name "delete-decomposed-post-rope-attention"
+                )

--- a/crates/luminal_metal/src/kernel/fusion/rms_norm.rs
+++ b/crates/luminal_metal/src/kernel/fusion/rms_norm.rs
@@ -1,0 +1,433 @@
+use luminal::{
+    egglog_utils::{
+        SerializedEGraph,
+        api::{Rule, SortDef, sort},
+        base::{ELIST, EXPRESSION, F64, IR},
+    },
+    op::*,
+    prelude::*,
+    shape::flatten_strides,
+};
+use metal::{Buffer, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize};
+
+use crate::kernel::{
+    MetalKernelOp,
+    ops::{compile_shader, lower_expression_for_metal},
+};
+
+/// Fuses the decomposed RMSNorm subgraph into one row-wise kernel:
+/// compute `scale = rsqrt(mean(x * x) + eps)` for each row, then write
+/// `x * scale * weight` with the requested output strides. This replaces the
+/// separate square/sum/scale/rsqrt/multiply kernels used in decoder blocks.
+#[derive(Debug, Clone, Default)]
+pub struct MetalRmsNorm {
+    rows: Expression,
+    cols: Expression,
+    eps: f32,
+    output_strides: Vec<Expression>,
+}
+
+impl EgglogOp for MetalRmsNorm {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "MetalRmsNorm",
+            &[
+                ("rows", EXPRESSION),
+                ("cols", EXPRESSION),
+                ("eps", F64),
+                ("input", IR),
+                ("weight", IR),
+                ("out_strides", ELIST),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![Rule::raw(
+            r#"
+            (rule
+                (
+                    (= ?eps_const (MetalConstant ?eps))
+                    (= ?sum_sq
+                        (GenericMatmul
+                            (ECons ?rows (ENil))
+                            (ECons ?rows (ECons ?cols (ENil)))
+                            ?cols
+                            ?input
+                            ?input_lhs_strides
+                            ?input
+                            ?input_rhs_strides
+                            ?sum_input_strides
+                            ?sum_iter_stride
+                            ?sum_out_strides))
+                    (= ?mean (Op
+                        (MetalMul
+                            (ECons ?rows (ENil))
+                            ?sum_out_strides
+                            ?mean_scale_strides
+                            ?mean_out_strides)
+                        (ICons ?sum_sq (ICons ?mean_scale (INil)))))
+                    (= ?with_eps (Op
+                        (MetalAdd
+                            (ECons ?rows (ENil))
+                            ?mean_out_strides
+                            ?eps_strides
+                            ?eps_out_strides)
+                        (ICons ?mean (ICons ?eps_const (INil)))))
+                    (= ?sqrt (Op
+                        (MetalSqrt
+                            (ECons ?rows (ENil))
+                            ?eps_out_strides
+                            ?sqrt_out_strides)
+                        (ICons ?with_eps (INil))))
+                    (= ?inv (Op
+                        (MetalRecip
+                            (ECons ?rows (ENil))
+                            ?sqrt_out_strides
+                            ?inv_out_strides)
+                        (ICons ?sqrt (INil))))
+                    (= ?normed (Op
+                        (MetalMul
+                            (ECons ?rows (ECons ?cols (ENil)))
+                            ?inv_broadcast_strides
+                            ?norm_input_strides
+                            ?norm_out_strides)
+                        (ICons ?inv (ICons ?input (INil)))))
+                    (= ?weighted (Op
+                        (MetalMul
+                            (ECons ?rows (ECons ?cols (ENil)))
+                            ?norm_out_strides
+                            (ECons (MNum 0) (ECons (MIter) (ENil)))
+                            ?weighted_out_strides)
+                        (ICons ?normed (ICons ?weight (INil)))))
+                )
+                (
+                    (let ?fused (MetalRmsNorm ?rows ?cols ?eps ?input ?weight ?weighted_out_strides))
+                    (union ?weighted ?fused)
+                    (set (dtype ?fused) (F32))
+                )
+                :ruleset matmul_backend
+                :name "metal-fused-weighted-rms-norm"
+            )
+
+            (rule
+                (
+                    (= ?eps_const (MetalConstant ?eps))
+                    (= ?fused (MetalRmsNorm ?rows ?cols ?eps ?input ?weight ?weighted_out_strides))
+                    (= ?sum_sq
+                        (GenericMatmul
+                            (ECons ?rows (ENil))
+                            (ECons ?rows (ECons ?cols (ENil)))
+                            ?cols
+                            ?input
+                            ?input_lhs_strides
+                            ?input
+                            ?input_rhs_strides
+                            ?sum_input_strides
+                            ?sum_iter_stride
+                            ?sum_out_strides))
+                    (= ?mean (Op
+                        (MetalMul
+                            (ECons ?rows (ENil))
+                            ?sum_out_strides
+                            ?mean_scale_strides
+                            ?mean_out_strides)
+                        (ICons ?sum_sq (ICons ?mean_scale (INil)))))
+                    (= ?with_eps (Op
+                        (MetalAdd
+                            (ECons ?rows (ENil))
+                            ?mean_out_strides
+                            ?eps_strides
+                            ?eps_out_strides)
+                        (ICons ?mean (ICons ?eps_const (INil)))))
+                    (= ?sqrt (Op
+                        (MetalSqrt
+                            (ECons ?rows (ENil))
+                            ?eps_out_strides
+                            ?sqrt_out_strides)
+                        (ICons ?with_eps (INil))))
+                    (= ?inv (Op
+                        (MetalRecip
+                            (ECons ?rows (ENil))
+                            ?sqrt_out_strides
+                            ?inv_out_strides)
+                        (ICons ?sqrt (INil))))
+                    (= ?normed (Op
+                        (MetalMul
+                            (ECons ?rows (ECons ?cols (ENil)))
+                            ?inv_broadcast_strides
+                            ?norm_input_strides
+                            ?norm_out_strides)
+                        (ICons ?inv (ICons ?input (INil)))))
+                    (= ?weighted (Op
+                        (MetalMul
+                            (ECons ?rows (ECons ?cols (ENil)))
+                            ?norm_out_strides
+                            (ECons (MNum 0) (ECons (MIter) (ENil)))
+                            ?weighted_out_strides)
+                        (ICons ?normed (ICons ?weight (INil)))))
+                )
+                (
+                    (delete (Op
+                        (MetalMul
+                            (ECons ?rows (ECons ?cols (ENil)))
+                            ?norm_out_strides
+                            (ECons (MNum 0) (ECons (MIter) (ENil)))
+                            ?weighted_out_strides)
+                        (ICons ?normed (ICons ?weight (INil)))))
+                    (delete (Op
+                        (MetalMul
+                            (ECons ?rows (ECons ?cols (ENil)))
+                            ?inv_broadcast_strides
+                            ?norm_input_strides
+                            ?norm_out_strides)
+                        (ICons ?inv (ICons ?input (INil)))))
+                    (delete (Op
+                        (MetalRecip
+                            (ECons ?rows (ENil))
+                            ?sqrt_out_strides
+                            ?inv_out_strides)
+                        (ICons ?sqrt (INil))))
+                    (delete (Op
+                        (MetalSqrt
+                            (ECons ?rows (ENil))
+                            ?eps_out_strides
+                            ?sqrt_out_strides)
+                        (ICons ?with_eps (INil))))
+                    (delete (Op
+                        (MetalAdd
+                            (ECons ?rows (ENil))
+                            ?mean_out_strides
+                            ?eps_strides
+                            ?eps_out_strides)
+                        (ICons ?mean (ICons ?eps_const (INil)))))
+                    (delete (Op
+                        (MetalMul
+                            (ECons ?rows (ENil))
+                            ?sum_out_strides
+                            ?mean_scale_strides
+                            ?mean_out_strides)
+                        (ICons ?sum_sq (ICons ?mean_scale (INil)))))
+                    (delete
+                        (GenericMatmul
+                            (ECons ?rows (ENil))
+                            (ECons ?rows (ECons ?cols (ENil)))
+                            ?cols
+                            ?input
+                            ?input_lhs_strides
+                            ?input
+                            ?input_rhs_strides
+                            ?sum_input_strides
+                            ?sum_iter_stride
+                            ?sum_out_strides))
+                )
+                :ruleset cleanup
+                :name "delete-decomposed-weighted-rms-norm"
+            )
+            "#,
+        )]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::{extract_expr, extract_expr_list};
+
+        let eps = egraph.enodes[children[2]]
+            .0
+            .replace('\"', "")
+            .parse::<f32>()
+            .expect("MetalRmsNorm eps must be a float");
+
+        (
+            LLIROp::new::<dyn MetalKernelOp>(Box::new(Self {
+                rows: extract_expr(egraph, children[0], expr_cache).unwrap(),
+                cols: extract_expr(egraph, children[1], expr_cache).unwrap(),
+                eps,
+                output_strides: extract_expr_list(egraph, children[5], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            vec![children[3], children[4]],
+        )
+    }
+}
+
+impl MetalKernelOp for MetalRmsNorm {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "RmsNorm"
+    }
+
+    fn compile(
+        &self,
+        device: &Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<ComputePipelineState> {
+        if input_dtypes.first().copied().unwrap_or(DType::F32) != DType::F32
+            || input_dtypes.get(1).copied().unwrap_or(DType::F32) != DType::F32
+            || output_dtype != DType::F32
+        {
+            return None;
+        }
+
+        let shape = vec![self.rows, self.cols];
+        let out_flat = flatten_strides(&shape, &self.output_strides);
+        let out_index = lower_expression_for_metal(&out_flat, "idx");
+        let output_body = if out_index == "idx" {
+            r#"
+                for (uint col = tid * 4; col < cols4; col += THREADS_PER_GROUP * 4) {
+                    const uint idx = row_base + col;
+                    const packed_float4 x = *(const device packed_float4 *)(input + idx);
+                    const packed_float4 w = *(const device packed_float4 *)(weight + col);
+                    const float4 y = float4(x) * scale * float4(w);
+                    *(device packed_float4 *)(out + idx) = packed_float4(y);
+                }
+                for (uint col = cols4 + tid; col < cols; col += THREADS_PER_GROUP) {
+                    const uint idx = row_base + col;
+                    out[idx] = input[idx] * scale * weight[col];
+                }
+            "#
+            .to_string()
+        } else {
+            format!(
+                r#"
+                for (uint col = tid; col < cols; col += THREADS_PER_GROUP) {{
+                    const uint idx = row_base + col;
+                    out[{out_index}] = input[idx] * scale * weight[col];
+                }}
+            "#
+            )
+        };
+        let eps = self.eps;
+        let source = format!(
+            r#"
+            #include <metal_stdlib>
+            using namespace metal;
+
+            #define THREADS_PER_GROUP 128
+            #define SIMD_GROUP_SIZE 32
+            #define SIMD_GROUPS_PER_TG 4
+            #define EPS {eps:.9e}f
+
+            kernel void rms_norm_kernel(
+                const device float *input [[buffer(0)]],
+                const device float *weight [[buffer(1)]],
+                device float *out [[buffer(2)]],
+                constant int *dyn [[buffer(3)]],
+                constant uint &rows [[buffer(4)]],
+                constant uint &cols [[buffer(5)]],
+                uint row [[threadgroup_position_in_grid]],
+                uint tid [[thread_index_in_threadgroup]],
+                uint lane [[thread_index_in_simdgroup]],
+                uint simd_group [[simdgroup_index_in_threadgroup]]
+            ) {{
+                (void)dyn;
+                if (row >= rows) {{
+                    return;
+                }}
+
+                threadgroup float partials[SIMD_GROUPS_PER_TG];
+                threadgroup float row_scale;
+                const uint row_base = row * cols;
+
+                float sum = 0.0f;
+                const uint cols4 = (cols / 4) * 4;
+                for (uint col = tid * 4; col < cols4; col += THREADS_PER_GROUP * 4) {{
+                    const packed_float4 v = *(const device packed_float4 *)(input + row_base + col);
+                    const float4 vf = float4(v);
+                    sum += dot(vf, vf);
+                }}
+                for (uint col = cols4 + tid; col < cols; col += THREADS_PER_GROUP) {{
+                    const float v = input[row_base + col];
+                    sum += v * v;
+                }}
+
+                sum = simd_sum(sum);
+                if (lane == 0) {{
+                    partials[simd_group] = sum;
+                }}
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                if (simd_group == 0) {{
+                    float total = lane < SIMD_GROUPS_PER_TG ? partials[lane] : 0.0f;
+                    total = simd_sum(total);
+                    if (lane == 0) {{
+                        row_scale = fast::rsqrt(total / float(cols) + EPS);
+                    }}
+                }}
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                const float scale = row_scale;
+{output_body}
+            }}
+            "#,
+            eps = eps,
+            output_body = output_body,
+        );
+        Some(compile_shader(device, &source, "rms_norm_kernel"))
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        DType::F32
+    }
+
+    fn output_size(&self) -> Expression {
+        (self.rows * self.cols).max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &FxHashMap<char, usize>,
+    ) {
+        let rows = self.rows.exec(dyn_map).unwrap() as u32;
+        let cols = self.cols.exec(dyn_map).unwrap() as u32;
+
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(inputs[0]), 0);
+        encoder.set_buffer(1, Some(inputs[1]), 0);
+        encoder.set_buffer(2, Some(output), 0);
+        encoder.set_bytes(
+            4,
+            std::mem::size_of::<u32>() as u64,
+            &rows as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            5,
+            std::mem::size_of::<u32>() as u64,
+            &cols as *const u32 as *const _,
+        );
+
+        let thread_group_size = MTLSize::new(128, 1, 1);
+        let thread_groups = MTLSize::new(rows as u64, 1, 1);
+        encoder.dispatch_thread_groups(thread_groups, thread_group_size);
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n = self.output_size().exec(dyn_map).unwrap_or(0);
+        3 * n * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n = self.output_size().exec(dyn_map).unwrap_or(0);
+        4 * n
+    }
+}

--- a/crates/luminal_metal/src/kernel/fusion/rope.rs
+++ b/crates/luminal_metal/src/kernel/fusion/rope.rs
@@ -1,0 +1,791 @@
+use luminal::{
+    egglog_utils::{
+        SerializedEGraph,
+        api::{Rule, SortDef, sort},
+        base::{ELIST, EXPRESSION, F64, IR},
+    },
+    op::*,
+    prelude::*,
+    shape::flatten_strides,
+};
+use metal::{Buffer, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize};
+
+use crate::kernel::{
+    MetalKernelOp,
+    ops::{compile_shader, lower_expression_for_metal},
+};
+
+#[derive(Debug, Clone, Default)]
+/// Replaces the decomposed Llama RoPE graph with a direct split-half rotary embedding kernel.
+/// input [seq, hidden] as [seq, n_heads, head_dim], pos [seq] -> out [seq, hidden]
+/// [x0, x1] -> [x0 * cos(pos, dim) - x1 * sin(pos, dim),
+///              x1 * cos(pos, dim) + x0 * sin(pos, dim)]
+pub struct MetalLlamaRope {
+    shape: Vec<Expression>,
+    n_heads: usize,
+    head_dim: usize,
+    theta_ln: f32,
+    output_strides: Vec<Expression>,
+}
+
+impl EgglogOp for MetalLlamaRope {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "MetalLlamaRope",
+            &[
+                ("shape", ELIST),
+                ("input", IR),
+                ("pos", IR),
+                ("n_heads", EXPRESSION),
+                ("head_dim", EXPRESSION),
+                ("theta_ln", F64),
+                ("out_strides", ELIST),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![Rule::raw(include_str!("llama_rope.egg"))]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::{extract_expr, extract_expr_list};
+
+        let static_usize = |expr: Expression, name: &str| {
+            expr.exec(&FxHashMap::default())
+                .unwrap_or_else(|| panic!("MetalLlamaRope {name} must be static"))
+        };
+        let n_heads = static_usize(
+            extract_expr(egraph, children[3], expr_cache).unwrap(),
+            "n_heads",
+        );
+        let head_dim = static_usize(
+            extract_expr(egraph, children[4], expr_cache).unwrap(),
+            "head_dim",
+        );
+        let theta_ln = egraph.enodes[children[5]]
+            .0
+            .replace('\"', "")
+            .parse::<f32>()
+            .expect("MetalLlamaRope theta_ln must be a float");
+
+        (
+            LLIROp::new::<dyn MetalKernelOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, children[0], list_cache, expr_cache).unwrap(),
+                n_heads,
+                head_dim,
+                theta_ln,
+                output_strides: extract_expr_list(egraph, children[6], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            vec![children[1], children[2]],
+        )
+    }
+}
+
+impl MetalKernelOp for MetalLlamaRope {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "LlamaRope"
+    }
+
+    fn compile(
+        &self,
+        device: &Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<ComputePipelineState> {
+        if input_dtypes.first().copied().unwrap_or(DType::F32) != DType::F32
+            || input_dtypes.get(1).copied().unwrap_or(DType::Int) != DType::Int
+            || output_dtype != DType::F32
+        {
+            return None;
+        }
+
+        let hidden = self.n_heads * self.head_dim;
+        let head_dim = self.head_dim;
+        let half_dim = self.head_dim / 2;
+        let theta_ln = self.theta_ln;
+        let out_index =
+            lower_expression_for_metal(&flatten_strides(&self.shape, &self.output_strides), "idx");
+        let source = format!(
+            r#"
+            #include <metal_stdlib>
+            using namespace metal;
+
+            #define HIDDEN {hidden}
+            #define HEAD_DIM {head_dim}
+            #define HALF_DIM {half_dim}
+            #define THETA_LN {theta_ln:.9e}f
+
+            inline float rotate_split_half(
+                const device float *x,
+                const uint base,
+                const uint d,
+                const int pos
+            ) {{
+                const uint pair = d < HALF_DIM ? d : d - HALF_DIM;
+                const float exponent = -float(pair * 2u) / float(HEAD_DIM);
+                const float angle = float(pos) * exp(THETA_LN * exponent);
+                const float c = fast::cos(angle);
+                const float s = fast::sin(angle);
+                const float x0 = x[base + pair];
+                const float x1 = x[base + pair + HALF_DIM];
+                return d < HALF_DIM ? x0 * c - x1 * s : x1 * c + x0 * s;
+            }}
+
+            kernel void llama_rope_kernel(
+                const device float *input [[buffer(0)]],
+                const device int *pos [[buffer(1)]],
+                device float *out [[buffer(2)]],
+                constant int *dyn [[buffer(3)]],
+                constant uint &n_elements [[buffer(4)]],
+                uint idx [[thread_position_in_grid]]
+            ) {{
+                if (idx >= n_elements) {{
+                    return;
+                }}
+
+                (void)dyn;
+                const uint token = idx / HIDDEN;
+                const uint flat = idx - token * HIDDEN;
+                const uint head = flat / HEAD_DIM;
+                const uint d = flat - head * HEAD_DIM;
+                const uint base = token * HIDDEN + head * HEAD_DIM;
+                out[{out_index}] = rotate_split_half(input, base, d, pos[token]);
+            }}
+            "#
+        );
+        Some(compile_shader(device, &source, "llama_rope_kernel"))
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        DType::F32
+    }
+
+    fn output_size(&self) -> Expression {
+        self.shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &FxHashMap<char, usize>,
+    ) {
+        let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
+
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(inputs[0]), 0);
+        encoder.set_buffer(1, Some(inputs[1]), 0);
+        encoder.set_buffer(2, Some(output), 0);
+        encoder.set_bytes(
+            4,
+            std::mem::size_of::<u32>() as u64,
+            &n_elements as *const u32 as *const _,
+        );
+
+        let thread_group_size = MTLSize::new(256, 1, 1);
+        let thread_groups = MTLSize::new((n_elements as u64).div_ceil(256), 1, 1);
+        encoder.dispatch_thread_groups(thread_groups, thread_group_size);
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n = self.output_size().exec(dyn_map).unwrap_or(0);
+        n * std::mem::size_of::<f32>()
+            + self
+                .shape
+                .first()
+                .and_then(|s| s.exec(dyn_map))
+                .unwrap_or(0)
+                * std::mem::size_of::<i32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * 8
+    }
+}
+
+/// Replaces the decomposed Llama RoPE graph while it is still materialized as
+/// `[heads, seq, head_dim]`. The kernel applies split-half rotary embedding
+/// directly in that 3D layout, which lets the KV-cache path avoid building the
+/// full gather/sin/cos/pad/add RoPE subtree before scatter.
+#[derive(Debug, Clone, Default)]
+pub struct MetalLlamaRope3D {
+    shape: Vec<Expression>,
+    input_strides: Vec<Expression>,
+    head_dim: usize,
+    theta_ln: f32,
+    output_strides: Vec<Expression>,
+}
+
+impl EgglogOp for MetalLlamaRope3D {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "MetalLlamaRope3D",
+            &[
+                ("shape", ELIST),
+                ("input", IR),
+                ("pos", IR),
+                ("input_strides", ELIST),
+                ("n_heads", EXPRESSION),
+                ("head_dim", EXPRESSION),
+                ("theta_ln", F64),
+                ("out_strides", ELIST),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![Rule::raw(
+            r#"
+            (rule
+                (
+                    (= ?rope (MetalLlamaRope3D ?shape ?input ?pos ?input_strides ?nheads ?hdim ?theta_ln ?rope_out_strides))
+                    (= ?scatter (Op
+                        (MetalScatterNoCopy ?dest_shape ?dest_strides ?index_shape ?index_strides ?src_strides ?out_strides)
+                        (ICons ?dest (ICons ?indexes (ICons ?rope (INil))))))
+                )
+                (
+                    (let ?fused (MetalLlamaRope3DScatter
+                        ?dest_shape
+                        ?dest_strides
+                        ?index_shape
+                        ?index_strides
+                        ?input_strides
+                        ?out_strides
+                        ?input
+                        ?pos
+                        ?dest
+                        ?indexes
+                        ?nheads
+                        ?hdim
+                        ?theta_ln))
+                    (union ?scatter ?fused)
+                    (set (dtype ?fused) (F32))
+                )
+                :ruleset cleanup
+                :name "metal-llama-rope-3d-scatter"
+            )
+
+            (rule
+                (
+                    (= ?scatter (Op
+                        (MetalScatterNoCopy ?dest_shape ?dest_strides ?index_shape ?index_strides ?src_strides ?out_strides)
+                        (ICons ?dest (ICons ?indexes (ICons ?rope (INil))))))
+                    (= ?scatter (MetalLlamaRope3DScatter
+                        ?dest_shape
+                        ?dest_strides
+                        ?index_shape
+                        ?index_strides
+                        ?input_strides
+                        ?out_strides
+                        ?input
+                        ?pos
+                        ?dest
+                        ?indexes
+                        ?nheads
+                        ?hdim
+                        ?theta_ln))
+                )
+                ((subsume (Op
+                    (MetalScatterNoCopy ?dest_shape ?dest_strides ?index_shape ?index_strides ?src_strides ?out_strides)
+                    (ICons ?dest (ICons ?indexes (ICons ?rope (INil)))))))
+                :ruleset cleanup
+                :name "metal-llama-rope-3d-scatter-subsumes-scatter"
+            )
+            "#,
+        )]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::{extract_expr, extract_expr_list};
+
+        let static_usize = |expr: Expression, name: &str| {
+            expr.exec(&FxHashMap::default())
+                .unwrap_or_else(|| panic!("MetalLlamaRope3D {name} must be static"))
+        };
+        let _n_heads = static_usize(
+            extract_expr(egraph, children[4], expr_cache).unwrap(),
+            "n_heads",
+        );
+        let head_dim = static_usize(
+            extract_expr(egraph, children[5], expr_cache).unwrap(),
+            "head_dim",
+        );
+        let theta_ln = egraph.enodes[children[6]]
+            .0
+            .replace('\"', "")
+            .parse::<f32>()
+            .expect("MetalLlamaRope3D theta_ln must be a float");
+
+        (
+            LLIROp::new::<dyn MetalKernelOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, children[0], list_cache, expr_cache).unwrap(),
+                input_strides: extract_expr_list(egraph, children[3], list_cache, expr_cache)
+                    .unwrap(),
+                head_dim,
+                theta_ln,
+                output_strides: extract_expr_list(egraph, children[7], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            vec![children[1], children[2]],
+        )
+    }
+}
+
+/// Fuses 3D RoPE with KV-cache scatter. The output aliases the destination
+/// cache buffer, and each thread rotates one `[head, token, dim]` element and
+/// writes it to the flat scatter index. This removes both the temporary RoPE
+/// tensor and the following `MetalScatterNoCopy` pass for K-cache updates.
+#[derive(Debug, Clone, Default)]
+pub struct MetalLlamaRope3DScatter {
+    dest_shape: Vec<Expression>,
+    dest_strides: Vec<Expression>,
+    index_shape: Vec<Expression>,
+    index_strides: Vec<Expression>,
+    input_strides: Vec<Expression>,
+    output_strides: Vec<Expression>,
+    head_dim: usize,
+    theta_ln: f32,
+}
+
+impl EgglogOp for MetalLlamaRope3DScatter {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "MetalLlamaRope3DScatter",
+            &[
+                ("dest_shape", ELIST),
+                ("dest_strides", ELIST),
+                ("index_shape", ELIST),
+                ("index_strides", ELIST),
+                ("input_strides", ELIST),
+                ("out_strides", ELIST),
+                ("input", IR),
+                ("pos", IR),
+                ("dest", IR),
+                ("indexes", IR),
+                ("n_heads", EXPRESSION),
+                ("head_dim", EXPRESSION),
+                ("theta_ln", F64),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::{extract_expr, extract_expr_list};
+
+        let static_usize = |expr: Expression, name: &str| {
+            expr.exec(&FxHashMap::default())
+                .unwrap_or_else(|| panic!("MetalLlamaRope3DScatter {name} must be static"))
+        };
+        let _n_heads = static_usize(
+            extract_expr(egraph, children[10], expr_cache).unwrap(),
+            "n_heads",
+        );
+        let head_dim = static_usize(
+            extract_expr(egraph, children[11], expr_cache).unwrap(),
+            "head_dim",
+        );
+        let theta_ln = egraph.enodes[children[12]]
+            .0
+            .replace('\"', "")
+            .parse::<f32>()
+            .expect("MetalLlamaRope3DScatter theta_ln must be a float");
+
+        (
+            LLIROp::new::<dyn MetalKernelOp>(Box::new(Self {
+                dest_shape: extract_expr_list(egraph, children[0], list_cache, expr_cache).unwrap(),
+                dest_strides: extract_expr_list(egraph, children[1], list_cache, expr_cache)
+                    .unwrap(),
+                index_shape: extract_expr_list(egraph, children[2], list_cache, expr_cache)
+                    .unwrap(),
+                index_strides: extract_expr_list(egraph, children[3], list_cache, expr_cache)
+                    .unwrap(),
+                input_strides: extract_expr_list(egraph, children[4], list_cache, expr_cache)
+                    .unwrap(),
+                output_strides: extract_expr_list(egraph, children[5], list_cache, expr_cache)
+                    .unwrap(),
+                head_dim,
+                theta_ln,
+            })),
+            vec![children[8], children[9], children[6], children[7]],
+        )
+    }
+}
+
+impl MetalKernelOp for MetalLlamaRope3DScatter {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "LlamaRope3DScatter"
+    }
+
+    fn compile(
+        &self,
+        device: &Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<ComputePipelineState> {
+        if input_dtypes.first().copied().unwrap_or(DType::F32) != DType::F32
+            || input_dtypes.get(1).copied().unwrap_or(DType::Int) != DType::Int
+            || input_dtypes.get(2).copied().unwrap_or(DType::F32) != DType::F32
+            || input_dtypes.get(3).copied().unwrap_or(DType::Int) != DType::Int
+            || output_dtype != DType::F32
+        {
+            return None;
+        }
+        let _ = (&self.dest_strides, &self.output_strides);
+        assert_eq!(
+            self.input_strides.len(),
+            3,
+            "MetalLlamaRope3DScatter input must be a 3D view"
+        );
+
+        let head_dim = self.head_dim;
+        let half_dim = self.head_dim / 2;
+        let theta_ln = self.theta_ln;
+        let in_head = lower_expression_for_metal(&self.input_strides[0], "head");
+        let in_token = lower_expression_for_metal(&self.input_strides[1], "token");
+        let in_pair = lower_expression_for_metal(&self.input_strides[2], "pair");
+        let in_other = lower_expression_for_metal(&self.input_strides[2], "other");
+        let index_idx = lower_expression_for_metal(
+            &flatten_strides(&self.index_shape, &self.index_strides),
+            "idx",
+        );
+        let source = format!(
+            r#"
+            #include <metal_stdlib>
+            using namespace metal;
+
+            #define HEAD_DIM {head_dim}
+            #define HALF_DIM {half_dim}
+            #define THETA_LN {theta_ln:.9e}f
+
+            kernel void llama_rope_3d_scatter_kernel(
+                device float *out [[buffer(0)]],
+                const device int *indexes [[buffer(1)]],
+                const device float *input [[buffer(2)]],
+                const device int *pos [[buffer(3)]],
+                constant int *dyn [[buffer(4)]],
+                constant uint &n_elements [[buffer(5)]],
+                constant uint &kv_dim [[buffer(6)]],
+                uint idx [[thread_position_in_grid]]
+            ) {{
+                (void)dyn;
+                if (idx >= n_elements) {{
+                    return;
+                }}
+
+                const uint token = idx / kv_dim;
+                const uint flat = idx - token * kv_dim;
+                const uint head = flat / HEAD_DIM;
+                const uint d = flat - head * HEAD_DIM;
+                const uint pair = d < HALF_DIM ? d : d - HALF_DIM;
+                const uint other = pair + HALF_DIM;
+                const float exponent = -float(pair * 2u) / float(HEAD_DIM);
+                const float angle = float(pos[token]) * exp(THETA_LN * exponent);
+                const float c = fast::cos(angle);
+                const float s = fast::sin(angle);
+                const uint input_idx0 = ({in_head}) + ({in_token}) + ({in_pair});
+                const uint input_idx1 = ({in_head}) + ({in_token}) + ({in_other});
+                const float x0 = input[input_idx0];
+                const float x1 = input[input_idx1];
+                const int scatter_idx = indexes[{index_idx}];
+                out[scatter_idx] = d < HALF_DIM ? x0 * c - x1 * s : x1 * c + x0 * s;
+            }}
+            "#,
+            head_dim = head_dim,
+            half_dim = half_dim,
+            theta_ln = theta_ln,
+            in_head = in_head,
+            in_token = in_token,
+            in_pair = in_pair,
+            in_other = in_other,
+            index_idx = index_idx,
+        );
+        Some(compile_shader(
+            device,
+            &source,
+            "llama_rope_3d_scatter_kernel",
+        ))
+    }
+
+    fn infer_output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        input_dtypes.first().copied().unwrap_or(DType::F32)
+    }
+
+    fn output_size(&self) -> Expression {
+        self.dest_shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &FxHashMap<char, usize>,
+    ) {
+        let n_elements = self
+            .index_shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .exec(dyn_map)
+            .unwrap() as u32;
+        let kv_dim = self
+            .index_shape
+            .last()
+            .and_then(|dim| dim.exec(dyn_map))
+            .unwrap() as u32;
+
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(output), 0);
+        encoder.set_buffer(1, Some(inputs[1]), 0);
+        encoder.set_buffer(2, Some(inputs[2]), 0);
+        encoder.set_buffer(3, Some(inputs[3]), 0);
+        encoder.set_bytes(
+            5,
+            std::mem::size_of::<u32>() as u64,
+            &n_elements as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            6,
+            std::mem::size_of::<u32>() as u64,
+            &kv_dim as *const u32 as *const _,
+        );
+
+        let thread_group_size = MTLSize::new(256, 1, 1);
+        encoder.dispatch_thread_groups(
+            MTLSize::new((n_elements as u64).div_ceil(256), 1, 1),
+            thread_group_size,
+        );
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n = self
+            .index_shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .exec(dyn_map)
+            .unwrap_or(0);
+        n * (std::mem::size_of::<i32>() + std::mem::size_of::<f32>())
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n = self
+            .index_shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .exec(dyn_map)
+            .unwrap_or(0);
+        n * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+        0
+    }
+
+    fn output_aliases_input(&self) -> Option<usize> {
+        Some(0)
+    }
+}
+
+impl MetalKernelOp for MetalLlamaRope3D {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "LlamaRope3D"
+    }
+
+    fn compile(
+        &self,
+        device: &Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<ComputePipelineState> {
+        if input_dtypes.first().copied().unwrap_or(DType::F32) != DType::F32
+            || input_dtypes.get(1).copied().unwrap_or(DType::Int) != DType::Int
+            || output_dtype != DType::F32
+        {
+            return None;
+        }
+        assert_eq!(
+            self.input_strides.len(),
+            3,
+            "MetalLlamaRope3D input must be a 3D view"
+        );
+
+        let head_dim = self.head_dim;
+        let half_dim = self.head_dim / 2;
+        let theta_ln = self.theta_ln;
+        let in_head = lower_expression_for_metal(&self.input_strides[0], "head");
+        let in_token = lower_expression_for_metal(&self.input_strides[1], "token");
+        let in_pair = lower_expression_for_metal(&self.input_strides[2], "pair");
+        let in_other = lower_expression_for_metal(&self.input_strides[2], "other");
+        let out_index =
+            lower_expression_for_metal(&flatten_strides(&self.shape, &self.output_strides), "idx");
+        let source = format!(
+            r#"
+            #include <metal_stdlib>
+            using namespace metal;
+
+            #define HEAD_DIM {head_dim}
+            #define HALF_DIM {half_dim}
+            #define THETA_LN {theta_ln:.9e}f
+
+            kernel void llama_rope_3d_kernel(
+                const device float *input [[buffer(0)]],
+                const device int *pos [[buffer(1)]],
+                device float *out [[buffer(2)]],
+                constant int *dyn [[buffer(3)]],
+                constant uint &n_elements [[buffer(4)]],
+                constant uint &seq [[buffer(5)]],
+                uint idx [[thread_position_in_grid]]
+            ) {{
+                if (idx >= n_elements) {{
+                    return;
+                }}
+
+                (void)dyn;
+                const uint d = idx % HEAD_DIM;
+                const uint token = (idx / HEAD_DIM) % seq;
+                const uint head = idx / (seq * HEAD_DIM);
+                const uint pair = d < HALF_DIM ? d : d - HALF_DIM;
+                const uint other = pair + HALF_DIM;
+                const float exponent = -float(pair * 2u) / float(HEAD_DIM);
+                const float angle = float(pos[token]) * exp(THETA_LN * exponent);
+                const float c = fast::cos(angle);
+                const float s = fast::sin(angle);
+                const uint input_idx0 = ({in_head}) + ({in_token}) + ({in_pair});
+                const uint input_idx1 = ({in_head}) + ({in_token}) + ({in_other});
+                const float x0 = input[input_idx0];
+                const float x1 = input[input_idx1];
+                out[{out_index}] = d < HALF_DIM ? x0 * c - x1 * s : x1 * c + x0 * s;
+            }}
+            "#,
+            head_dim = head_dim,
+            half_dim = half_dim,
+            theta_ln = theta_ln,
+            in_head = in_head,
+            in_token = in_token,
+            in_pair = in_pair,
+            in_other = in_other,
+            out_index = out_index,
+        );
+        Some(compile_shader(device, &source, "llama_rope_3d_kernel"))
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        DType::F32
+    }
+
+    fn output_size(&self) -> Expression {
+        self.shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &FxHashMap<char, usize>,
+    ) {
+        let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
+        let seq = self.shape[1].exec(dyn_map).unwrap() as u32;
+
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(inputs[0]), 0);
+        encoder.set_buffer(1, Some(inputs[1]), 0);
+        encoder.set_buffer(2, Some(output), 0);
+        encoder.set_bytes(
+            4,
+            std::mem::size_of::<u32>() as u64,
+            &n_elements as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            5,
+            std::mem::size_of::<u32>() as u64,
+            &seq as *const u32 as *const _,
+        );
+
+        let thread_group_size = MTLSize::new(256, 1, 1);
+        let thread_groups = MTLSize::new((n_elements as u64).div_ceil(256), 1, 1);
+        encoder.dispatch_thread_groups(thread_groups, thread_group_size);
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n = self.output_size().exec(dyn_map).unwrap_or(0);
+        n * std::mem::size_of::<f32>()
+            + self.shape.get(1).and_then(|s| s.exec(dyn_map)).unwrap_or(0)
+                * std::mem::size_of::<i32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * 8
+    }
+}

--- a/crates/luminal_metal/src/kernel/fusion/swiglu.rs
+++ b/crates/luminal_metal/src/kernel/fusion/swiglu.rs
@@ -1,0 +1,615 @@
+use luminal::{
+    egglog_utils::{
+        SerializedEGraph,
+        api::{Rule, SortDef, sort},
+        base::{ELIST, EXPRESSION, IR},
+    },
+    op::*,
+    prelude::*,
+    shape::flatten_strides,
+};
+use metal::{Buffer, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize};
+
+use crate::kernel::{
+    MetalKernelOp,
+    ops::{compile_shader, lower_expression_for_metal},
+};
+
+/// Fuses the elementwise SwiGLU activation into one kernel:
+/// `gate * sigmoid(gate) * up`. The rewrite removes the decomposed neg/exp2,
+/// add, reciprocal, and multiply chain after the gate and up projections have
+/// already been materialized.
+#[derive(Debug, Clone, Default)]
+pub struct MetalSwiGLU {
+    shape: Vec<Expression>,
+    output_strides: Vec<Expression>,
+}
+
+impl EgglogOp for MetalSwiGLU {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "MetalSwiGLU",
+            &[
+                ("shape", ELIST),
+                ("gate", IR),
+                ("up", IR),
+                ("out_strides", ELIST),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![Rule::raw(
+            r#"
+            (rule
+                (
+                    (= ?neg_one (MetalConstant -1.000000))
+                    (= ?log2e (MetalConstant 1.442695))
+                    (= ?one (MetalConstant 1.000000))
+                    (= ?neg_gate (Op
+                        (MetalMul ?shape ?gate_stride ?neg_one_stride ?neg_gate_stride)
+                        (ICons ?gate (ICons ?neg_one (INil)))))
+                    (= ?scaled (Op
+                        (MetalMul ?shape ?neg_gate_stride ?log2e_stride ?scaled_stride)
+                        (ICons ?neg_gate (ICons ?log2e (INil)))))
+                    (= ?exp (Op
+                        (MetalExp2 ?shape ?scaled_stride ?exp_stride)
+                        (ICons ?scaled (INil))))
+                    (= ?denom (Op
+                        (MetalAdd ?shape ?exp_stride ?one_stride ?denom_stride)
+                        (ICons ?exp (ICons ?one (INil)))))
+                    (= ?sigmoid (Op
+                        (MetalRecip ?shape ?denom_stride ?sigmoid_stride)
+                        (ICons ?denom (INil))))
+                    (= ?swish (Op
+                        (MetalMul ?shape ?gate_stride ?sigmoid_stride ?swish_stride)
+                        (ICons ?gate (ICons ?sigmoid (INil)))))
+                    (= ?out (Op
+                        (MetalMul ?shape ?swish_stride ?up_stride ?out_stride)
+                        (ICons ?swish (ICons ?up (INil)))))
+                )
+                (
+                    (let ?fused (MetalSwiGLU ?shape ?gate ?up ?out_stride))
+                    (union ?out ?fused)
+                    (set (dtype ?fused) (F32))
+                )
+                :ruleset matmul_backend
+                :name "metal-fused-swiglu"
+            )
+
+            (rule
+                (
+                    (= ?fused (MetalSwiGLU ?shape ?gate ?up ?out_stride))
+                    (= ?neg_one (MetalConstant -1.000000))
+                    (= ?log2e (MetalConstant 1.442695))
+                    (= ?one (MetalConstant 1.000000))
+                    (= ?neg_gate (Op
+                        (MetalMul ?shape ?gate_stride ?neg_one_stride ?neg_gate_stride)
+                        (ICons ?gate (ICons ?neg_one (INil)))))
+                    (= ?scaled (Op
+                        (MetalMul ?shape ?neg_gate_stride ?log2e_stride ?scaled_stride)
+                        (ICons ?neg_gate (ICons ?log2e (INil)))))
+                    (= ?exp (Op
+                        (MetalExp2 ?shape ?scaled_stride ?exp_stride)
+                        (ICons ?scaled (INil))))
+                    (= ?denom (Op
+                        (MetalAdd ?shape ?exp_stride ?one_stride ?denom_stride)
+                        (ICons ?exp (ICons ?one (INil)))))
+                    (= ?sigmoid (Op
+                        (MetalRecip ?shape ?denom_stride ?sigmoid_stride)
+                        (ICons ?denom (INil))))
+                    (= ?swish (Op
+                        (MetalMul ?shape ?gate_stride ?sigmoid_stride ?swish_stride)
+                        (ICons ?gate (ICons ?sigmoid (INil)))))
+                    (= ?out (Op
+                        (MetalMul ?shape ?swish_stride ?up_stride ?out_stride)
+                        (ICons ?swish (ICons ?up (INil)))))
+                )
+                (
+                    (delete (Op
+                        (MetalMul ?shape ?swish_stride ?up_stride ?out_stride)
+                        (ICons ?swish (ICons ?up (INil)))))
+                    (delete (Op
+                        (MetalMul ?shape ?gate_stride ?sigmoid_stride ?swish_stride)
+                        (ICons ?gate (ICons ?sigmoid (INil)))))
+                    (delete (Op
+                        (MetalRecip ?shape ?denom_stride ?sigmoid_stride)
+                        (ICons ?denom (INil))))
+                    (delete (Op
+                        (MetalAdd ?shape ?exp_stride ?one_stride ?denom_stride)
+                        (ICons ?exp (ICons ?one (INil)))))
+                    (delete (Op
+                        (MetalExp2 ?shape ?scaled_stride ?exp_stride)
+                        (ICons ?scaled (INil))))
+                    (delete (Op
+                        (MetalMul ?shape ?neg_gate_stride ?log2e_stride ?scaled_stride)
+                        (ICons ?neg_gate (ICons ?log2e (INil)))))
+                    (delete (Op
+                        (MetalMul ?shape ?gate_stride ?neg_one_stride ?neg_gate_stride)
+                        (ICons ?gate (ICons ?neg_one (INil)))))
+                )
+                :ruleset cleanup
+                :name "delete-decomposed-swiglu"
+            )
+            "#,
+        )]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::extract_expr_list;
+
+        (
+            LLIROp::new::<dyn MetalKernelOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, children[0], list_cache, expr_cache).unwrap(),
+                output_strides: extract_expr_list(egraph, children[3], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            vec![children[1], children[2]],
+        )
+    }
+}
+
+impl MetalKernelOp for MetalSwiGLU {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "SwiGLU"
+    }
+
+    fn compile(
+        &self,
+        device: &Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<ComputePipelineState> {
+        if input_dtypes.first().copied().unwrap_or(DType::F32) != DType::F32
+            || input_dtypes.get(1).copied().unwrap_or(DType::F32) != DType::F32
+            || output_dtype != DType::F32
+        {
+            return None;
+        }
+
+        let out_index =
+            lower_expression_for_metal(&flatten_strides(&self.shape, &self.output_strides), "idx");
+        let source = format!(
+            r#"
+            #include <metal_stdlib>
+            using namespace metal;
+
+            #define LOG2E 1.4426950408889634f
+
+            kernel void swiglu_kernel(
+                const device float *gate [[buffer(0)]],
+                const device float *up [[buffer(1)]],
+                device float *out [[buffer(2)]],
+                constant int *dyn [[buffer(3)]],
+                constant uint &n_elements [[buffer(4)]],
+                uint idx [[thread_position_in_grid]]
+            ) {{
+                (void)dyn;
+                if (idx >= n_elements) {{
+                    return;
+                }}
+
+                const float g = gate[idx];
+                const float sigmoid = 1.0f / (1.0f + fast::exp2(-g * LOG2E));
+                out[{out_index}] = g * sigmoid * up[idx];
+            }}
+            "#,
+            out_index = out_index,
+        );
+        Some(compile_shader(device, &source, "swiglu_kernel"))
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        DType::F32
+    }
+
+    fn output_size(&self) -> Expression {
+        self.shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &FxHashMap<char, usize>,
+    ) {
+        let n_elements = self.output_size().exec(dyn_map).unwrap() as u32;
+
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(inputs[0]), 0);
+        encoder.set_buffer(1, Some(inputs[1]), 0);
+        encoder.set_buffer(2, Some(output), 0);
+        encoder.set_bytes(
+            4,
+            std::mem::size_of::<u32>() as u64,
+            &n_elements as *const u32 as *const _,
+        );
+
+        let thread_group_size = MTLSize::new(256, 1, 1);
+        let thread_groups = MTLSize::new((n_elements as u64).div_ceil(256), 1, 1);
+        encoder.dispatch_thread_groups(thread_groups, thread_group_size);
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n = self.output_size().exec(dyn_map).unwrap_or(0);
+        2 * n * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        6 * self.output_size().exec(dyn_map).unwrap_or(0)
+    }
+}
+
+/// Fuses the decode-time gate and up GEMVs with the SwiGLU activation:
+/// `(lhs @ gate.T) * sigmoid(lhs @ gate.T) * (lhs @ up.T)`. Each SIMD group
+/// accumulates matching gate/up columns together, so the intermediate
+/// projection buffers and standalone SwiGLU kernel disappear from the decode
+/// MLP path.
+#[derive(Debug, Clone, Default)]
+pub struct MetalFusedSwiGLUGemv {
+    shape: Vec<Expression>,
+    m: Expression,
+    n: Expression,
+    k: Expression,
+    output_strides: Vec<Expression>,
+}
+
+impl MetalFusedSwiGLUGemv {
+    fn static_nk(&self) -> (Option<usize>, Option<usize>) {
+        let static_dims = FxHashMap::default();
+        (self.n.exec(&static_dims), self.k.exec(&static_dims))
+    }
+
+    fn cols_per_simdgroup(&self) -> usize {
+        let (static_n, static_k) = self.static_nk();
+        if matches!((static_n, static_k), (Some(8_192), Some(2_048))) {
+            2
+        } else if static_n.is_some_and(|n| n >= 32_768) || static_k.is_some_and(|k| k >= 8_192) {
+            8
+        } else {
+            4
+        }
+    }
+}
+
+impl EgglogOp for MetalFusedSwiGLUGemv {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "MetalFusedSwiGLUGemv",
+            &[
+                ("shape", ELIST),
+                ("m", EXPRESSION),
+                ("n", EXPRESSION),
+                ("k", EXPRESSION),
+                ("lhs", IR),
+                ("gate_rhs", IR),
+                ("up_rhs", IR),
+                ("out_strides", ELIST),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![Rule::raw(
+            r#"
+            (rule
+                (
+                    (= ?gate (MetalTransposedRhsGemv ?m ?n ?k ?lhs ?gate_rhs))
+                    (= ?up (MetalTransposedRhsGemv ?m ?n ?k ?lhs ?up_rhs))
+                    (= ?out (MetalSwiGLU ?shape ?gate ?up ?out_stride))
+                )
+                (
+                    (let ?fused (MetalFusedSwiGLUGemv ?shape ?m ?n ?k ?lhs ?gate_rhs ?up_rhs ?out_stride))
+                    (union ?out ?fused)
+                    (set (dtype ?fused) (F32))
+                )
+                :ruleset matmul_backend
+                :name "metal-fused-swiglu-gemv"
+            )
+
+            (rule
+                (
+                    (= ?out (MetalSwiGLU ?shape ?gate ?up ?out_stride))
+                    (= ?out (MetalFusedSwiGLUGemv ?shape ?m ?n ?k ?lhs ?gate_rhs ?up_rhs ?out_stride))
+                )
+                (
+                    (subsume (MetalSwiGLU ?shape ?gate ?up ?out_stride))
+                )
+                :ruleset cleanup
+                :name "metal-fused-swiglu-gemv-subsumes-standalone-swiglu"
+            )
+            "#,
+        )]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::{extract_expr, extract_expr_list};
+
+        (
+            LLIROp::new::<dyn MetalKernelOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, children[0], list_cache, expr_cache).unwrap(),
+                m: extract_expr(egraph, children[1], expr_cache).unwrap(),
+                n: extract_expr(egraph, children[2], expr_cache).unwrap(),
+                k: extract_expr(egraph, children[3], expr_cache).unwrap(),
+                output_strides: extract_expr_list(egraph, children[7], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            vec![children[4], children[5], children[6]],
+        )
+    }
+}
+
+impl MetalKernelOp for MetalFusedSwiGLUGemv {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "FusedSwiGLUGemv"
+    }
+
+    fn compile(
+        &self,
+        device: &Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<ComputePipelineState> {
+        assert_eq!(
+            input_dtypes.first().copied().unwrap_or(DType::F32),
+            DType::F32,
+            "MetalFusedSwiGLUGemv lhs must be F32"
+        );
+        assert_eq!(
+            input_dtypes.get(1).copied().unwrap_or(DType::F32),
+            DType::F32,
+            "MetalFusedSwiGLUGemv gate weights must be F32"
+        );
+        assert_eq!(
+            input_dtypes.get(2).copied().unwrap_or(DType::F32),
+            DType::F32,
+            "MetalFusedSwiGLUGemv up weights must be F32"
+        );
+        assert_eq!(
+            output_dtype,
+            DType::F32,
+            "MetalFusedSwiGLUGemv output must be F32"
+        );
+
+        let (static_n, static_k) = self.static_nk();
+        let accumulator_count = self.cols_per_simdgroup();
+        let out_index = lower_expression_for_metal(
+            &flatten_strides(&self.shape, &self.output_strides),
+            "elem_idx",
+        );
+        let sum_decls = (0..accumulator_count)
+            .flat_map(|j| {
+                [
+                    format!("            float gate_sum{j} = 0.0f;"),
+                    format!("            float up_sum{j} = 0.0f;"),
+                ]
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let dot_body = (0..accumulator_count)
+            .map(|j| {
+                format!(
+                    "                if (col_base + {j} < n) {{\n                    const uint rhs_offset{j} = (col_base + {j}) * k + i;\n                    gate_sum{j} += dot(float4(lhs_vec), load_rhs4(gate_rhs, rhs_offset{j}));\n                    up_sum{j} += dot(float4(lhs_vec), load_rhs4(up_rhs, rhs_offset{j}));\n                }}"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let tail_body = (0..accumulator_count)
+            .map(|j| {
+                format!(
+                    "                if (col_base + {j} < n) {{\n                    const uint rhs_offset{j} = (col_base + {j}) * k + i;\n                    gate_sum{j} += lhs_val * gate_rhs[rhs_offset{j}];\n                    up_sum{j} += lhs_val * up_rhs[rhs_offset{j}];\n                }}"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let reduce_body = (0..accumulator_count)
+            .flat_map(|j| {
+                [
+                    format!("            gate_sum{j} = simd_sum(gate_sum{j});"),
+                    format!("            up_sum{j} = simd_sum(up_sum{j});"),
+                ]
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let store_body = (0..accumulator_count)
+            .map(|j| {
+                format!(
+                    "                if (col_base + {j} < n) {{\n                    const float gate = gate_sum{j};\n                    const float sigmoid = 1.0f / (1.0f + fast::exp2(-gate * LOG2E));\n                    const uint elem_idx = row * n + col_base + {j};\n                    out[{out_index}] = gate * sigmoid * up_sum{j};\n                }}"
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n");
+        let function_name = match (static_n, static_k) {
+            (Some(n), Some(k)) => format!("swiglu_gemv_n{n}_k{k}"),
+            _ => "swiglu_gemv_dyn".to_string(),
+        };
+
+        let source = format!(
+            r#"
+            #include <metal_stdlib>
+            using namespace metal;
+
+            #define THREADS_PER_GROUP 128
+            #define SIMD_GROUP_SIZE 32
+            #define SIMD_GROUPS_PER_TG 4
+            #define COLS_PER_SIMDGROUP {accumulator_count}
+            #define COLS_PER_GROUP (SIMD_GROUPS_PER_TG * COLS_PER_SIMDGROUP)
+            #define LOG2E 1.4426950408889634f
+
+            inline float4 load_rhs4(const device float *rhs, uint offset) {{
+                const packed_float4 v = *(const device packed_float4 *)(rhs + offset);
+                return float4(v);
+            }}
+
+            kernel void {function_name}(
+                const device float *lhs [[buffer(0)]],
+                const device float *gate_rhs [[buffer(1)]],
+                const device float *up_rhs [[buffer(2)]],
+                device float *out [[buffer(3)]],
+                constant int *dyn [[buffer(4)]],
+                constant uint &m [[buffer(5)]],
+                constant uint &n [[buffer(6)]],
+                constant uint &k [[buffer(7)]],
+                uint2 gid [[threadgroup_position_in_grid]],
+                uint tid [[thread_index_in_threadgroup]],
+                uint lane [[thread_index_in_simdgroup]],
+                uint simd_group [[simdgroup_index_in_threadgroup]]
+            ) {{
+                (void)dyn;
+                (void)tid;
+
+                const uint row = gid.y;
+                const uint col_base = gid.x * COLS_PER_GROUP + simd_group * COLS_PER_SIMDGROUP;
+                if (row >= m) {{
+                    return;
+                }}
+
+                const uint lhs_base = row * k;
+{sum_decls}
+
+                const uint k4 = (k / 4) * 4;
+
+                for (uint i = lane * 4; i < k4; i += SIMD_GROUP_SIZE * 4) {{
+                    const packed_float4 lhs_vec = *(const device packed_float4 *)(lhs + lhs_base + i);
+{dot_body}
+                }}
+
+                for (uint i = k4 + lane; i < k; i += SIMD_GROUP_SIZE) {{
+                    const float lhs_val = lhs[lhs_base + i];
+{tail_body}
+                }}
+
+{reduce_body}
+
+                if (lane == 0) {{
+{store_body}
+                }}
+            }}
+            "#,
+            accumulator_count = accumulator_count,
+            function_name = function_name,
+            sum_decls = sum_decls,
+            dot_body = dot_body,
+            tail_body = tail_body,
+            reduce_body = reduce_body,
+            store_body = store_body,
+        );
+
+        Some(compile_shader(device, &source, &function_name))
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        DType::F32
+    }
+
+    fn output_size(&self) -> Expression {
+        self.shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &FxHashMap<char, usize>,
+    ) {
+        let m = self.m.exec(dyn_map).unwrap() as u32;
+        let n = self.n.exec(dyn_map).unwrap() as u32;
+        let k = self.k.exec(dyn_map).unwrap() as u32;
+
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(inputs[0]), 0);
+        encoder.set_buffer(1, Some(inputs[1]), 0);
+        encoder.set_buffer(2, Some(inputs[2]), 0);
+        encoder.set_buffer(3, Some(output), 0);
+        encoder.set_bytes(
+            5,
+            std::mem::size_of::<u32>() as u64,
+            &m as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            6,
+            std::mem::size_of::<u32>() as u64,
+            &n as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            7,
+            std::mem::size_of::<u32>() as u64,
+            &k as *const u32 as *const _,
+        );
+
+        let cols_per_group = if n == 8_192 && k == 2_048 {
+            8
+        } else if n >= 32_768 || k >= 8_192 {
+            32
+        } else {
+            16
+        };
+        let thread_group_size = MTLSize::new(128, 1, 1);
+        let thread_groups = MTLSize::new((n as u64).div_ceil(cols_per_group), m as u64, 1);
+        encoder.dispatch_thread_groups(thread_groups, thread_group_size);
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let m = self.m.exec(dyn_map).unwrap_or(0);
+        let n = self.n.exec(dyn_map).unwrap_or(0);
+        let k = self.k.exec(dyn_map).unwrap_or(0);
+        (m * k + 2 * n * k) * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let m = self.m.exec(dyn_map).unwrap_or(0);
+        let n = self.n.exec(dyn_map).unwrap_or(0);
+        let k = self.k.exec(dyn_map).unwrap_or(0);
+        4 * m * n * k + 6 * m * n
+    }
+
+    fn is_matmul(&self) -> bool {
+        true
+    }
+}

--- a/crates/luminal_metal/src/kernel/matmul.rs
+++ b/crates/luminal_metal/src/kernel/matmul.rs
@@ -1,5 +1,393 @@
+use luminal::{
+    egglog_utils::{
+        SerializedEGraph,
+        api::{Rule, SortDef, Term as EggTerm, app, eq, i64 as lit_i64, rule, sort, union, v},
+        base::{EXPRESSION, IR, SORTS, cons, dtype, ilist, iter, mul, nil, num, op_term},
+    },
+    op::*,
+    prelude::*,
+};
+use metal::{Buffer, ComputeCommandEncoderRef, ComputePipelineState, Device, MTLSize};
+
+use crate::kernel::{
+    MetalKernelOp,
+    ops::{MetalMul, MetalSumReduce, compile_shader},
+};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MPSMatrixLayout {
     RowMajor,
     TransposedRowMajor,
+}
+
+/// Specialized row-major lhs by transposed row-major rhs matmul for decode GEMV.
+/// Cleanup keeps this candidate only for single-row/decode buckets (m < 2);
+/// multi-row buckets prefer MPSMatmul.
+/// [m, k] x [n, k].T -> [m, n]
+/// out[i, j] = sum(lhs[i, t] * rhs[j, t], t in 0..k)
+#[derive(Debug, Default, Clone)]
+pub struct MetalTransposedRhsGemv {
+    m: Expression,
+    n: Expression,
+    k: Expression,
+}
+
+impl EgglogOp for MetalTransposedRhsGemv {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "MetalTransposedRhsGemv",
+            &[
+                ("m", EXPRESSION),
+                ("n", EXPRESSION),
+                ("k", EXPRESSION),
+                ("lhs", IR),
+                ("rhs", IR),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        let zero = num(lit_i64(0));
+        let z = iter();
+        let expr_list = |terms: Vec<EggTerm>| {
+            terms
+                .into_iter()
+                .rev()
+                .fold(nil(), |tail, head| cons(head, tail))
+        };
+
+        let m = v("?metal_transposed_rhs_gemv_m");
+        let n = v("?metal_transposed_rhs_gemv_n");
+        let k = v("?metal_transposed_rhs_gemv_k");
+        let lhs = v("?metal_transposed_rhs_gemv_lhs");
+        let rhs = v("?metal_transposed_rhs_gemv_rhs");
+        let out_row_stride = mul(n.clone(), z.clone());
+        let mul_op = op_term(
+            MetalMul::default().sort().call([
+                (
+                    "shape",
+                    cons(m.clone(), cons(n.clone(), cons(k.clone(), nil()))),
+                ),
+                (
+                    "a_strides",
+                    expr_list(vec![mul(k.clone(), z.clone()), zero.clone(), z.clone()]),
+                ),
+                (
+                    "b_strides",
+                    expr_list(vec![zero.clone(), mul(k.clone(), z.clone()), z.clone()]),
+                ),
+                (
+                    "out_strides",
+                    v("?metal_transposed_rhs_gemv_mul_output_strides"),
+                ),
+            ]),
+            ilist(vec![lhs.clone(), rhs.clone()]),
+        );
+        let sum_op = op_term(
+            MetalSumReduce::default().sort().call([
+                ("shape", cons(m.clone(), cons(n.clone(), nil()))),
+                ("iters", k.clone()),
+                ("strides", v("?metal_transposed_rhs_gemv_sum_input_strides")),
+                ("iter_stride", z.clone()),
+                (
+                    "out_strides",
+                    cons(out_row_stride.clone(), cons(z.clone(), nil())),
+                ),
+            ]),
+            ilist(vec![mul_op.clone()]),
+        );
+        let gemv_op = Self::default().sort().call([
+            ("m", m.clone()),
+            ("n", n.clone()),
+            ("k", k.clone()),
+            ("lhs", lhs.clone()),
+            ("rhs", rhs.clone()),
+        ]);
+
+        vec![
+            rule(union(sum_op.clone(), gemv_op.clone()))
+                .set(dtype(gemv_op), app(&SORTS.f32_dt, vec![]))
+                .fact(eq(app(&SORTS.f32_dt, vec![]), dtype(sum_op)))
+                .ruleset("matmul_backend")
+                .name("metal-transposed-rhs-gemv-row-transposed-rhs"),
+            // Materialize the row-count predicate so interval simplification can
+            // prove whether this is (m < 2) or multi-row.
+            Rule::raw(
+                "(rule
+                    ((= ?matmul (MetalTransposedRhsGemv ?m ?n ?k ?lhs ?rhs)))
+                    ((union (MGte ?m (MNum 2)) (MGte ?m (MNum 2))))
+                    :ruleset matmul_backend
+                    :name \"materialize-metal-transposed-rhs-gemv-row-count-check\"
+                )",
+            ),
+            // Once the fused GEMV exists, remove the decomposed broadcast
+            // multiply + sum that produced the same matmul.
+            Rule::raw(
+                "(rule
+                    ((= ?mul (Op (MetalMul ?shape ?as ?bs ?os) ?inputs))
+                     (= ?sum (Op (MetalSum ?sshape ?sk ?ssi ?sks ?sso) (ICons ?mul (INil))))
+                     (= ?sum (MetalTransposedRhsGemv ?m ?n ?k ?lhs ?rhs)))
+                    ((delete (Op (MetalSum ?sshape ?sk ?ssi ?sks ?sso) (ICons ?mul (INil))))
+                     (delete (Op (MetalMul ?shape ?as ?bs ?os) ?inputs)))
+                    :ruleset cleanup
+                    :name \"delete-broadcast-mul-sum-when-metal-transposed-rhs-gemv-exists\"
+                )",
+            ),
+            // Prefer the specialized transposed-RHS GEMV over the generic
+            // matmul fallback whenever both describe the same computation.
+            Rule::raw(
+                "(rule
+                    ((= ?matmul (GenericMatmul ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos))
+                     (= ?matmul (MetalTransposedRhsGemv ?m ?n ?k ?lhs ?rhs)))
+                    ((subsume (GenericMatmul ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos)))
+                    :ruleset cleanup
+                    :name \"metal-transposed-rhs-gemv-subsumes-generic-matmul\"
+                )",
+            ),
+            // For single-row/decode matmul, keep the custom GEMV candidate and
+            // remove the equivalent MPS matmul candidate.
+            Rule::raw(
+                "(rule
+                    ((= ?matmul (MetalTransposedRhsGemv ?m ?n ?k ?lhs ?rhs))
+                     (= ?matmul (MPSMatmul ?m ?n ?k ?lhs ?lhsrs ?rhs ?rhsrs ?ors ?tl ?tr))
+                     (= (MGte ?m (MNum 2)) (MNum 0)))
+                    ((subsume (MPSMatmul ?m ?n ?k ?lhs ?lhsrs ?rhs ?rhsrs ?ors ?tl ?tr)))
+                    :ruleset cleanup
+                    :name \"metal-transposed-rhs-gemv-subsumes-single-row-mps-matmul\"
+                )",
+            ),
+            // When this is not a single-row/decode matmul, remove the custom
+            // GEMV candidate and keep the MPS matmul candidate.
+            Rule::raw(
+                "(rule
+                    ((= ?matmul (MetalTransposedRhsGemv ?m ?n ?k ?lhs ?rhs))
+                     (= ?matmul (MPSMatmul ?m ?n ?k ?lhs ?lhsrs ?rhs ?rhsrs ?ors ?tl ?tr))
+                     (= (MGte ?m (MNum 2)) (MNum 1)))
+                    ((subsume (MetalTransposedRhsGemv ?m ?n ?k ?lhs ?rhs)))
+                    :ruleset cleanup
+                    :name \"mps-matmul-subsumes-multi-row-metal-transposed-rhs-gemv\"
+                )",
+            ),
+        ]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::extract_expr;
+        (
+            LLIROp::new::<dyn MetalKernelOp>(Box::new(Self {
+                m: extract_expr(egraph, kind_children[0], expr_cache).unwrap(),
+                n: extract_expr(egraph, kind_children[1], expr_cache).unwrap(),
+                k: extract_expr(egraph, kind_children[2], expr_cache).unwrap(),
+            })),
+            vec![kind_children[3], kind_children[4]],
+        )
+    }
+}
+
+impl MetalKernelOp for MetalTransposedRhsGemv {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "MetalTransposedRhsGemv"
+    }
+
+    fn compile(
+        &self,
+        device: &Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<ComputePipelineState> {
+        assert_eq!(
+            input_dtypes.first().copied().unwrap_or(DType::F32),
+            DType::F32,
+            "MetalTransposedRhsGemv lhs must be F32"
+        );
+        assert_eq!(
+            input_dtypes.get(1).copied().unwrap_or(DType::F32),
+            DType::F32,
+            "MetalTransposedRhsGemv rhs must be F32"
+        );
+        assert_eq!(
+            output_dtype,
+            DType::F32,
+            "MetalTransposedRhsGemv output must be F32"
+        );
+        let source = r#"
+        #include <metal_stdlib>
+        using namespace metal;
+
+        #define THREADS_PER_GROUP 64
+        #define SIMD_GROUP_SIZE 32
+        #define SIMD_GROUPS_PER_TG 2
+        #define COLS_PER_SIMDGROUP 4
+        #define COLS_PER_GROUP (SIMD_GROUPS_PER_TG * COLS_PER_SIMDGROUP)
+
+        kernel void gemv16_kernel(
+            const device float *lhs [[buffer(0)]],
+            const device float *rhs [[buffer(1)]],
+            device float *out [[buffer(2)]],
+            constant int *dyn [[buffer(3)]],
+            constant uint &m [[buffer(4)]],
+            constant uint &n [[buffer(5)]],
+            constant uint &k [[buffer(6)]],
+            uint2 gid [[threadgroup_position_in_grid]],
+            uint tid [[thread_index_in_threadgroup]],
+            uint lane [[thread_index_in_simdgroup]],
+            uint simd_group [[simdgroup_index_in_threadgroup]]
+        ) {
+            (void)dyn;
+            (void)tid;
+
+            const uint row = gid.y;
+            const uint col_base = gid.x * COLS_PER_GROUP + simd_group * COLS_PER_SIMDGROUP;
+            if (row >= m) {
+                return;
+            }
+
+            const uint lhs_base = row * k;
+            float sum0 = 0.0f;
+            float sum1 = 0.0f;
+            float sum2 = 0.0f;
+            float sum3 = 0.0f;
+
+            const uint k4 = (k / 4) * 4;
+
+            for (uint i = lane * 4; i < k4; i += SIMD_GROUP_SIZE * 4) {
+                const packed_float4 lhs_vec = *(const device packed_float4 *)(lhs + lhs_base + i);
+                if (col_base + 0 < n) {
+                    const packed_float4 rhs_vec = *(const device packed_float4 *)(rhs + (col_base + 0) * k + i);
+                    sum0 += dot(float4(lhs_vec), float4(rhs_vec));
+                }
+                if (col_base + 1 < n) {
+                    const packed_float4 rhs_vec = *(const device packed_float4 *)(rhs + (col_base + 1) * k + i);
+                    sum1 += dot(float4(lhs_vec), float4(rhs_vec));
+                }
+                if (col_base + 2 < n) {
+                    const packed_float4 rhs_vec = *(const device packed_float4 *)(rhs + (col_base + 2) * k + i);
+                    sum2 += dot(float4(lhs_vec), float4(rhs_vec));
+                }
+                if (col_base + 3 < n) {
+                    const packed_float4 rhs_vec = *(const device packed_float4 *)(rhs + (col_base + 3) * k + i);
+                    sum3 += dot(float4(lhs_vec), float4(rhs_vec));
+                }
+            }
+
+            for (uint i = k4 + lane; i < k; i += SIMD_GROUP_SIZE) {
+                const float lhs_val = lhs[lhs_base + i];
+                if (col_base + 0 < n) {
+                    sum0 += lhs_val * rhs[(col_base + 0) * k + i];
+                }
+                if (col_base + 1 < n) {
+                    sum1 += lhs_val * rhs[(col_base + 1) * k + i];
+                }
+                if (col_base + 2 < n) {
+                    sum2 += lhs_val * rhs[(col_base + 2) * k + i];
+                }
+                if (col_base + 3 < n) {
+                    sum3 += lhs_val * rhs[(col_base + 3) * k + i];
+                }
+            }
+
+            sum0 = simd_sum(sum0);
+            sum1 = simd_sum(sum1);
+            sum2 = simd_sum(sum2);
+            sum3 = simd_sum(sum3);
+
+            if (lane == 0) {
+                const uint out_base = row * n + col_base;
+                if (col_base + 0 < n) {
+                    out[out_base + 0] = sum0;
+                }
+                if (col_base + 1 < n) {
+                    out[out_base + 1] = sum1;
+                }
+                if (col_base + 2 < n) {
+                    out[out_base + 2] = sum2;
+                }
+                if (col_base + 3 < n) {
+                    out[out_base + 3] = sum3;
+                }
+            }
+        }
+        "#;
+        Some(compile_shader(device, source, "gemv16_kernel"))
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        DType::F32
+    }
+
+    fn output_size(&self) -> Expression {
+        (self.m * self.n).max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        encoder: &ComputeCommandEncoderRef,
+        pipeline: &ComputePipelineState,
+        inputs: &[&Buffer],
+        output: &Buffer,
+        dyn_map: &FxHashMap<char, usize>,
+    ) {
+        let m = self.m.exec(dyn_map).unwrap() as u32;
+        let n = self.n.exec(dyn_map).unwrap() as u32;
+        let k = self.k.exec(dyn_map).unwrap() as u32;
+
+        encoder.set_compute_pipeline_state(pipeline);
+        encoder.set_buffer(0, Some(inputs[0]), 0);
+        encoder.set_buffer(1, Some(inputs[1]), 0);
+        encoder.set_buffer(2, Some(output), 0);
+        encoder.set_bytes(
+            4,
+            std::mem::size_of::<u32>() as u64,
+            &m as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            5,
+            std::mem::size_of::<u32>() as u64,
+            &n as *const u32 as *const _,
+        );
+        encoder.set_bytes(
+            6,
+            std::mem::size_of::<u32>() as u64,
+            &k as *const u32 as *const _,
+        );
+
+        let thread_group_size = MTLSize::new(64, 1, 1);
+        let thread_groups = MTLSize::new((n as u64).div_ceil(8), m as u64, 1);
+        encoder.dispatch_thread_groups(thread_groups, thread_group_size);
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let m = self.m.exec(dyn_map).unwrap_or(0);
+        let n = self.n.exec(dyn_map).unwrap_or(0);
+        let k = self.k.exec(dyn_map).unwrap_or(0);
+        (m * k + n * k) * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let m = self.m.exec(dyn_map).unwrap_or(0);
+        let n = self.n.exec(dyn_map).unwrap_or(0);
+        let k = self.k.exec(dyn_map).unwrap_or(0);
+        2 * m * n * k
+    }
+
+    fn is_matmul(&self) -> bool {
+        true
+    }
 }

--- a/crates/luminal_metal/src/kernel/mod.rs
+++ b/crates/luminal_metal/src/kernel/mod.rs
@@ -1,5 +1,7 @@
+mod fusion;
 mod matmul;
-mod ops;
+pub(crate) mod ops;
+pub use fusion::*;
 pub use matmul::*;
 pub use ops::*;
 
@@ -166,6 +168,11 @@ pub trait MetalKernelOp: EgglogOp {
         dyn_map: &FxHashMap<char, usize>,
     );
 
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        ""
+    }
+
     #[allow(clippy::too_many_arguments)]
     fn encode(
         &self,
@@ -179,9 +186,17 @@ pub trait MetalKernelOp: EgglogOp {
     ) {
         let pipeline = pipeline.expect("compute pipeline not compiled");
         let encoder = context.command_buffer.new_compute_command_encoder();
+        #[cfg(feature = "debug")]
+        {
+            let label = self.label();
+            set_objc_label(encoder.as_ptr() as *mut Object, label);
+            push_debug_group(encoder.as_ptr() as *mut Object, label);
+        }
         let dyn_idx = inputs.len() as u64 + 1;
         encoder.set_buffer(dyn_idx, Some(context.dyn_buffer), 0);
         self.encode_compute(encoder, pipeline, inputs, output, dyn_map);
+        #[cfg(feature = "debug")]
+        pop_debug_group(encoder.as_ptr() as *mut Object, self.label());
         encoder.end_encoding();
     }
 
@@ -219,3 +234,37 @@ pub trait MetalKernelOp: EgglogOp {
 }
 
 luminal::impl_into_ops!(MetalKernelOp);
+
+#[cfg(feature = "debug")]
+pub(crate) fn set_objc_label(object: *mut Object, label: &str) {
+    if label.is_empty() {
+        return;
+    }
+    unsafe {
+        let s = std::ffi::CString::new(label).unwrap();
+        let ns: *mut Object = msg_send![class!(NSString), stringWithUTF8String: s.as_ptr()];
+        let _: () = msg_send![object, setLabel: ns];
+    }
+}
+
+#[cfg(feature = "debug")]
+pub(crate) fn push_debug_group(object: *mut Object, label: &str) {
+    if label.is_empty() {
+        return;
+    }
+    unsafe {
+        let s = std::ffi::CString::new(label).unwrap();
+        let ns: *mut Object = msg_send![class!(NSString), stringWithUTF8String: s.as_ptr()];
+        let _: () = msg_send![object, pushDebugGroup: ns];
+    }
+}
+
+#[cfg(feature = "debug")]
+pub(crate) fn pop_debug_group(object: *mut Object, label: &str) {
+    if label.is_empty() {
+        return;
+    }
+    unsafe {
+        let _: () = msg_send![object, popDebugGroup];
+    }
+}

--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -76,13 +76,11 @@ pub(crate) fn compile_shader(
     let function = library
         .get_function(function_name, None)
         .expect("Failed to get function from library");
-    let pipeline = device
+    device
         .new_compute_pipeline_state_with_function(&function)
         .unwrap_or_else(|err| {
             panic!("Failed to create Metal compute pipeline state for {function_name}: {err:?}\n{source}")
-        });
-
-    pipeline
+        })
 }
 
 fn lower_dynamic_consts(mut code: String) -> String {

--- a/crates/luminal_metal/src/kernel/ops.rs
+++ b/crates/luminal_metal/src/kernel/ops.rs
@@ -1,4 +1,9 @@
-use super::{MPSMatrixLayout, MetalEncodeContext, MetalKernelOp, MetalMulInfo, MetalSumReduceInfo};
+use super::{
+    MPSMatrixLayout, MetalEncodeContext, MetalKernelOp, MetalMulInfo, MetalSumReduceInfo,
+    MetalTransposedRhsGemv, fusion,
+};
+#[cfg(feature = "debug")]
+use super::{pop_debug_group, push_debug_group, set_objc_label};
 use luminal::{
     egglog_utils::{
         SerializedEGraph,
@@ -44,6 +49,8 @@ pub type MetalOps = (
     MPSMatmul,
     MPSBatchedMatmul,
     GenericMatmul,
+    MetalTransposedRhsGemv,
+    fusion::Ops,
     // Data ops
     MetalConstant,
     MetalIota,
@@ -54,7 +61,11 @@ pub type MetalOps = (
     MetalCast,
 );
 
-fn compile_shader(device: &Device, source: &str, function_name: &str) -> ComputePipelineState {
+pub(crate) fn compile_shader(
+    device: &Device,
+    source: &str,
+    function_name: &str,
+) -> ComputePipelineState {
     let options = metal::CompileOptions::new();
     options.set_language_version(MTLLanguageVersion::V2_4);
     let library = device
@@ -65,11 +76,13 @@ fn compile_shader(device: &Device, source: &str, function_name: &str) -> Compute
     let function = library
         .get_function(function_name, None)
         .expect("Failed to get function from library");
-    device
+    let pipeline = device
         .new_compute_pipeline_state_with_function(&function)
         .unwrap_or_else(|err| {
             panic!("Failed to create Metal compute pipeline state for {function_name}: {err:?}\n{source}")
-        })
+        });
+
+    pipeline
 }
 
 fn lower_dynamic_consts(mut code: String) -> String {
@@ -443,6 +456,11 @@ impl EgglogOp for MetalAdd {
 }
 
 impl MetalKernelOp for MetalAdd {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "Add"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -577,6 +595,11 @@ impl EgglogOp for MetalMul {
 }
 
 impl MetalKernelOp for MetalMul {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "Mul"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -719,6 +742,11 @@ impl EgglogOp for MetalMod {
 }
 
 impl MetalKernelOp for MetalMod {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "Mod"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -860,6 +888,11 @@ impl EgglogOp for MetalLessThan {
 }
 
 impl MetalKernelOp for MetalLessThan {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "LessThan"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -1011,6 +1044,11 @@ impl EgglogOp for MetalSumReduce {
 }
 
 impl MetalKernelOp for MetalSumReduce {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "SumReduce"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -1182,6 +1220,11 @@ impl EgglogOp for MetalMaxReduce {
 }
 
 impl MetalKernelOp for MetalMaxReduce {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "MaxReduce"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -1534,6 +1577,11 @@ impl MPSMatmul {
 }
 
 impl MetalKernelOp for MPSMatmul {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "MPSMatmul"
+    }
+
     fn compile(
         &self,
         _device: &Device,
@@ -1623,6 +1671,12 @@ impl MetalKernelOp for MPSMatmul {
         let out = Self::matrix(output, out_desc);
 
         unsafe {
+            #[cfg(feature = "debug")]
+            {
+                let label = self.label();
+                set_objc_label(kernel, label);
+                push_debug_group(context.command_buffer.as_ptr() as *mut Object, label);
+            }
             let _: () = msg_send![
                 kernel,
                 encodeToCommandBuffer: context.command_buffer.as_ptr()
@@ -1633,6 +1687,8 @@ impl MetalKernelOp for MPSMatmul {
             let _: () = msg_send![lhs, release];
             let _: () = msg_send![rhs, release];
             let _: () = msg_send![out, release];
+            #[cfg(feature = "debug")]
+            pop_debug_group(context.command_buffer.as_ptr() as *mut Object, self.label());
         }
     }
 
@@ -1907,6 +1963,11 @@ impl EgglogOp for MPSBatchedMatmul {
 }
 
 impl MetalKernelOp for MPSBatchedMatmul {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "MPSBatchedMatmul"
+    }
+
     fn compile(
         &self,
         _device: &Device,
@@ -1985,6 +2046,12 @@ impl MetalKernelOp for MPSBatchedMatmul {
         };
 
         unsafe {
+            #[cfg(feature = "debug")]
+            {
+                let label = self.label();
+                set_objc_label(kernel, label);
+                push_debug_group(context.command_buffer.as_ptr() as *mut Object, label);
+            }
             for batch_idx in 0..batch {
                 let batch_expr = Expression::from(batch_idx as i64);
                 let lhs_offset = self
@@ -2020,6 +2087,8 @@ impl MetalKernelOp for MPSBatchedMatmul {
                 let _: () = msg_send![rhs, release];
                 let _: () = msg_send![out, release];
             }
+            #[cfg(feature = "debug")]
+            pop_debug_group(context.command_buffer.as_ptr() as *mut Object, self.label());
         }
     }
 
@@ -2137,6 +2206,24 @@ impl EgglogOp for GenericMatmul {
                 .name("generic-matmul-metal-mul-sum"),
             Rule::raw(
                 "(rule
+                    ((= ?matmul (GenericMatmul ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos))
+                     (= ?matmul (MPSMatmul ?m ?n ?k ?lhs ?lhsrs ?rhs ?rhsrs ?ors ?tl ?tr)))
+                    ((union (MGte ?m (MNum 2)) (MGte ?m (MNum 2))))
+                    :ruleset matmul_backend
+                    :name \"materialize-mps-matmul-row-count-check\"
+                )",
+            ),
+            Rule::raw(
+                "(rule
+                    ((= ?matmul (GenericMatmul ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos))
+                     (= ?matmul (MPSBatchedMatmul ?b ?m ?n ?k ?lhs ?lhsbs ?lhsrs ?rhs ?rhsbs ?rhsrs ?obs ?ors ?tl ?tr)))
+                    ((union (MGte ?m (MNum 2)) (MGte ?m (MNum 2))))
+                    :ruleset matmul_backend
+                    :name \"materialize-mps-batched-matmul-row-count-check\"
+                )",
+            ),
+            Rule::raw(
+                "(rule
                     ((= ?mul (Op (MetalMul ?shape ?as ?bs ?os) ?inputs))
                      (= ?sum (Op (MetalSum ?sshape ?sk ?ssi ?sks ?sso) (ICons ?mul (INil))))
                      (= ?sum (GenericMatmul ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos)))
@@ -2144,6 +2231,26 @@ impl EgglogOp for GenericMatmul {
                      (delete (Op (MetalMul ?shape ?as ?bs ?os) ?inputs)))
                     :ruleset cleanup
                     :name \"delete-broadcast-mul-sum-when-generic-matmul-exists\"
+                )",
+            ),
+            Rule::raw(
+                "(rule
+                    ((= ?matmul (GenericMatmul ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos))
+                     (= ?matmul (MPSMatmul ?m ?n ?k ?lhs ?lhsrs ?rhs ?rhsrs ?ors ?tl ?tr))
+                     (= (MGte ?m (MNum 2)) (MNum 1)))
+                    ((subsume (GenericMatmul ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos)))
+                    :ruleset cleanup
+                    :name \"mps-matmul-subsumes-dynamic-generic-matmul\"
+                )",
+            ),
+            Rule::raw(
+                "(rule
+                    ((= ?matmul (GenericMatmul ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos))
+                     (= ?matmul (MPSBatchedMatmul ?b ?m ?n ?k ?lhs ?lhsbs ?lhsrs ?rhs ?rhsbs ?rhsrs ?obs ?ors ?tl ?tr))
+                     (= (MGte ?m (MNum 2)) (MNum 1)))
+                    ((subsume (GenericMatmul ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos)))
+                    :ruleset cleanup
+                    :name \"mps-batched-matmul-subsumes-dynamic-generic-matmul\"
                 )",
             ),
         ]
@@ -2190,6 +2297,11 @@ impl EgglogOp for GenericMatmul {
 }
 
 impl MetalKernelOp for GenericMatmul {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "GenericMatmul"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -2386,6 +2498,11 @@ impl EgglogOp for MetalConstant {
 }
 
 impl MetalKernelOp for MetalConstant {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "Constant"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -2496,6 +2613,11 @@ impl EgglogOp for MetalIota {
 }
 
 impl MetalKernelOp for MetalIota {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "Iota"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -2648,6 +2770,11 @@ impl EgglogOp for MetalGather {
 }
 
 impl MetalKernelOp for MetalGather {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "Gather"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -2873,6 +3000,11 @@ impl EgglogOp for MetalScatter {
 }
 
 impl MetalKernelOp for MetalScatter {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "Scatter"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -3185,6 +3317,11 @@ impl EgglogOp for MetalScatterNoCopy {
 }
 
 impl MetalKernelOp for MetalScatterNoCopy {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "ScatterNoCopy"
+    }
+
     fn compile(
         &self,
         device: &Device,
@@ -3358,6 +3495,11 @@ impl EgglogOp for MetalCast {
 }
 
 impl MetalKernelOp for MetalCast {
+    #[cfg(feature = "debug")]
+    fn label(&self) -> &'static str {
+        "Cast"
+    }
+
     fn compile(
         &self,
         device: &Device,

--- a/crates/luminal_metal/src/runtime.rs
+++ b/crates/luminal_metal/src/runtime.rs
@@ -46,6 +46,8 @@ pub struct MetalRuntime {
     input_data: FxHashMap<NodeIndex, NativeData>,
     /// Buffers for HLIR input tensors (set by user)
     pub hlir_buffers: FxHashMap<NodeIndex, Buffer>,
+    /// Logical byte length for each HLIR input buffer.
+    hlir_buffer_lengths: FxHashMap<NodeIndex, u64>,
     /// Buffers for LLIR intermediate/output tensors
     pub buffers: FxHashMap<NodeIndex, Buffer>,
     /// Logical byte length for each active LLIR buffer.
@@ -204,6 +206,7 @@ impl MetalRuntime {
             {
                 let buffer = self.buffer_from_safetensor(&tensor, input.dtype);
                 self.input_data.remove(&node);
+                self.hlir_buffer_lengths.insert(node, buffer.length());
                 self.hlir_buffers.insert(node, buffer);
             }
         }
@@ -213,8 +216,7 @@ impl MetalRuntime {
         let id = id.to_id();
         let data = data.into();
         if let Some(dtype) = self.input_dtype(id) {
-            let buffer = self.create_input_buffer(&data, dtype);
-            self.hlir_buffers.insert(id, buffer);
+            self.update_input_buffer_from_native(id, &data, dtype);
         }
         self.input_data.insert(id, data);
     }
@@ -228,6 +230,7 @@ impl MetalRuntime {
             std::ptr::write_bytes(buffer.contents(), 0, num_bytes);
         }
         self.input_data.remove(&id);
+        self.hlir_buffer_lengths.insert(id, num_bytes as u64);
         self.hlir_buffers.insert(id, buffer);
     }
 
@@ -240,6 +243,7 @@ impl MetalRuntime {
         }
 
         if let Some(Input { node, .. }) = self.llir_graph[data_id].to_op::<Input>() {
+            self.hlir_buffer_lengths.remove(&NodeIndex::new(*node));
             return self
                 .hlir_buffers
                 .remove(&NodeIndex::new(*node))
@@ -252,6 +256,7 @@ impl MetalRuntime {
     pub fn set_buffer(&mut self, id: impl ToId, buffer: Buffer) {
         let id = id.to_id();
         self.input_data.remove(&id);
+        self.hlir_buffer_lengths.insert(id, buffer.length());
         self.hlir_buffers.insert(id, buffer);
     }
 
@@ -284,6 +289,13 @@ impl MetalRuntime {
             .buffer_lengths
             .get(&data_id)
             .copied()
+            .or_else(|| {
+                self.llir_graph[data_id].to_op::<Input>().and_then(|inp| {
+                    self.hlir_buffer_lengths
+                        .get(&NodeIndex::new(inp.node))
+                        .copied()
+                })
+            })
             .unwrap_or_else(|| buffer.length());
         assert!(
             logical_bytes <= buffer.length(),
@@ -357,6 +369,7 @@ impl Runtime for MetalRuntime {
             command_queue,
             input_data: FxHashMap::default(),
             hlir_buffers: FxHashMap::default(),
+            hlir_buffer_lengths: FxHashMap::default(),
             buffers: FxHashMap::default(),
             buffer_lengths: FxHashMap::default(),
             dyn_buffer,
@@ -532,34 +545,76 @@ impl RuntimeStats for MetalRuntime {
 }
 
 impl MetalRuntime {
-    fn create_input_buffer(&self, data: &NativeData, dtype: DType) -> Buffer {
+    fn update_input_buffer_from_native(&mut self, id: impl ToId, data: &NativeData, dtype: DType) {
         match dtype {
             DType::F32 => {
-                let values = data.to_f32_vec();
-                self.device.new_buffer_with_data(
-                    values.as_ptr() as *const _,
-                    std::mem::size_of_val(values.as_slice()) as u64,
-                    MTLResourceOptions::StorageModeShared,
-                )
+                if let NativeData::F32(values) = data {
+                    self.update_input_buffer(id, DType::F32, values);
+                } else {
+                    let values = data.to_f32_vec();
+                    self.update_input_buffer(id, DType::F32, &values);
+                }
             }
             DType::F16 => {
-                let values = data.to_f16_vec();
-                self.device.new_buffer_with_data(
-                    values.as_ptr() as *const _,
-                    std::mem::size_of_val(values.as_slice()) as u64,
-                    MTLResourceOptions::StorageModeShared,
-                )
+                if let NativeData::F16(values) = data {
+                    self.update_input_buffer(id, DType::F16, values);
+                } else {
+                    let values = data.to_f16_vec();
+                    self.update_input_buffer(id, DType::F16, &values);
+                }
             }
             DType::Int => {
-                let values = data.to_i32_vec();
-                self.device.new_buffer_with_data(
-                    values.as_ptr() as *const _,
-                    std::mem::size_of_val(values.as_slice()) as u64,
-                    MTLResourceOptions::StorageModeShared,
-                )
+                if let NativeData::Int(values) = data {
+                    self.update_input_buffer(id, DType::Int, values);
+                } else {
+                    let values = data.to_i32_vec();
+                    self.update_input_buffer(id, DType::Int, &values);
+                }
             }
             unsupported => panic!("Metal input dtype {unsupported:?} is not supported yet"),
         }
+    }
+
+    fn update_input_buffer<T: Copy>(&mut self, id: impl ToId, expected_dtype: DType, values: &[T]) {
+        let id = id.to_id();
+        if let Some(dtype) = self.input_dtype(id) {
+            assert_eq!(
+                dtype, expected_dtype,
+                "Cannot update Metal input {id:?} as {expected_dtype:?}; graph input has dtype {dtype:?}"
+            );
+        }
+
+        let byte_len = std::mem::size_of_val(values) as u64;
+        let needs_buffer = self
+            .hlir_buffers
+            .get(&id)
+            .is_none_or(|buffer| byte_len > buffer.length());
+        if needs_buffer {
+            let capacity = byte_len.max(1);
+            let buffer = self
+                .device
+                .new_buffer(capacity, MTLResourceOptions::StorageModeShared);
+            if byte_len > 0 {
+                unsafe {
+                    std::ptr::copy_nonoverlapping(
+                        values.as_ptr() as *const u8,
+                        buffer.contents() as *mut u8,
+                        byte_len as usize,
+                    );
+                }
+            }
+            self.hlir_buffers.insert(id, buffer);
+        } else if byte_len > 0 {
+            let buffer = self.hlir_buffers.get(&id).expect("Input buffer not set!");
+            unsafe {
+                std::ptr::copy_nonoverlapping(
+                    values.as_ptr() as *const u8,
+                    buffer.contents() as *mut u8,
+                    byte_len as usize,
+                );
+            }
+        }
+        self.hlir_buffer_lengths.insert(id, byte_len);
     }
 
     pub fn allocate_intermediate_buffers(&mut self, dyn_map: &FxHashMap<char, usize>) {
@@ -739,13 +794,19 @@ impl MetalRuntime {
     }
 
     fn refresh_input_data_buffers(&mut self) {
-        for node in self.llir_graph.node_indices() {
-            if let Some(input) = self.llir_graph[node].to_op::<Input>() {
-                let hlir_id = NodeIndex::new(input.node);
-                if let Some(data) = self.input_data.get(&hlir_id) {
-                    let buffer = self.create_input_buffer(data, input.dtype);
-                    self.hlir_buffers.insert(hlir_id, buffer);
-                }
+        let inputs = self
+            .llir_graph
+            .node_indices()
+            .filter_map(|node| {
+                self.llir_graph[node]
+                    .to_op::<Input>()
+                    .map(|input| (NodeIndex::new(input.node), input.dtype))
+            })
+            .collect::<Vec<_>>();
+
+        for (hlir_id, dtype) in inputs {
+            if let Some(data) = self.input_data.get(&hlir_id).cloned() {
+                self.update_input_buffer_from_native(hlir_id, &data, dtype);
             }
         }
     }

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -61,10 +61,6 @@ fn assert_matmul_options(cx: &Graph, mps_op_name: &str) {
         egraph_has_op(cx, mps_op_name),
         "expected {mps_op_name} rewrite option in e-graph"
     );
-    assert!(
-        egraph_has_op(cx, "GenericMatmul"),
-        "expected GenericMatmul rewrite option in e-graph"
-    );
 }
 
 fn write_test_safetensors(tensors: &[(&str, Dtype, Vec<usize>, Vec<u8>)]) -> PathBuf {
@@ -342,6 +338,33 @@ fn metal_bucketed_dynamic_dim_dispatches_correct_graph() {
     rt.execute(&cx.dyn_map);
     let s3_out = rt.get_f32(output);
     assert_close(&s3_out[..12], &s3_expected, 0.001);
+}
+
+#[test]
+fn metal_set_data_reuses_input_buffer_and_preserves_logical_len() {
+    let mut cx = Graph::default();
+    let input = cx.tensor(('s',));
+    let output = input.output();
+
+    cx.set_dim('s', 8);
+    cx.build_search_space::<MetalRuntime>(
+        CompileOptions::default().dim_buckets('s', &[DimBucket::new(1, 8)]),
+    );
+
+    let mut rt = MetalRuntime::initialize(());
+    rt.set_data(input, vec![0.0f32; 8]);
+    rt = cx.search(rt, CompileOptions::new(1));
+    let initial_capacity = rt.hlir_buffers.get(&input.id).unwrap().length();
+
+    cx.set_dim('s', 2);
+    rt.set_data(input, &[3.0f32, 4.0]);
+    assert_eq!(
+        rt.hlir_buffers.get(&input.id).unwrap().length(),
+        initial_capacity
+    );
+
+    rt.execute(&cx.dyn_map);
+    assert_eq!(rt.get_f32(output), vec![3.0, 4.0]);
 }
 
 #[test]

--- a/crates/luminal_metal/src/tests.rs
+++ b/crates/luminal_metal/src/tests.rs
@@ -353,7 +353,7 @@ fn metal_set_data_reuses_input_buffer_and_preserves_logical_len() {
 
     let mut rt = MetalRuntime::initialize(());
     rt.set_data(input, vec![0.0f32; 8]);
-    rt = cx.search(rt, CompileOptions::new(1));
+    rt = cx.search(rt, CompileOptions::default().search_graph_limit(1));
     let initial_capacity = rt.hlir_buffers.get(&input.id).unwrap().length();
 
     cx.set_dim('s', 2);


### PR DESCRIPTION
Optimize Llama inference on Metal with fused kernels and decode-time buffer reuse,
the previous Llama path decomposed RMSNorm, RoPE, attention, SwiGLU, and decode GEMVs into many small kernels and intermediate tensors. That is expensive during autoregressive decode, where the model repeatedly executes single-token steps. These new fused kernels let extraction select direct Metal implementations for the recognized Llama patterns, reducing memory traffic and dispatch overhead. which will put it on par with lama.cpp running on f32 model 

- Updated the` llama_1b` example to:
Compute logits only for the final query token.
Size KV caches to the prompt/generation context instead of always using MAX_SEQ_LEN.
Use a last_idx input for final-token selection.
Reduce per-step input allocation churn.
Better exercise prefill and decode shape buckets.

- `MetalRuntime`: 
Updated input handling to reuse existing HLIR input buffers when new data fits in the current allocation, while tracking logical byte lengths separately from buffer capacity, this we significantly decrease the number of buffer alloc and dealloc per step  


- `matmul`:
Updated rewrite cleanup so:
MPS matmul is preferred for multi-row cases.
The custom GEMV is preferred for single-row decode cases.
Generic matmul candidates are subsumed once better Metal candidates are available.


- Added `MetalTransposedRhsGemv`, a custom transposed-RHS GEMV path for single-row decode matmuls.


- Added a new Metal fusion module with specialized kernels for:
Llama RoPE in both flattened and [heads, seq, head_dim] layouts.
RoPE + KV-cache scatter for K-cache updates.
Post-RoPE paged attention, including a decode-specific path for seq == 1.
RMSNorm.
SwiGLU.
Decode-time fused SwiGLU GEMV for gate/up projections.

last thing i added was an optional debug feature support for Metal labels/debug groups. which can be enabled for profiling/debugging 