### PR TITLE
add WebGPU runtime and llama example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,7 @@ members = [
     "crates/luminal_nn",
     "crates/luminal_cuda_lite",
     "crates/luminal_metal",
+    "crates/luminal_webgpu",
     "crates/luminal_tracing",
     "crates/luminal_bench",
     "crates/luminal_python/rust",

--- a/crates/luminal_webgpu/Cargo.toml
+++ b/crates/luminal_webgpu/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "luminal_webgpu"
+version = "0.2.0"
+edition = "2024"
+description = "WebGPU backend for luminal"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+luminal = { path = "../.." }
+itertools = "0.12.1"
+half = { version = "2.7.1", features = ["bytemuck"] }
+tracing = "0.1.43"
+safetensors = "0.7.0"
+memmap2 = "0.9.9"
+bytemuck = "1.24.0"
+pollster = "0.3"
+wgpu = "0.19"
+
+[dev-dependencies]
+hf-hub = { version = "0.4", default-features = false, features = ["rustls-tls", "ureq"] }
+luminal_nn = { path = "../luminal_nn" }
+luminal_tracing = { path = "../luminal_tracing" }
+rustc-hash = "2.1"
+tokenizers = "0.22.2"
+tracing-subscriber = "0.3"

--- a/crates/luminal_webgpu/examples/llama_1b.rs
+++ b/crates/luminal_webgpu/examples/llama_1b.rs
@@ -503,7 +503,13 @@ fn main() -> Result<(), Box<dyn Error>> {
     runtime.set_data(scatter_idx_t, (0..search_s as i32).collect::<Vec<_>>());
     runtime.set_data(gather_idx_t, (0..search_c as i32).collect::<Vec<_>>());
     runtime.set_data(attn_mask_t, vec![0.0f32; search_s * search_c]);
-    runtime = cx.search(runtime, CompileOptions::new(SEARCH_GRAPHS));
+    runtime = cx.search(
+        runtime,
+        CompileOptions {
+            limit: SEARCH_GRAPHS,
+            ..CompileOptions::default()
+        },
+    );
     println!(
         "  Search/compile: {:.2} s",
         compile_start.elapsed().as_secs_f64()

--- a/crates/luminal_webgpu/examples/llama_1b.rs
+++ b/crates/luminal_webgpu/examples/llama_1b.rs
@@ -1,0 +1,641 @@
+use hf_hub::api::sync::Api;
+use luminal::{
+    dtype::DType,
+    graph::{CompileOptions, DimBucket, Graph},
+    prelude::{F32Pow, GraphTensor, Runtime},
+};
+use luminal_nn::{LayerNorm, gather_rows, scatter_rows};
+use luminal_tracing::luminal_filter;
+use luminal_webgpu::WebGpuRuntime;
+use rustc_hash::FxHashSet;
+use std::{
+    error::Error,
+    io::Write,
+    path::PathBuf,
+    time::{Duration, Instant},
+};
+use tokenizers::Tokenizer;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+const REPO_ID: &str = "unsloth/Llama-3.2-1B-Instruct";
+const MAX_SEQ_LEN: usize = 2048;
+const GEN_TOKENS: usize = 96;
+const SEARCH_GRAPHS: usize = 100;
+const SEARCH_MEMORY_MIB: usize = 1536;
+const PROMPT: &str = "In one short paragraph, explain neural networks using the words layers, neurons, learning, and data.";
+
+const LAYERS: usize = 16;
+const HIDDEN: usize = 2048;
+const INTERMEDIATE: usize = 8192;
+const HEAD_DIM: usize = 64;
+const N_HEADS: usize = 32;
+const N_KV_HEADS: usize = 8;
+const KV_GROUPS: usize = N_HEADS / N_KV_HEADS;
+const KV_DIM: usize = N_KV_HEADS * HEAD_DIM;
+const VOCAB_SIZE: usize = 128256;
+const RMS_NORM_EPS: f32 = 1e-5;
+const ROPE_THETA: f32 = 500_000.0;
+const EOS_TOKEN: u32 = 128009;
+const STOP_TOKEN: u32 = 128001;
+
+fn prepare_hf_model() -> Result<PathBuf, Box<dyn Error>> {
+    let repo = Api::new()?.model(REPO_ID.to_string());
+    let tokenizer_path = repo.get("tokenizer.json")?;
+    repo.get("model.safetensors")?;
+    Ok(tokenizer_path.parent().unwrap().to_path_buf())
+}
+
+fn llama3_chat_prompt(user_prompt: &str) -> String {
+    format!(
+        "<|begin_of_text|><|start_header_id|>user<|end_header_id|>\n\n{user_prompt}<|eot_id|><|start_header_id|>assistant<|end_header_id|>\n\n"
+    )
+}
+
+#[derive(Default, Clone)]
+struct StepProfile {
+    total: Duration,
+    execute: Duration,
+    get_logits: Duration,
+    cache_roundtrip: Duration,
+}
+
+fn avg_ms(duration: Duration, n: usize) -> f64 {
+    if n == 0 {
+        0.0
+    } else {
+        duration.as_secs_f64() * 1e3 / n as f64
+    }
+}
+
+fn sample_greedy(logits_row: &[f32], seen: &FxHashSet<u32>, repetition_penalty: f32) -> u32 {
+    let mut row = logits_row.to_vec();
+    for &tok in seen {
+        let logit = &mut row[tok as usize];
+        if *logit > 0.0 {
+            *logit /= repetition_penalty;
+        } else {
+            *logit *= repetition_penalty;
+        }
+    }
+    row.iter()
+        .enumerate()
+        .max_by(|(_, a), (_, b)| a.total_cmp(b))
+        .unwrap()
+        .0 as u32
+}
+
+fn causal_mask(q_pos: &[usize], context_len: usize) -> Vec<f32> {
+    let mut mask = vec![-1e10f32; q_pos.len() * context_len];
+    for (qi, &pos) in q_pos.iter().enumerate() {
+        for ci in 0..context_len {
+            if ci <= pos {
+                mask[qi * context_len + ci] = 0.0;
+            }
+        }
+    }
+    mask
+}
+
+struct KVCache {
+    k_caches: Vec<GraphTensor>,
+    v_caches: Vec<GraphTensor>,
+}
+
+impl KVCache {
+    fn new(cx: &mut Graph, num_slots: usize) -> Self {
+        let mut k_caches = Vec::with_capacity(LAYERS);
+        let mut v_caches = Vec::with_capacity(LAYERS);
+        for l in 0..LAYERS {
+            k_caches.push(
+                cx.named_tensor(format!("kv_cache.{l}.k"), (num_slots, KV_DIM))
+                    .persist(),
+            );
+            v_caches.push(
+                cx.named_tensor(format!("kv_cache.{l}.v"), (num_slots, KV_DIM))
+                    .persist(),
+            );
+        }
+        Self { k_caches, v_caches }
+    }
+}
+
+struct Llama {
+    embedding: GraphTensor,
+    layers: Vec<LlamaLayer>,
+    lm_norm: LayerNorm,
+}
+
+impl Llama {
+    fn init(cx: &mut Graph) -> Self {
+        let mut layers = Vec::with_capacity(LAYERS);
+        for l in 0..LAYERS {
+            layers.push(LlamaLayer {
+                up: cx
+                    .named_tensor(
+                        format!("model.layers.{l}.mlp.up_proj.weight"),
+                        (INTERMEDIATE, HIDDEN),
+                    )
+                    .persist(),
+                gate: cx
+                    .named_tensor(
+                        format!("model.layers.{l}.mlp.gate_proj.weight"),
+                        (INTERMEDIATE, HIDDEN),
+                    )
+                    .persist(),
+                down: cx
+                    .named_tensor(
+                        format!("model.layers.{l}.mlp.down_proj.weight"),
+                        (HIDDEN, INTERMEDIATE),
+                    )
+                    .persist(),
+                q_proj: cx
+                    .named_tensor(
+                        format!("model.layers.{l}.self_attn.q_proj.weight"),
+                        (HIDDEN, HIDDEN),
+                    )
+                    .persist(),
+                k_proj: cx
+                    .named_tensor(
+                        format!("model.layers.{l}.self_attn.k_proj.weight"),
+                        (KV_DIM, HIDDEN),
+                    )
+                    .persist(),
+                v_proj: cx
+                    .named_tensor(
+                        format!("model.layers.{l}.self_attn.v_proj.weight"),
+                        (KV_DIM, HIDDEN),
+                    )
+                    .persist(),
+                o_proj: cx
+                    .named_tensor(
+                        format!("model.layers.{l}.self_attn.o_proj.weight"),
+                        (HIDDEN, HIDDEN),
+                    )
+                    .persist(),
+                attn_rms: LayerNorm::new(
+                    HIDDEN,
+                    Some(&format!("model.layers.{l}.input_layernorm.weight")),
+                    None,
+                    false,
+                    RMS_NORM_EPS,
+                    cx,
+                ),
+                mlp_rms: LayerNorm::new(
+                    HIDDEN,
+                    Some(&format!("model.layers.{l}.post_attention_layernorm.weight")),
+                    None,
+                    false,
+                    RMS_NORM_EPS,
+                    cx,
+                ),
+            });
+        }
+
+        Self {
+            embedding: cx
+                .named_tensor("model.embed_tokens.weight", (VOCAB_SIZE, HIDDEN))
+                .persist(),
+            layers,
+            lm_norm: LayerNorm::new(
+                HIDDEN,
+                Some("model.norm.weight"),
+                None,
+                false,
+                RMS_NORM_EPS,
+                cx,
+            ),
+        }
+    }
+
+    fn forward(
+        &self,
+        input: GraphTensor,
+        q_pos: GraphTensor,
+        scatter_idx: GraphTensor,
+        gather_idx: GraphTensor,
+        attn_mask: GraphTensor,
+        kv_cache: &KVCache,
+    ) -> (GraphTensor, Vec<(GraphTensor, GraphTensor)>) {
+        let seq = input.dims1();
+        let mut x = self.embedding.gather(
+            (input * HIDDEN).expand_dim(1, HIDDEN)
+                + input.graph().arange(HIDDEN).expand_dim(0, seq),
+        );
+        let mut cache_outputs = Vec::with_capacity(LAYERS);
+        for (i, layer) in self.layers.iter().enumerate() {
+            let (x_new, k_out, v_out) = layer.forward(
+                x,
+                q_pos,
+                scatter_idx,
+                gather_idx,
+                attn_mask,
+                kv_cache.k_caches[i],
+                kv_cache.v_caches[i],
+            );
+            x = x_new;
+            cache_outputs.push((k_out, v_out));
+        }
+
+        let logits = self.lm_norm.forward(x).matmul(self.embedding.t());
+        (logits, cache_outputs)
+    }
+}
+
+struct LlamaLayer {
+    up: GraphTensor,
+    gate: GraphTensor,
+    down: GraphTensor,
+    q_proj: GraphTensor,
+    k_proj: GraphTensor,
+    v_proj: GraphTensor,
+    o_proj: GraphTensor,
+    attn_rms: LayerNorm,
+    mlp_rms: LayerNorm,
+}
+
+fn llama_rotary_embeddings(mut input: GraphTensor, pos_ids: GraphTensor) -> GraphTensor {
+    input = input.split_dims(1, HEAD_DIM).transpose(0, 1);
+
+    let freqs = input
+        .graph()
+        .arange_options(0, HEAD_DIM, 2)
+        .cast(DType::F32)
+        / HEAD_DIM as f32;
+    let inv_freqs = ROPE_THETA.pow(freqs).reciprocal();
+    let emb = pos_ids
+        .cast(DType::F32)
+        .expand_dim(1, 1)
+        .matmul(inv_freqs.expand_dim(0, 1));
+
+    let x0 = input.slice((.., .., ..HEAD_DIM / 2));
+    let x1 = input.slice((.., .., HEAD_DIM / 2..));
+
+    let cos = emb.cos().expand_dim(0, x0.dims()[0]);
+    let sin = emb.sin().expand_dim(0, x0.dims()[0]);
+    let x0_out = x0 * cos - x1 * sin;
+    let x1_out = x1 * cos + x0 * sin;
+
+    x0_out
+        .concat_along(x1_out, 2)
+        .transpose(0, 1)
+        .merge_dims(1, 2)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn attention(
+    q_rope: GraphTensor,
+    k_rope: GraphTensor,
+    v: GraphTensor,
+    k_cache: GraphTensor,
+    v_cache: GraphTensor,
+    scatter_idx: GraphTensor,
+    gather_idx: GraphTensor,
+    attn_mask: GraphTensor,
+) -> (GraphTensor, GraphTensor, GraphTensor) {
+    let k_cache_out = scatter_rows(k_rope, scatter_idx, k_cache, KV_DIM);
+    let v_cache_out = scatter_rows(v, scatter_idx, v_cache, KV_DIM);
+
+    let k = gather_rows(k_cache_out, gather_idx, KV_DIM);
+    let v_ctx = gather_rows(v_cache_out, gather_idx, KV_DIM);
+
+    let q = (q_rope * 1.0).split_dims(1, HEAD_DIM).transpose(0, 1);
+    let k = k.split_dims(1, HEAD_DIM).permute((1, 2, 0));
+    let v_ctx = v_ctx.split_dims(1, HEAD_DIM).transpose(0, 1);
+
+    let k = k.expand_dim(1, KV_GROUPS).merge_dims(0, 1) * 1.0;
+    let v_ctx = v_ctx.expand_dim(1, KV_GROUPS).merge_dims(0, 1) * 1.0;
+
+    let scores = q.matmul(k) / (HEAD_DIM as f32).sqrt();
+    let masked_scores = scores + attn_mask.expand_dim(0, N_HEADS);
+    let weights = masked_scores.softmax(2);
+    let out = weights.matmul(v_ctx);
+    let attn_out = out.transpose(0, 1).merge_dims(1, 2);
+
+    (attn_out, k_cache_out, v_cache_out)
+}
+
+impl LlamaLayer {
+    #[allow(clippy::too_many_arguments)]
+    fn forward(
+        &self,
+        mut x: GraphTensor,
+        q_pos: GraphTensor,
+        scatter_idx: GraphTensor,
+        gather_idx: GraphTensor,
+        attn_mask: GraphTensor,
+        k_cache: GraphTensor,
+        v_cache: GraphTensor,
+    ) -> (GraphTensor, GraphTensor, GraphTensor) {
+        let x_attn = self.attn_rms.forward(x);
+        let q = x_attn.matmul(self.q_proj.t());
+        let k = x_attn.matmul(self.k_proj.t());
+        let v = x_attn.matmul(self.v_proj.t());
+
+        let q_rope = llama_rotary_embeddings(q, q_pos);
+        let k_rope = llama_rotary_embeddings(k, q_pos);
+        let (attn_out, k_cache_out, v_cache_out) = attention(
+            q_rope,
+            k_rope,
+            v,
+            k_cache,
+            v_cache,
+            scatter_idx,
+            gather_idx,
+            attn_mask,
+        );
+        x += attn_out.matmul(self.o_proj.t());
+
+        let x_mlp = self.mlp_rms.forward(x);
+        let mlp_out =
+            (x_mlp.matmul(self.gate.t()).swish() * x_mlp.matmul(self.up.t())).matmul(self.down.t());
+        (x + mlp_out, k_cache_out, v_cache_out)
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn run_model_step(
+    cx: &mut Graph,
+    runtime: &mut WebGpuRuntime,
+    input: GraphTensor,
+    q_pos_t: GraphTensor,
+    scatter_idx_t: GraphTensor,
+    gather_idx_t: GraphTensor,
+    attn_mask_t: GraphTensor,
+    logits: GraphTensor,
+    kv_cache: &KVCache,
+    cache_outputs: &[(GraphTensor, GraphTensor)],
+    tokens: &[u32],
+    q_pos: &[i32],
+    scatter_idx: &[i32],
+    gather_idx: &[i32],
+    attn_mask: &[f32],
+) -> (Vec<f32>, StepProfile) {
+    let start = Instant::now();
+    cx.set_dim('s', tokens.len());
+    cx.set_dim('c', gather_idx.len());
+
+    runtime.set_data(input, tokens.iter().map(|t| *t as i32).collect::<Vec<_>>());
+    runtime.set_data(q_pos_t, q_pos.to_vec());
+    runtime.set_data(scatter_idx_t, scatter_idx.to_vec());
+    runtime.set_data(gather_idx_t, gather_idx.to_vec());
+    runtime.set_data(attn_mask_t, attn_mask.to_vec());
+    runtime.allocate_intermediate_buffers(&cx.dyn_map);
+
+    let execute_start = Instant::now();
+    runtime.execute(&cx.dyn_map);
+    let execute = execute_start.elapsed();
+
+    let logits_start = Instant::now();
+    let logits_data = runtime.get_f32(logits);
+    let get_logits = logits_start.elapsed();
+
+    let cache_start = Instant::now();
+    for (layer_idx, (k_out, v_out)) in cache_outputs.iter().enumerate() {
+        let k_buf = runtime.remove_buffer(*k_out);
+        let v_buf = runtime.remove_buffer(*v_out);
+        runtime.set_buffer(kv_cache.k_caches[layer_idx], k_buf);
+        runtime.set_buffer(kv_cache.v_caches[layer_idx], v_buf);
+    }
+    let cache_roundtrip = cache_start.elapsed();
+
+    (
+        logits_data,
+        StepProfile {
+            total: start.elapsed(),
+            execute,
+            get_logits,
+            cache_roundtrip,
+        },
+    )
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let _ = tracing_subscriber::registry()
+        .with(tracing_subscriber::fmt::layer())
+        .with(luminal_filter())
+        .try_init();
+
+    let model_dir = prepare_hf_model()?;
+    println!("Using model directory: {}", model_dir.display());
+
+    let tokenizer = Tokenizer::from_file(model_dir.join("tokenizer.json"))
+        .map_err(|err| err as Box<dyn Error>)?;
+    let prompt_tokens = tokenizer
+        .encode(llama3_chat_prompt(PROMPT), false)
+        .map_err(|err| err as Box<dyn Error>)?
+        .get_ids()
+        .to_vec();
+
+    let mut cx = Graph::default();
+    let input = cx.named_tensor("input", 's').as_dtype(DType::Int);
+    let q_pos_t = cx.named_tensor("q_pos", 's').as_dtype(DType::Int);
+    let scatter_idx_t = cx.named_tensor("scatter_idx", 's').as_dtype(DType::Int);
+    let gather_idx_t = cx.named_tensor("gather_idx", 'c').as_dtype(DType::Int);
+    let attn_mask_t = cx.named_tensor("attn_mask", ('s', 'c'));
+    let kv_cache = KVCache::new(&mut cx, MAX_SEQ_LEN);
+    let (logits, cache_outputs) = Llama::init(&mut cx).forward(
+        input,
+        q_pos_t,
+        scatter_idx_t,
+        gather_idx_t,
+        attn_mask_t,
+        &kv_cache,
+    );
+    let logits = logits.output();
+    for (k_out, v_out) in &cache_outputs {
+        k_out.output();
+        v_out.output();
+    }
+
+    cx.set_dim('s', 1);
+    cx.set_dim('c', 1);
+    let max_prefill = (prompt_tokens.len() + 16)
+        .next_power_of_two()
+        .min(MAX_SEQ_LEN);
+    let max_context = (prompt_tokens.len() + GEN_TOKENS + 1)
+        .next_power_of_two()
+        .min(MAX_SEQ_LEN);
+    let search_s = 16.min(max_prefill).max(2);
+    let search_c = 16.min(max_context).max(2);
+    let build_options = CompileOptions::default()
+        .max_memory_mib(SEARCH_MEMORY_MIB)
+        .dim_buckets(
+            's',
+            &[
+                DimBucket::new(1, 1),
+                DimBucket::new(2, max_prefill).representative(search_s),
+            ],
+        )
+        .dim_buckets(
+            'c',
+            &[
+                DimBucket::new(1, 1),
+                DimBucket::new(2, max_context).representative(search_c),
+            ],
+        );
+
+    println!("Building E-Graph...");
+    let egraph_start = Instant::now();
+    cx.build_search_space::<WebGpuRuntime>(build_options);
+    println!(
+        "  E-Graph build: {:.2} s",
+        egraph_start.elapsed().as_secs_f64()
+    );
+
+    println!("Loading weights...");
+    let load_start = Instant::now();
+    let mut runtime = WebGpuRuntime::initialize(());
+    runtime.load_safetensors(&cx, model_dir.join("model.safetensors").to_str().unwrap());
+    println!("  Weight load: {:.2} s", load_start.elapsed().as_secs_f64());
+
+    let cache_bytes = MAX_SEQ_LEN * KV_DIM * std::mem::size_of::<f32>();
+    for i in 0..LAYERS {
+        runtime.set_zeros(kv_cache.k_caches[i], cache_bytes);
+        runtime.set_zeros(kv_cache.v_caches[i], cache_bytes);
+    }
+
+    println!("Compiling...");
+    let compile_start = Instant::now();
+    cx.set_dim('s', search_s);
+    cx.set_dim('c', search_c);
+    runtime.set_data(input, vec![1; search_s]);
+    runtime.set_data(q_pos_t, (0..search_s as i32).collect::<Vec<_>>());
+    runtime.set_data(scatter_idx_t, (0..search_s as i32).collect::<Vec<_>>());
+    runtime.set_data(gather_idx_t, (0..search_c as i32).collect::<Vec<_>>());
+    runtime.set_data(attn_mask_t, vec![0.0f32; search_s * search_c]);
+    runtime = cx.search(runtime, CompileOptions::new(SEARCH_GRAPHS));
+    println!(
+        "  Search/compile: {:.2} s",
+        compile_start.elapsed().as_secs_f64()
+    );
+
+    for i in 0..LAYERS {
+        runtime.set_zeros(kv_cache.k_caches[i], cache_bytes);
+        runtime.set_zeros(kv_cache.v_caches[i], cache_bytes);
+    }
+
+    let prompt_len = prompt_tokens.len();
+    let mut context_len = 0usize;
+    let mut profiles = Vec::new();
+    let mut seen_tokens = FxHashSet::default();
+    let repetition_penalty = 1.05;
+
+    println!(
+        "Prompt: {} tokens, generating up to {} tokens",
+        prompt_len, GEN_TOKENS
+    );
+
+    let mut generated = 0usize;
+    let mut next_token = None;
+    if GEN_TOKENS > 0 && prompt_len > 0 {
+        let positions: Vec<usize> = (0..prompt_len).collect();
+        let q_pos: Vec<i32> = positions.iter().map(|&p| p as i32).collect();
+        let mask = causal_mask(&positions, prompt_len);
+        let (logits_data, profile) = run_model_step(
+            &mut cx,
+            &mut runtime,
+            input,
+            q_pos_t,
+            scatter_idx_t,
+            gather_idx_t,
+            attn_mask_t,
+            logits,
+            &kv_cache,
+            &cache_outputs,
+            &prompt_tokens,
+            &q_pos,
+            &q_pos,
+            &q_pos,
+            &mask,
+        );
+        context_len = prompt_len;
+
+        let token = sample_greedy(
+            &logits_data[logits_data.len() - VOCAB_SIZE..],
+            &seen_tokens,
+            repetition_penalty,
+        );
+        seen_tokens.insert(token);
+        next_token = Some(token);
+        generated = 1;
+        profiles.push(profile);
+
+        if token != EOS_TOKEN && token != STOP_TOKEN {
+            print!(
+                "{}",
+                tokenizer
+                    .decode(&[token], true)
+                    .map_err(|err| err as Box<dyn Error>)?
+            );
+            std::io::stdout().flush()?;
+        }
+    }
+
+    while generated < GEN_TOKENS {
+        let current_token = match next_token {
+            Some(token) if token != EOS_TOKEN && token != STOP_TOKEN => token,
+            _ => break,
+        };
+        let gather_idx = (0..=context_len as i32).collect::<Vec<_>>();
+        let mask = causal_mask(&[context_len], context_len + 1);
+        let (logits_data, profile) = run_model_step(
+            &mut cx,
+            &mut runtime,
+            input,
+            q_pos_t,
+            scatter_idx_t,
+            gather_idx_t,
+            attn_mask_t,
+            logits,
+            &kv_cache,
+            &cache_outputs,
+            &[current_token],
+            &[context_len as i32],
+            &[context_len as i32],
+            &gather_idx,
+            &mask,
+        );
+        context_len += 1;
+
+        let token = sample_greedy(
+            &logits_data[logits_data.len() - VOCAB_SIZE..],
+            &seen_tokens,
+            repetition_penalty,
+        );
+        seen_tokens.insert(token);
+        next_token = Some(token);
+        generated += 1;
+        profiles.push(profile);
+
+        if token == EOS_TOKEN || token == STOP_TOKEN {
+            break;
+        }
+        print!(
+            "{}",
+            tokenizer
+                .decode(&[token], true)
+                .map_err(|err| err as Box<dyn Error>)?
+        );
+        std::io::stdout().flush()?;
+    }
+    println!();
+
+    let ttft = profiles.first().map(|p| p.total).unwrap_or_default();
+    let decode_steps = profiles.len().saturating_sub(1);
+    let decode_total: Duration = profiles.iter().skip(1).map(|p| p.total).sum();
+    println!("  TTFT: {:.2} ms", ttft.as_secs_f64() * 1e3);
+    println!("  TPOT: {:.2} ms", avg_ms(decode_total, decode_steps));
+
+    let execute_total: Duration = profiles.iter().map(|p| p.execute).sum();
+    let logits_total: Duration = profiles.iter().map(|p| p.get_logits).sum();
+    let cache_total: Duration = profiles.iter().map(|p| p.cache_roundtrip).sum();
+    println!(
+        "  Profile: n={}, exec={:.2} ms, logits={:.2} ms, cache={:.2} ms",
+        profiles.len(),
+        avg_ms(execute_total, profiles.len()),
+        avg_ms(logits_total, profiles.len()),
+        avg_ms(cache_total, profiles.len()),
+    );
+
+    Ok(())
+}

--- a/crates/luminal_webgpu/src/dyn_backend.rs
+++ b/crates/luminal_webgpu/src/dyn_backend.rs
@@ -1,0 +1,80 @@
+//! [`DynBackend`] implementation for the WebGPU runtime.
+
+use luminal::dtype::DType;
+use luminal::dyn_backend::{BackendCompileArgs, DynBackend, bytes_to_native_data, compile_backend};
+use luminal::prelude::*;
+
+use crate::runtime::WebGpuRuntime;
+
+/// [`DynBackend`] wrapper for [`WebGpuRuntime`].
+pub struct WebGpuDynBackend {
+    pub runtime: WebGpuRuntime,
+}
+
+impl DynBackend for WebGpuDynBackend {
+    fn name(&self) -> &str {
+        "webgpu"
+    }
+
+    fn set_data_bytes(&mut self, node: NodeIndex, bytes: Vec<u8>, dtype: DType) {
+        self.runtime
+            .set_data(node, bytes_to_native_data(bytes, dtype));
+    }
+    fn set_data_f32(&mut self, node: NodeIndex, data: Vec<f32>) {
+        self.runtime.set_data(node, data);
+    }
+    fn get_output_f32(&self, node: NodeIndex) -> Vec<f32> {
+        self.runtime.get_f32(node)
+    }
+    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) {
+        self.runtime.execute(dyn_map);
+    }
+}
+
+/// Reject dtypes the WebGPU kernel emitters don't support.
+///
+/// WebGPU codegen has no native 64-bit integer or 64-bit float paths.
+/// Reaching the kernel emitter with one of these dtypes used to panic deep
+/// in MSL generation with an unhelpful error; surfacing a clean message
+/// at translate-time lets the user fall back to CPU or pick a narrower
+/// dtype before any WebGPU compilation runs.
+fn reject_unsupported_dtype(graph: &Graph) -> Result<(), String> {
+    for node_id in graph.graph.node_indices() {
+        if let Some(input) = (*graph.graph[node_id])
+            .as_any()
+            .downcast_ref::<luminal::hlir::Input>()
+        {
+            match input.dtype {
+                DType::I64 | DType::F64 => {
+                    return Err(format!(
+                        "WebGPU backend does not support {:?} (input `{}`). \
+                         WebGPU codegen has no native 64-bit kernels; either \
+                         narrow the dtype (e.g. `.to(torch.int32)` / \
+                         `.to(torch.float32)`) before the boundary or \
+                         compile with the CPU / CUDA backend.",
+                        input.dtype, input.label
+                    ));
+                }
+                _ => {}
+            }
+        }
+    }
+    Ok(())
+}
+
+pub fn webgpu_factory(
+    graph: &mut Graph,
+    args: BackendCompileArgs,
+) -> Result<Box<dyn DynBackend>, String> {
+    reject_unsupported_dtype(graph)?;
+    compile_backend::<WebGpuRuntime>(
+        graph,
+        args,
+        || Ok(WebGpuRuntime::initialize(())),
+        |rt, node, bytes, dtype| {
+            rt.set_data(node, bytes_to_native_data(bytes, dtype));
+        },
+        None,
+        |rt| Box::new(WebGpuDynBackend { runtime: rt }),
+    )
+}

--- a/crates/luminal_webgpu/src/kernel/matmul.rs
+++ b/crates/luminal_webgpu/src/kernel/matmul.rs
@@ -1,0 +1,5 @@
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WebGpuMatrixLayout {
+    RowMajor,
+    TransposedRowMajor,
+}

--- a/crates/luminal_webgpu/src/kernel/mod.rs
+++ b/crates/luminal_webgpu/src/kernel/mod.rs
@@ -1,0 +1,139 @@
+mod matmul;
+mod ops;
+pub use matmul::*;
+pub use ops::*;
+
+use crate::runtime::WebGpuBuffer;
+use luminal::dtype::DType;
+use luminal::op::EgglogOp;
+use luminal::prelude::*;
+use std::sync::Arc;
+
+pub const DYN_SLOT_COUNT: usize = 26;
+pub const PARAM_SLOT_COUNT: usize = DYN_SLOT_COUNT + 2;
+pub const COUNT_PARAM_SLOT: usize = DYN_SLOT_COUNT;
+pub const OFFSET_PARAM_SLOT: usize = DYN_SLOT_COUNT + 1;
+pub const WORKGROUP_SIZE: u32 = 256;
+
+#[derive(Clone)]
+pub struct WebGpuPipeline {
+    pipelines: Vec<Arc<wgpu::ComputePipeline>>,
+}
+
+impl WebGpuPipeline {
+    pub(crate) fn single(pipeline: wgpu::ComputePipeline) -> Self {
+        Self {
+            pipelines: vec![Arc::new(pipeline)],
+        }
+    }
+
+    pub(crate) fn new(pipelines: Vec<wgpu::ComputePipeline>) -> Self {
+        Self {
+            pipelines: pipelines.into_iter().map(Arc::new).collect(),
+        }
+    }
+
+    pub(crate) fn get(&self, index: usize) -> &wgpu::ComputePipeline {
+        &self.pipelines[index]
+    }
+}
+
+pub struct WebGpuEncodeContext<'a> {
+    pub(crate) device: &'a wgpu::Device,
+    pub(crate) encoder: &'a mut wgpu::CommandEncoder,
+    pub(crate) dyn_map: &'a FxHashMap<char, usize>,
+    pub(crate) max_compute_workgroups_per_dimension: u32,
+}
+
+#[derive(Debug, Clone)]
+pub struct WebGpuMulInfo {
+    pub shape: Vec<Expression>,
+    pub a_strides: Vec<Expression>,
+    pub b_strides: Vec<Expression>,
+    pub output_strides: Vec<Expression>,
+}
+
+#[derive(Debug, Clone)]
+pub struct WebGpuSumReduceInfo {
+    pub shape: Vec<Expression>,
+    pub strides: Vec<Expression>,
+    pub iters: Expression,
+    pub iter_stride: Expression,
+}
+
+pub trait WebGpuKernelOp: EgglogOp {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<WebGpuPipeline>;
+
+    fn infer_output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        input_dtypes.first().copied().unwrap_or(DType::F32)
+    }
+
+    fn output_size(&self) -> Expression;
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    );
+
+    #[allow(clippy::too_many_arguments)]
+    fn encode(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: Option<&WebGpuPipeline>,
+        inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _dyn_map: &FxHashMap<char, usize>,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) {
+        let pipeline = pipeline.expect("compute pipeline not compiled");
+        self.encode_compute(
+            context,
+            pipeline,
+            inputs,
+            output,
+            input_dtypes,
+            output_dtype,
+        );
+    }
+
+    fn bytes_loaded(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+        0
+    }
+
+    fn bytes_stored(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+        0
+    }
+
+    fn flops(&self, _dyn_map: &FxHashMap<char, usize>) -> usize {
+        0
+    }
+
+    fn mul_info(&self) -> Option<WebGpuMulInfo> {
+        None
+    }
+
+    fn sum_reduce_info(&self) -> Option<WebGpuSumReduceInfo> {
+        None
+    }
+
+    fn output_aliases_input(&self) -> Option<usize> {
+        None
+    }
+
+    fn is_matmul(&self) -> bool {
+        false
+    }
+}
+
+luminal::impl_into_ops!(WebGpuKernelOp);

--- a/crates/luminal_webgpu/src/kernel/ops.rs
+++ b/crates/luminal_webgpu/src/kernel/ops.rs
@@ -1,0 +1,2802 @@
+use super::{
+    COUNT_PARAM_SLOT, OFFSET_PARAM_SLOT, PARAM_SLOT_COUNT, WORKGROUP_SIZE, WebGpuEncodeContext,
+    WebGpuKernelOp, WebGpuMatrixLayout, WebGpuPipeline,
+};
+use crate::runtime::WebGpuBuffer;
+use luminal::{
+    egglog_utils::{
+        SerializedEGraph,
+        api::{
+            Args, Rule, SortDef, Term as EggTerm, app, eq, i64 as lit_i64, rule, sort, union, v,
+        },
+        base::{
+            DTYPE, ELIST, EXPRESSION, F64, I64, IR, SORTS, cons, dtype, ilist, iter, mul,
+            new_op_call, nil, num, op_term,
+        },
+    },
+    hlir::{
+        Add, Cast, Constant, Gather, Iota, LessThan, MaxReduce, Mod, Mul, Scatter, SumReduce,
+        binary_sort, reduce_sort, unary_sort,
+    },
+    op::*,
+    prelude::*,
+    shape::{Term, flatten_strides},
+};
+use wgpu::util::DeviceExt;
+
+pub type WebGpuOps = (
+    WebGpuExp2,
+    WebGpuLog2,
+    WebGpuSin,
+    WebGpuSqrt,
+    WebGpuRecip,
+    WebGpuAdd,
+    WebGpuMul,
+    WebGpuMod,
+    WebGpuLessThan,
+    WebGpuSumReduce,
+    WebGpuMaxReduce,
+    WebGpuMatmul,
+    GenericMatmul,
+    WebGpuConstant,
+    WebGpuIota,
+    WebGpuGather,
+    WebGpuScatter,
+    WebGpuScatterNoCopy,
+    WebGpuCast,
+);
+
+fn compile_shader_raw(
+    device: &wgpu::Device,
+    source: &str,
+    entry_point: &str,
+) -> wgpu::ComputePipeline {
+    let shader = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: None,
+        source: wgpu::ShaderSource::Wgsl(source.into()),
+    });
+    device.create_compute_pipeline(&wgpu::ComputePipelineDescriptor {
+        label: None,
+        layout: None,
+        module: &shader,
+        entry_point,
+    })
+}
+
+fn compile_shader(device: &wgpu::Device, source: &str, entry_point: &str) -> WebGpuPipeline {
+    WebGpuPipeline::single(compile_shader_raw(device, source, entry_point))
+}
+
+fn shader_prelude() -> String {
+    format!(
+        r#"
+struct Params {{
+    dims: array<i32, {dyn_slots}>,
+    n: i32,
+    offset: i32,
+}}
+"#,
+        dyn_slots = super::DYN_SLOT_COUNT
+    )
+}
+
+fn params_buffer(
+    device: &wgpu::Device,
+    dyn_map: &FxHashMap<char, usize>,
+    count: u32,
+    offset: u32,
+) -> wgpu::Buffer {
+    let mut params = [0i32; PARAM_SLOT_COUNT];
+    for (&symbol, &value) in dyn_map {
+        if symbol.is_ascii_lowercase() {
+            let slot = (symbol as u8 - b'a') as usize;
+            if slot < super::DYN_SLOT_COUNT {
+                params[slot] = value as i32;
+            }
+        }
+    }
+    params[COUNT_PARAM_SLOT] = count as i32;
+    params[OFFSET_PARAM_SLOT] = offset as i32;
+    device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+        label: None,
+        contents: bytemuck::cast_slice(&params),
+        usage: wgpu::BufferUsages::STORAGE,
+    })
+}
+
+fn dispatch_chunk(
+    context: &mut WebGpuEncodeContext<'_>,
+    pipeline: &wgpu::ComputePipeline,
+    buffers: &[&WebGpuBuffer],
+    count: u32,
+    offset: u32,
+    workgroups: u32,
+) {
+    if workgroups == 0 {
+        return;
+    }
+    let params = params_buffer(context.device, context.dyn_map, count, offset);
+    let mut entries = buffers
+        .iter()
+        .enumerate()
+        .map(|(binding, buffer)| wgpu::BindGroupEntry {
+            binding: binding as u32,
+            resource: buffer.raw().as_entire_binding(),
+        })
+        .collect::<Vec<_>>();
+    entries.push(wgpu::BindGroupEntry {
+        binding: buffers.len() as u32,
+        resource: params.as_entire_binding(),
+    });
+    let bind_group = context
+        .device
+        .create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &pipeline.get_bind_group_layout(0),
+            entries: &entries,
+        });
+    let mut pass = context
+        .encoder
+        .begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: None,
+            timestamp_writes: None,
+        });
+    pass.set_pipeline(pipeline);
+    pass.set_bind_group(0, &bind_group, &[]);
+    pass.dispatch_workgroups(workgroups, 1, 1);
+}
+
+fn dispatch_1d(
+    context: &mut WebGpuEncodeContext<'_>,
+    pipeline: &wgpu::ComputePipeline,
+    buffers: &[&WebGpuBuffer],
+    count: u32,
+) {
+    if count == 0 {
+        return;
+    }
+    assert!(
+        count <= i32::MAX as u32,
+        "WebGPU kernels currently index buffers with i32 and cannot dispatch {count} elements"
+    );
+    let max_workgroups = context.max_compute_workgroups_per_dimension.max(1);
+    let max_elements_per_dispatch = max_workgroups.saturating_mul(WORKGROUP_SIZE).max(1);
+    let mut offset = 0u32;
+    while offset < count {
+        let chunk_elements = (count - offset).min(max_elements_per_dispatch);
+        let workgroups = chunk_elements.div_ceil(WORKGROUP_SIZE);
+        dispatch_chunk(context, pipeline, buffers, count, offset, workgroups);
+        offset += chunk_elements;
+    }
+}
+
+fn dispatch_workgroups(
+    context: &mut WebGpuEncodeContext<'_>,
+    pipeline: &wgpu::ComputePipeline,
+    buffers: &[&WebGpuBuffer],
+    count: u32,
+    workgroups: u32,
+) {
+    if workgroups == 0 {
+        return;
+    }
+    assert!(
+        count <= i32::MAX as u32 && workgroups <= i32::MAX as u32,
+        "WebGPU kernels currently index workgroups with i32 and cannot dispatch count={count}, workgroups={workgroups}"
+    );
+    let max_workgroups = context.max_compute_workgroups_per_dimension.max(1);
+    let mut offset = 0u32;
+    while offset < workgroups {
+        let chunk_workgroups = (workgroups - offset).min(max_workgroups);
+        dispatch_chunk(context, pipeline, buffers, count, offset, chunk_workgroups);
+        offset += chunk_workgroups;
+    }
+}
+
+fn dispatch_2d(
+    context: &mut WebGpuEncodeContext<'_>,
+    pipeline: &wgpu::ComputePipeline,
+    buffers: &[&WebGpuBuffer],
+    count: u32,
+    workgroups_x: u32,
+    workgroups_y: u32,
+) {
+    if workgroups_x == 0 || workgroups_y == 0 {
+        return;
+    }
+    let max_workgroups = context.max_compute_workgroups_per_dimension.max(1);
+    assert!(
+        workgroups_x <= max_workgroups && workgroups_y <= max_workgroups,
+        "WebGPU 2D dispatch dimensions [{workgroups_x}, {workgroups_y}] exceed adapter limit {max_workgroups}"
+    );
+    let params = params_buffer(context.device, context.dyn_map, count, 0);
+    let mut entries = buffers
+        .iter()
+        .enumerate()
+        .map(|(binding, buffer)| wgpu::BindGroupEntry {
+            binding: binding as u32,
+            resource: buffer.raw().as_entire_binding(),
+        })
+        .collect::<Vec<_>>();
+    entries.push(wgpu::BindGroupEntry {
+        binding: buffers.len() as u32,
+        resource: params.as_entire_binding(),
+    });
+    let bind_group = context
+        .device
+        .create_bind_group(&wgpu::BindGroupDescriptor {
+            label: None,
+            layout: &pipeline.get_bind_group_layout(0),
+            entries: &entries,
+        });
+    let mut pass = context
+        .encoder
+        .begin_compute_pass(&wgpu::ComputePassDescriptor {
+            label: None,
+            timestamp_writes: None,
+        });
+    pass.set_pipeline(pipeline);
+    pass.set_bind_group(0, &bind_group, &[]);
+    pass.dispatch_workgroups(workgroups_x, workgroups_y, 1);
+}
+
+pub(crate) fn lower_expression_for_webgpu(expr: &Expression, index_var: &str) -> String {
+    let mut stack = Vec::new();
+    for term in expr.terms.read().iter().copied() {
+        let value = match term {
+            Term::Num(n) => n.to_string(),
+            Term::Var('z') => index_var.to_string(),
+            Term::Var(c) => {
+                assert!(c.is_ascii_lowercase(), "unsupported dynamic symbol {c:?}");
+                format!("params.dims[{}]", (c as u8 - b'a') as usize)
+            }
+            Term::Add => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("(({a}) + ({b}))")
+            }
+            Term::Sub => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("(({a}) - ({b}))")
+            }
+            Term::Mul => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("(({a}) * ({b}))")
+            }
+            Term::Div => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("(({a}) / ({b}))")
+            }
+            Term::CeilDiv => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("((({a}) + ({b}) - 1) / ({b}))")
+            }
+            Term::Mod => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("(({a}) % ({b}))")
+            }
+            Term::Min => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("min({a}, {b})")
+            }
+            Term::Max => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("max({a}, {b})")
+            }
+            Term::And => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("select(0, 1, (({a}) != 0 && ({b}) != 0))")
+            }
+            Term::Or => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("select(0, 1, (({a}) != 0 || ({b}) != 0))")
+            }
+            Term::Gte => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("select(0, 1, ({a}) >= ({b}))")
+            }
+            Term::Lt => {
+                let a = stack.pop().unwrap();
+                let b = stack.pop().unwrap();
+                format!("select(0, 1, ({a}) < ({b}))")
+            }
+        };
+        stack.push(value);
+    }
+    stack.pop().unwrap_or_else(|| "0".to_string())
+}
+
+pub(crate) fn lower_scalar_expression_for_webgpu(expr: &Expression) -> String {
+    lower_expression_for_webgpu(&expr.substitute('z', Expression::from(1)), "idx")
+}
+
+fn webgpu_buffer_type(dtype: DType) -> &'static str {
+    match dtype {
+        DType::F32 | DType::TF32 => "f32",
+        DType::Int => "i32",
+        _ => panic!("WebGPU dtype {dtype:?} is not supported yet"),
+    }
+}
+
+fn buffer_index(index: &str) -> String {
+    format!("u32({index})")
+}
+
+fn webgpu_numeric_read(dtype: DType, buffer: &str, index: &str) -> String {
+    match dtype {
+        DType::F32 | DType::TF32 => format!("{buffer}[{}]", buffer_index(index)),
+        DType::Int => format!("f32({buffer}[{}])", buffer_index(index)),
+        _ => panic!("WebGPU dtype {dtype:?} is not supported yet"),
+    }
+}
+
+fn webgpu_numeric_write(dtype: DType, expr: &str) -> String {
+    match dtype {
+        DType::F32 | DType::TF32 => expr.to_string(),
+        DType::Int => format!("i32({expr})"),
+        _ => panic!("WebGPU dtype {dtype:?} is not supported yet"),
+    }
+}
+
+fn webgpu_copy_value(dtype: DType, buffer: &str, index: &str) -> String {
+    match dtype {
+        DType::F32 | DType::TF32 | DType::Int => {
+            format!("{buffer}[{}]", buffer_index(index))
+        }
+        _ => panic!("WebGPU dtype {dtype:?} is not supported yet"),
+    }
+}
+
+fn webgpu_binary_op_values(
+    output_dtype: DType,
+    a_dtype: DType,
+    b_dtype: DType,
+    a_idx: &str,
+    b_idx: &str,
+) -> (String, String) {
+    let read: fn(DType, &str, &str) -> String = if output_dtype == DType::Int {
+        webgpu_copy_value
+    } else {
+        webgpu_numeric_read
+    };
+    (read(a_dtype, "a", a_idx), read(b_dtype, "b", b_idx))
+}
+
+fn call_sort_from_args(sort: &SortDef, args: &Args) -> EggTerm {
+    let mut filtered_args = Args::new();
+    for field in &sort.fields {
+        filtered_args.add(&field.name, args[field.name.as_str()].clone());
+    }
+    sort.call(filtered_args)
+}
+
+fn unary_dtype_rewrite(hlir_sort: &SortDef, webgpu_sort: &SortDef) -> Rule {
+    let (args, hlir_match) = new_op_call(hlir_sort, &["inp"]);
+    let webgpu_op = op_term(
+        call_sort_from_args(webgpu_sort, &args),
+        args["__inputs"].clone(),
+    );
+    let dt = v("?__dt");
+    rule(union(hlir_match.clone(), webgpu_op.clone()))
+        .subsume(hlir_match)
+        .set(dtype(webgpu_op), dt.clone())
+        .fact(eq(dt, dtype(args["inp"].clone())))
+        .ruleset("kernel_lower")
+}
+
+fn binary_dtype_rewrite(hlir_sort: &SortDef, webgpu_sort: &SortDef) -> Rule {
+    let (args, hlir_match) = new_op_call(hlir_sort, &["inp_a", "inp_b"]);
+    let webgpu_op = op_term(
+        call_sort_from_args(webgpu_sort, &args),
+        args["__inputs"].clone(),
+    );
+    let dt = v("?__dt");
+    rule(union(hlir_match.clone(), webgpu_op.clone()))
+        .subsume(hlir_match)
+        .set(dtype(webgpu_op), dt.clone())
+        .fact(eq(dt, dtype(args["inp_a"].clone())))
+        .ruleset("kernel_lower")
+}
+
+macro_rules! impl_unary_metrics {
+    ($self:ident, $dyn_map:ident) => {
+        fn bytes_loaded(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+            $self.output_size().exec($dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+        }
+
+        fn bytes_stored(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+            $self.output_size().exec($dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+        }
+
+        fn flops(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+            $self.output_size().exec($dyn_map).unwrap_or(0)
+        }
+    };
+}
+
+macro_rules! impl_binary_metrics {
+    ($self:ident, $dyn_map:ident, $flops_per_elem:expr) => {
+        fn bytes_loaded(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+            $self.output_size().exec($dyn_map).unwrap_or(0) * 2 * std::mem::size_of::<f32>()
+        }
+
+        fn bytes_stored(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+            $self.output_size().exec($dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+        }
+
+        fn flops(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+            $self.output_size().exec($dyn_map).unwrap_or(0) * $flops_per_elem
+        }
+    };
+}
+
+macro_rules! impl_reduce_metrics {
+    ($self:ident, $dyn_map:ident) => {
+        fn bytes_loaded(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+            let n_outputs = $self.output_size().exec($dyn_map).unwrap_or(0);
+            let iters = $self.iters.exec($dyn_map).unwrap_or(0);
+            n_outputs * iters * std::mem::size_of::<f32>()
+        }
+
+        fn bytes_stored(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+            $self.output_size().exec($dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+        }
+
+        fn flops(&$self, $dyn_map: &FxHashMap<char, usize>) -> usize {
+            let n_outputs = $self.output_size().exec($dyn_map).unwrap_or(0);
+            let iters = $self.iters.exec($dyn_map).unwrap_or(0);
+            n_outputs * iters
+        }
+    };
+}
+
+macro_rules! webgpu_unary_op {
+    ($name:ident, $op_name:expr, $expr_builder:expr) => {
+        #[derive(Debug, Default, Clone)]
+        pub struct $name {
+            shape: Vec<Expression>,
+            input_strides: Vec<Expression>,
+            output_strides: Vec<Expression>,
+        }
+
+        impl EgglogOp for $name {
+            fn sort(&self) -> SortDef {
+                unary_sort($op_name)
+            }
+
+            fn rewrites(&self) -> Vec<Rule> {
+                let hlir_name = ($op_name).strip_prefix("WebGpu").unwrap_or($op_name);
+                let hlir_sort = unary_sort(hlir_name);
+                vec![unary_dtype_rewrite(&hlir_sort, &self.sort())]
+            }
+
+            fn cleanup(&self) -> bool {
+                false
+            }
+
+            fn extract<'a>(
+                &'a self,
+                egraph: &'a SerializedEGraph,
+                kind_children: &[&'a ENodeId],
+                input_enodes: Vec<&'a ENodeId>,
+                list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+                expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+            ) -> (LLIROp, Vec<&'a ENodeId>) {
+                use luminal::egglog_utils::extract_expr_list;
+                (
+                    LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                        shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache)
+                            .unwrap(),
+                        input_strides: extract_expr_list(
+                            egraph,
+                            kind_children[1],
+                            list_cache,
+                            expr_cache,
+                        )
+                        .unwrap(),
+                        output_strides: extract_expr_list(
+                            egraph,
+                            kind_children[2],
+                            list_cache,
+                            expr_cache,
+                        )
+                        .unwrap(),
+                    })),
+                    input_enodes,
+                )
+            }
+        }
+
+        impl WebGpuKernelOp for $name {
+            fn compile(
+                &self,
+                device: &wgpu::Device,
+                input_dtypes: &[DType],
+                output_dtype: DType,
+            ) -> Option<WebGpuPipeline> {
+                let input_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
+                let input_ty = webgpu_buffer_type(input_dtype);
+                let output_ty = webgpu_buffer_type(output_dtype);
+                let inp_index = flatten_strides(&self.shape, &self.input_strides);
+                let out_index = flatten_strides(&self.shape, &self.output_strides);
+                let inp_idx = lower_expression_for_webgpu(&inp_index, "idx");
+                let out_idx = lower_expression_for_webgpu(&out_index, "idx");
+                let input_expr = webgpu_numeric_read(input_dtype, "inp", &inp_idx);
+                let body_expr = ($expr_builder)(&input_expr);
+                let write_expr = webgpu_numeric_write(output_dtype, &body_expr);
+                let prelude = shader_prelude();
+                let source = format!(
+                    r#"
+{prelude}
+@group(0) @binding(0) var<storage, read> inp: array<{input_ty}>;
+@group(0) @binding(1) var<storage, read_write> out: array<{output_ty}>;
+@group(0) @binding(2) var<storage, read> params: Params;
+
+@compute @workgroup_size({workgroup_size})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {{
+    let idx = i32(global_id.x) + params.offset;
+    if (idx < params.n) {{
+        out[{out_index}] = {write_expr};
+    }}
+}}
+"#,
+                    out_index = buffer_index(&out_idx),
+                    workgroup_size = WORKGROUP_SIZE,
+                );
+                Some(compile_shader(device, &source, "main"))
+            }
+
+            fn output_size(&self) -> Expression {
+                self.shape
+                    .iter()
+                    .cloned()
+                    .product::<Expression>()
+                    .max(Expression::from(1))
+            }
+
+            fn encode_compute(
+                &self,
+                context: &mut WebGpuEncodeContext<'_>,
+                pipeline: &WebGpuPipeline,
+                inputs: &[&WebGpuBuffer],
+                output: &WebGpuBuffer,
+                _input_dtypes: &[DType],
+                _output_dtype: DType,
+            ) {
+                let n_elements = self.output_size().exec(context.dyn_map).unwrap() as u32;
+                dispatch_1d(context, pipeline.get(0), &[inputs[0], output], n_elements);
+            }
+
+            impl_unary_metrics!(self, dyn_map);
+        }
+    };
+}
+
+webgpu_unary_op!(WebGpuExp2, "WebGpuExp2", |x: &str| format!("exp2({x})"));
+webgpu_unary_op!(WebGpuLog2, "WebGpuLog2", |x: &str| format!("log2({x})"));
+webgpu_unary_op!(WebGpuSin, "WebGpuSin", |x: &str| format!("sin({x})"));
+webgpu_unary_op!(WebGpuSqrt, "WebGpuSqrt", |x: &str| format!("sqrt({x})"));
+webgpu_unary_op!(WebGpuRecip, "WebGpuRecip", |x: &str| format!("1.0 / ({x})"));
+
+macro_rules! webgpu_binary_op {
+    ($name:ident, $sort_name:expr, $hlir:ty, $expr_builder:expr, $flops:expr) => {
+        #[derive(Debug, Default, Clone)]
+        pub struct $name {
+            shape: Vec<Expression>,
+            a_strides: Vec<Expression>,
+            b_strides: Vec<Expression>,
+            output_strides: Vec<Expression>,
+        }
+
+        impl EgglogOp for $name {
+            fn sort(&self) -> SortDef {
+                binary_sort($sort_name)
+            }
+
+            fn rewrites(&self) -> Vec<Rule> {
+                vec![binary_dtype_rewrite(
+                    &<$hlir>::default().sort(),
+                    &self.sort(),
+                )]
+            }
+
+            fn cleanup(&self) -> bool {
+                false
+            }
+
+            fn extract<'a>(
+                &'a self,
+                egraph: &'a SerializedEGraph,
+                kind_children: &[&'a ENodeId],
+                input_enodes: Vec<&'a ENodeId>,
+                list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+                expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+            ) -> (LLIROp, Vec<&'a ENodeId>) {
+                use luminal::egglog_utils::extract_expr_list;
+                (
+                    LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                        shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache)
+                            .unwrap(),
+                        a_strides: extract_expr_list(
+                            egraph,
+                            kind_children[1],
+                            list_cache,
+                            expr_cache,
+                        )
+                        .unwrap(),
+                        b_strides: extract_expr_list(
+                            egraph,
+                            kind_children[2],
+                            list_cache,
+                            expr_cache,
+                        )
+                        .unwrap(),
+                        output_strides: extract_expr_list(
+                            egraph,
+                            kind_children[3],
+                            list_cache,
+                            expr_cache,
+                        )
+                        .unwrap(),
+                    })),
+                    input_enodes,
+                )
+            }
+        }
+
+        impl WebGpuKernelOp for $name {
+            fn compile(
+                &self,
+                device: &wgpu::Device,
+                input_dtypes: &[DType],
+                output_dtype: DType,
+            ) -> Option<WebGpuPipeline> {
+                let a_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
+                let b_dtype = input_dtypes.get(1).copied().unwrap_or(a_dtype);
+                let a_ty = webgpu_buffer_type(a_dtype);
+                let b_ty = webgpu_buffer_type(b_dtype);
+                let out_ty = webgpu_buffer_type(output_dtype);
+                let a_index = flatten_strides(&self.shape, &self.a_strides);
+                let b_index = flatten_strides(&self.shape, &self.b_strides);
+                let out_index = flatten_strides(&self.shape, &self.output_strides);
+                let a_idx = lower_expression_for_webgpu(&a_index, "idx");
+                let b_idx = lower_expression_for_webgpu(&b_index, "idx");
+                let out_idx = lower_expression_for_webgpu(&out_index, "idx");
+                let (a_val, b_val) =
+                    webgpu_binary_op_values(output_dtype, a_dtype, b_dtype, &a_idx, &b_idx);
+                let out_expr = ($expr_builder)(&a_val, &b_val, output_dtype);
+                let out_val = webgpu_numeric_write(output_dtype, &out_expr);
+                let prelude = shader_prelude();
+                let source = format!(
+                    r#"
+{prelude}
+@group(0) @binding(0) var<storage, read> a: array<{a_ty}>;
+@group(0) @binding(1) var<storage, read> b: array<{b_ty}>;
+@group(0) @binding(2) var<storage, read_write> out: array<{out_ty}>;
+@group(0) @binding(3) var<storage, read> params: Params;
+
+@compute @workgroup_size({workgroup_size})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {{
+    let idx = i32(global_id.x) + params.offset;
+    if (idx < params.n) {{
+        out[{out_index}] = {out_val};
+    }}
+}}
+"#,
+                    out_index = buffer_index(&out_idx),
+                    workgroup_size = WORKGROUP_SIZE,
+                );
+                Some(compile_shader(device, &source, "main"))
+            }
+
+            fn output_size(&self) -> Expression {
+                self.shape
+                    .iter()
+                    .cloned()
+                    .product::<Expression>()
+                    .max(Expression::from(1))
+            }
+
+            fn encode_compute(
+                &self,
+                context: &mut WebGpuEncodeContext<'_>,
+                pipeline: &WebGpuPipeline,
+                inputs: &[&WebGpuBuffer],
+                output: &WebGpuBuffer,
+                _input_dtypes: &[DType],
+                _output_dtype: DType,
+            ) {
+                let n_elements = self.output_size().exec(context.dyn_map).unwrap() as u32;
+                dispatch_1d(
+                    context,
+                    pipeline.get(0),
+                    &[inputs[0], inputs[1], output],
+                    n_elements,
+                );
+            }
+
+            impl_binary_metrics!(self, dyn_map, $flops);
+        }
+    };
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct WebGpuAdd {
+    shape: Vec<Expression>,
+    a_strides: Vec<Expression>,
+    b_strides: Vec<Expression>,
+    output_strides: Vec<Expression>,
+}
+
+impl EgglogOp for WebGpuAdd {
+    fn sort(&self) -> SortDef {
+        binary_sort("WebGpuAdd")
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        let (args2, hlir_match2) = new_op_call(&Add::default().sort(), &["inp_a", "inp_b"]);
+        let webgpu_op2 = op_term(
+            call_sort_from_args(&self.sort(), &args2),
+            args2["__inputs"].clone(),
+        );
+
+        vec![
+            binary_dtype_rewrite(&Add::default().sort(), &self.sort()),
+            rule(union(hlir_match2.clone(), webgpu_op2.clone()))
+                .subsume(hlir_match2)
+                .set(dtype(webgpu_op2), app(&SORTS.f32_dt, vec![]))
+                .ruleset("kernel_lower"),
+        ]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::extract_expr_list;
+        (
+            LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                a_strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                b_strides: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                output_strides: extract_expr_list(egraph, kind_children[3], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl WebGpuKernelOp for WebGpuAdd {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<WebGpuPipeline> {
+        compile_binary_kernel(
+            device,
+            &self.shape,
+            &self.a_strides,
+            &self.b_strides,
+            &self.output_strides,
+            input_dtypes,
+            output_dtype,
+            |a, b, _| format!("({a}) + ({b})"),
+        )
+    }
+
+    fn output_size(&self) -> Expression {
+        self.shape
+            .iter()
+            .cloned()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        let n_elements = self.output_size().exec(context.dyn_map).unwrap() as u32;
+        dispatch_1d(
+            context,
+            pipeline.get(0),
+            &[inputs[0], inputs[1], output],
+            n_elements,
+        );
+    }
+
+    impl_binary_metrics!(self, dyn_map, 1);
+}
+
+#[allow(clippy::too_many_arguments)]
+fn compile_binary_kernel(
+    device: &wgpu::Device,
+    shape: &[Expression],
+    a_strides: &[Expression],
+    b_strides: &[Expression],
+    output_strides: &[Expression],
+    input_dtypes: &[DType],
+    output_dtype: DType,
+    expr_builder: impl Fn(&str, &str, DType) -> String,
+) -> Option<WebGpuPipeline> {
+    let a_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
+    let b_dtype = input_dtypes.get(1).copied().unwrap_or(a_dtype);
+    let a_ty = webgpu_buffer_type(a_dtype);
+    let b_ty = webgpu_buffer_type(b_dtype);
+    let out_ty = webgpu_buffer_type(output_dtype);
+    let a_idx = lower_expression_for_webgpu(&flatten_strides(shape, a_strides), "idx");
+    let b_idx = lower_expression_for_webgpu(&flatten_strides(shape, b_strides), "idx");
+    let out_idx = lower_expression_for_webgpu(&flatten_strides(shape, output_strides), "idx");
+    let (a_val, b_val) = webgpu_binary_op_values(output_dtype, a_dtype, b_dtype, &a_idx, &b_idx);
+    let out_expr = expr_builder(&a_val, &b_val, output_dtype);
+    let out_val = webgpu_numeric_write(output_dtype, &out_expr);
+    let prelude = shader_prelude();
+    let source = format!(
+        r#"
+{prelude}
+@group(0) @binding(0) var<storage, read> a: array<{a_ty}>;
+@group(0) @binding(1) var<storage, read> b: array<{b_ty}>;
+@group(0) @binding(2) var<storage, read_write> out: array<{out_ty}>;
+@group(0) @binding(3) var<storage, read> params: Params;
+
+@compute @workgroup_size({workgroup_size})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {{
+    let idx = i32(global_id.x) + params.offset;
+    if (idx < params.n) {{
+        out[{out_index}] = {out_val};
+    }}
+}}
+"#,
+        out_index = buffer_index(&out_idx),
+        workgroup_size = WORKGROUP_SIZE,
+    );
+    Some(compile_shader(device, &source, "main"))
+}
+
+webgpu_binary_op!(
+    WebGpuMul,
+    "WebGpuMul",
+    Mul,
+    |a: &str, b: &str, _dtype: DType| format!("({a}) * ({b})"),
+    1
+);
+
+webgpu_binary_op!(
+    WebGpuMod,
+    "WebGpuMod",
+    Mod,
+    |a: &str, b: &str, dtype: DType| {
+        if dtype == DType::Int {
+            format!("({a}) % ({b})")
+        } else {
+            format!("({a}) - ({b}) * floor(({a}) / ({b}))")
+        }
+    },
+    10
+);
+
+#[derive(Debug, Default, Clone)]
+pub struct WebGpuLessThan {
+    shape: Vec<Expression>,
+    a_strides: Vec<Expression>,
+    b_strides: Vec<Expression>,
+    output_strides: Vec<Expression>,
+}
+
+impl EgglogOp for WebGpuLessThan {
+    fn sort(&self) -> SortDef {
+        binary_sort("WebGpuLessThan")
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![binary_dtype_rewrite(
+            &LessThan::default().sort(),
+            &self.sort(),
+        )]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::extract_expr_list;
+        (
+            LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache).unwrap(),
+                a_strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                b_strides: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                output_strides: extract_expr_list(egraph, kind_children[3], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl WebGpuKernelOp for WebGpuLessThan {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<WebGpuPipeline> {
+        compile_binary_kernel(
+            device,
+            &self.shape,
+            &self.a_strides,
+            &self.b_strides,
+            &self.output_strides,
+            input_dtypes,
+            output_dtype,
+            |a, b, _| format!("select(0.0, 1.0, ({a}) < ({b}))"),
+        )
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        DType::F32
+    }
+
+    fn output_size(&self) -> Expression {
+        self.shape
+            .iter()
+            .cloned()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        let n_elements = self.output_size().exec(context.dyn_map).unwrap() as u32;
+        dispatch_1d(
+            context,
+            pipeline.get(0),
+            &[inputs[0], inputs[1], output],
+            n_elements,
+        );
+    }
+
+    impl_binary_metrics!(self, dyn_map, 1);
+}
+
+macro_rules! webgpu_reduce_op {
+    ($name:ident, $sort_name:expr, $hlir:ty, $identity:expr, $combine:expr, $metrics_flops:expr) => {
+        #[derive(Debug, Default, Clone)]
+        pub struct $name {
+            out_shape: Vec<Expression>,
+            iters: Expression,
+            in_stride: Vec<Expression>,
+            iter_stride: Expression,
+            out_stride: Vec<Expression>,
+        }
+
+        impl EgglogOp for $name {
+            fn sort(&self) -> SortDef {
+                reduce_sort($sort_name)
+            }
+
+            fn rewrites(&self) -> Vec<Rule> {
+                vec![unary_dtype_rewrite(
+                    &<$hlir>::default().sort(),
+                    &self.sort(),
+                )]
+            }
+
+            fn cleanup(&self) -> bool {
+                false
+            }
+
+            fn extract<'a>(
+                &'a self,
+                egraph: &'a SerializedEGraph,
+                kind_children: &[&'a ENodeId],
+                input_enodes: Vec<&'a ENodeId>,
+                list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+                expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+            ) -> (LLIROp, Vec<&'a ENodeId>) {
+                use luminal::egglog_utils::{extract_expr, extract_expr_list};
+                (
+                    LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                        out_shape: extract_expr_list(
+                            egraph,
+                            kind_children[0],
+                            list_cache,
+                            expr_cache,
+                        )
+                        .unwrap(),
+                        iters: extract_expr(egraph, kind_children[1], expr_cache).unwrap(),
+                        in_stride: extract_expr_list(
+                            egraph,
+                            kind_children[2],
+                            list_cache,
+                            expr_cache,
+                        )
+                        .unwrap(),
+                        iter_stride: extract_expr(egraph, kind_children[3], expr_cache).unwrap(),
+                        out_stride: extract_expr_list(
+                            egraph,
+                            kind_children[4],
+                            list_cache,
+                            expr_cache,
+                        )
+                        .unwrap(),
+                    })),
+                    input_enodes,
+                )
+            }
+        }
+
+        impl WebGpuKernelOp for $name {
+            fn compile(
+                &self,
+                device: &wgpu::Device,
+                input_dtypes: &[DType],
+                output_dtype: DType,
+            ) -> Option<WebGpuPipeline> {
+                let input_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
+                let input_ty = webgpu_buffer_type(input_dtype);
+                let output_ty = webgpu_buffer_type(output_dtype);
+                let in_idx = lower_expression_for_webgpu(
+                    &flatten_strides(&self.out_shape, &self.in_stride),
+                    "gid",
+                );
+                let out_idx = lower_expression_for_webgpu(
+                    &flatten_strides(&self.out_shape, &self.out_stride),
+                    "gid",
+                );
+                let iters = lower_expression_for_webgpu(&self.iters, "gid");
+                let iter_offset = lower_expression_for_webgpu(&self.iter_stride, "i");
+                let in_val =
+                    webgpu_numeric_read(input_dtype, "input", &format!("in_start + {iter_offset}"));
+                let out_val = webgpu_numeric_write(output_dtype, "block_value");
+                let prelude = shader_prelude();
+                let source = format!(
+                    r#"
+{prelude}
+@group(0) @binding(0) var<storage, read> input: array<{input_ty}>;
+@group(0) @binding(1) var<storage, read_write> out: array<{output_ty}>;
+@group(0) @binding(2) var<storage, read> params: Params;
+
+var<workgroup> partials: array<f32, {workgroup_size}>;
+
+@compute @workgroup_size({workgroup_size})
+fn main(
+    @builtin(workgroup_id) workgroup_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>
+) {{
+    let gid = i32(workgroup_id.x) + params.offset;
+    if (gid >= params.n) {{
+        return;
+    }}
+    let tid = i32(local_id.x);
+    let in_start = {in_idx};
+    let iters = {iters};
+
+    var value: f32 = {identity};
+    var i = tid;
+    loop {{
+        if (i >= iters) {{
+            break;
+        }}
+        value = {combine_loop};
+        i = i + i32({workgroup_size});
+    }}
+
+    partials[local_id.x] = value;
+    workgroupBarrier();
+
+    var stride = {half_workgroup}u;
+    loop {{
+        if (stride == 0u) {{
+            break;
+        }}
+        if (local_id.x < stride) {{
+            partials[local_id.x] = {combine_reduce};
+        }}
+        workgroupBarrier();
+        stride = stride / 2u;
+    }}
+
+    if (local_id.x == 0u) {{
+        let block_value = partials[0u];
+        out[{out_idx}] = {out_val};
+    }}
+}}
+"#,
+                    workgroup_size = WORKGROUP_SIZE,
+                    half_workgroup = WORKGROUP_SIZE / 2,
+                    identity = $identity,
+                    combine_loop = ($combine)("value", &in_val),
+                    combine_reduce =
+                        ($combine)("partials[local_id.x]", "partials[local_id.x + stride]"),
+                    out_idx = buffer_index(&out_idx),
+                );
+                Some(compile_shader(device, &source, "main"))
+            }
+
+            fn output_size(&self) -> Expression {
+                self.out_shape
+                    .iter()
+                    .cloned()
+                    .product::<Expression>()
+                    .max(Expression::from(1))
+            }
+
+            fn encode_compute(
+                &self,
+                context: &mut WebGpuEncodeContext<'_>,
+                pipeline: &WebGpuPipeline,
+                inputs: &[&WebGpuBuffer],
+                output: &WebGpuBuffer,
+                _input_dtypes: &[DType],
+                _output_dtype: DType,
+            ) {
+                let n_outputs = self.output_size().exec(context.dyn_map).unwrap() as u32;
+                dispatch_workgroups(
+                    context,
+                    pipeline.get(0),
+                    &[inputs[0], output],
+                    n_outputs,
+                    n_outputs,
+                );
+            }
+
+            impl_reduce_metrics!(self, dyn_map);
+        }
+    };
+}
+
+webgpu_reduce_op!(
+    WebGpuSumReduce,
+    "WebGpuSum",
+    SumReduce,
+    "0.0",
+    |a: &str, b: &str| format!("({a}) + ({b})"),
+    1
+);
+
+webgpu_reduce_op!(
+    WebGpuMaxReduce,
+    "WebGpuMax",
+    MaxReduce,
+    "-3.4028234663852886e38",
+    |a: &str, b: &str| format!("max({a}, {b})"),
+    1
+);
+
+#[derive(Debug, Default, Clone)]
+pub struct WebGpuMatmul {
+    pub m: Expression,
+    pub n: Expression,
+    pub k: Expression,
+    pub lhs_row_stride: Expression,
+    pub rhs_row_stride: Expression,
+    pub out_row_stride: Expression,
+    pub transpose_lhs: bool,
+    pub transpose_rhs: bool,
+}
+
+impl EgglogOp for WebGpuMatmul {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "WebGpuMatmul",
+            &[
+                ("m", EXPRESSION),
+                ("n", EXPRESSION),
+                ("k", EXPRESSION),
+                ("lhs", IR),
+                ("lhs_row_stride", EXPRESSION),
+                ("rhs", IR),
+                ("rhs_row_stride", EXPRESSION),
+                ("out_row_stride", EXPRESSION),
+                ("transpose_lhs", I64),
+                ("transpose_rhs", I64),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        let zero = num(lit_i64(0));
+        let z = iter();
+        let expr_list = |terms: Vec<EggTerm>| {
+            terms
+                .into_iter()
+                .rev()
+                .fold(nil(), |tail, head| cons(head, tail))
+        };
+
+        let matmul_rule = |name: &'static str,
+                           lhs_layout: WebGpuMatrixLayout,
+                           rhs_layout: WebGpuMatrixLayout,
+                           transpose_lhs: i64,
+                           transpose_rhs: i64| {
+            let m = v("?m");
+            let n = v("?n");
+            let k = v("?k");
+            let lhs = v("?lhs");
+            let rhs = v("?rhs");
+            let lhs_row_stride = match lhs_layout {
+                WebGpuMatrixLayout::RowMajor => mul(k.clone(), z.clone()),
+                WebGpuMatrixLayout::TransposedRowMajor => mul(m.clone(), z.clone()),
+            };
+            let rhs_row_stride = match rhs_layout {
+                WebGpuMatrixLayout::RowMajor => mul(n.clone(), z.clone()),
+                WebGpuMatrixLayout::TransposedRowMajor => mul(k.clone(), z.clone()),
+            };
+            let lhs_strides = match lhs_layout {
+                WebGpuMatrixLayout::RowMajor => {
+                    vec![lhs_row_stride.clone(), zero.clone(), z.clone()]
+                }
+                WebGpuMatrixLayout::TransposedRowMajor => {
+                    vec![z.clone(), zero.clone(), lhs_row_stride.clone()]
+                }
+            };
+            let rhs_strides = match rhs_layout {
+                WebGpuMatrixLayout::RowMajor => {
+                    vec![zero.clone(), z.clone(), rhs_row_stride.clone()]
+                }
+                WebGpuMatrixLayout::TransposedRowMajor => {
+                    vec![zero.clone(), rhs_row_stride.clone(), z.clone()]
+                }
+            };
+            let out_row_stride = mul(n.clone(), z.clone());
+            let mul_output_strides = v("?webgpu_matmul_mul_output_strides");
+
+            let mul_op = op_term(
+                WebGpuMul::default().sort().call([
+                    (
+                        "shape",
+                        cons(m.clone(), cons(n.clone(), cons(k.clone(), nil()))),
+                    ),
+                    ("a_strides", expr_list(lhs_strides)),
+                    ("b_strides", expr_list(rhs_strides)),
+                    ("out_strides", mul_output_strides),
+                ]),
+                ilist(vec![lhs.clone(), rhs.clone()]),
+            );
+            let sum_op = op_term(
+                WebGpuSumReduce::default().sort().call([
+                    ("shape", cons(m.clone(), cons(n.clone(), nil()))),
+                    ("iters", k.clone()),
+                    ("strides", v("?webgpu_matmul_sum_in_strides")),
+                    ("iter_stride", z.clone()),
+                    (
+                        "out_strides",
+                        cons(out_row_stride.clone(), cons(z.clone(), nil())),
+                    ),
+                ]),
+                ilist(vec![mul_op.clone()]),
+            );
+            let matmul_op = WebGpuMatmul::default().sort().call([
+                ("m", m),
+                ("n", n),
+                ("k", k),
+                ("lhs", lhs),
+                ("lhs_row_stride", lhs_row_stride),
+                ("rhs", rhs),
+                ("rhs_row_stride", rhs_row_stride),
+                ("out_row_stride", out_row_stride),
+                ("transpose_lhs", lit_i64(transpose_lhs)),
+                ("transpose_rhs", lit_i64(transpose_rhs)),
+            ]);
+            let dt = v(format!("?{}_dt", name.replace('-', "_")));
+
+            rule(union(sum_op.clone(), matmul_op.clone()))
+                .set(dtype(matmul_op), dt.clone())
+                .fact(eq(dt, dtype(sum_op)))
+                .ruleset("kernel_lower")
+                .name(name)
+        };
+
+        vec![
+            matmul_rule(
+                "webgpu-matmul-row-row",
+                WebGpuMatrixLayout::RowMajor,
+                WebGpuMatrixLayout::RowMajor,
+                0,
+                0,
+            ),
+            matmul_rule(
+                "webgpu-matmul-row-transposed-rhs",
+                WebGpuMatrixLayout::RowMajor,
+                WebGpuMatrixLayout::TransposedRowMajor,
+                0,
+                1,
+            ),
+            matmul_rule(
+                "webgpu-matmul-transposed-lhs-row",
+                WebGpuMatrixLayout::TransposedRowMajor,
+                WebGpuMatrixLayout::RowMajor,
+                1,
+                0,
+            ),
+            matmul_rule(
+                "webgpu-matmul-transposed-lhs-transposed-rhs",
+                WebGpuMatrixLayout::TransposedRowMajor,
+                WebGpuMatrixLayout::TransposedRowMajor,
+                1,
+                1,
+            ),
+            Rule::raw(
+                "(rule
+                    ((= ?mul (Op (WebGpuMul ?shape ?as ?bs ?os) ?inputs))
+                     (= ?sum (Op (WebGpuSum ?sshape ?sk ?ssi ?sks ?sso) (ICons ?mul (INil))))
+                     (= ?sum (WebGpuMatmul ?m ?n ?k ?lhs ?lhsrs ?rhs ?rhsrs ?ors ?tl ?tr)))
+                    ((delete (Op (WebGpuSum ?sshape ?sk ?ssi ?sks ?sso) (ICons ?mul (INil))))
+                     (delete (Op (WebGpuMul ?shape ?as ?bs ?os) ?inputs)))
+                    :ruleset cleanup
+                    :name \"delete-broadcast-mul-sum-when-webgpu-matmul-exists\"
+                )",
+            ),
+        ]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::extract_expr;
+        let extract_flag = |node: &'a ENodeId| -> bool {
+            match egraph.enodes[node].0.as_str() {
+                "0" => false,
+                "1" => true,
+                other => panic!("invalid WebGpuMatmul transpose flag {other}"),
+            }
+        };
+
+        (
+            LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                m: extract_expr(egraph, kind_children[0], expr_cache).unwrap(),
+                n: extract_expr(egraph, kind_children[1], expr_cache).unwrap(),
+                k: extract_expr(egraph, kind_children[2], expr_cache).unwrap(),
+                lhs_row_stride: extract_expr(egraph, kind_children[4], expr_cache).unwrap(),
+                rhs_row_stride: extract_expr(egraph, kind_children[6], expr_cache).unwrap(),
+                out_row_stride: extract_expr(egraph, kind_children[7], expr_cache).unwrap(),
+                transpose_lhs: extract_flag(kind_children[8]),
+                transpose_rhs: extract_flag(kind_children[9]),
+            })),
+            vec![kind_children[3], kind_children[5]],
+        )
+    }
+}
+
+impl WebGpuKernelOp for WebGpuMatmul {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<WebGpuPipeline> {
+        let lhs_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
+        let rhs_dtype = input_dtypes.get(1).copied().unwrap_or(lhs_dtype);
+        let lhs_ty = webgpu_buffer_type(lhs_dtype);
+        let rhs_ty = webgpu_buffer_type(rhs_dtype);
+        let out_ty = webgpu_buffer_type(output_dtype);
+        let m = lower_scalar_expression_for_webgpu(&self.m);
+        let n = lower_scalar_expression_for_webgpu(&self.n);
+        let k = lower_scalar_expression_for_webgpu(&self.k);
+        let lhs_row_stride = lower_scalar_expression_for_webgpu(&self.lhs_row_stride);
+        let rhs_row_stride = lower_scalar_expression_for_webgpu(&self.rhs_row_stride);
+        let out_row_stride = lower_scalar_expression_for_webgpu(&self.out_row_stride);
+        let lhs_idx = if self.transpose_lhs {
+            format!("lhs_col * ({lhs_row_stride}) + row")
+        } else {
+            format!("row * ({lhs_row_stride}) + lhs_col")
+        };
+        let rhs_idx = if self.transpose_rhs {
+            format!("col * ({rhs_row_stride}) + rhs_row")
+        } else {
+            format!("rhs_row * ({rhs_row_stride}) + col")
+        };
+        let lhs_val = webgpu_numeric_read(lhs_dtype, "lhs", &lhs_idx);
+        let rhs_val = webgpu_numeric_read(rhs_dtype, "rhs", &rhs_idx);
+        let out_val = webgpu_numeric_write(output_dtype, "sum");
+        let prelude = shader_prelude();
+        let source = format!(
+            r#"
+{prelude}
+@group(0) @binding(0) var<storage, read> lhs: array<{lhs_ty}>;
+@group(0) @binding(1) var<storage, read> rhs: array<{rhs_ty}>;
+@group(0) @binding(2) var<storage, read_write> out: array<{out_ty}>;
+@group(0) @binding(3) var<storage, read> params: Params;
+
+var<workgroup> lhs_tile: array<array<f32, 16>, 16>;
+var<workgroup> rhs_tile: array<array<f32, 16>, 16>;
+
+@compute @workgroup_size(16, 16, 1)
+fn main(
+    @builtin(global_invocation_id) global_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>
+) {{
+    let col = i32(global_id.x);
+    let row = i32(global_id.y);
+    let lx = local_id.x;
+    let ly = local_id.y;
+    let m = {m};
+    let n = {n};
+    let k = {k};
+
+    var sum = 0.0;
+    var tile_start = 0;
+    loop {{
+        if (tile_start >= k) {{
+            break;
+        }}
+
+        let lhs_col = tile_start + i32(lx);
+        let rhs_row = tile_start + i32(ly);
+        var lhs_load = 0.0;
+        var rhs_load = 0.0;
+        if (row < m && lhs_col < k) {{
+            lhs_load = {lhs_val};
+        }}
+        if (rhs_row < k && col < n) {{
+            rhs_load = {rhs_val};
+        }}
+        lhs_tile[ly][lx] = lhs_load;
+        rhs_tile[ly][lx] = rhs_load;
+        workgroupBarrier();
+
+        var inner = 0u;
+        loop {{
+            if (inner >= 16u) {{
+                break;
+            }}
+            sum = sum + lhs_tile[ly][inner] * rhs_tile[inner][lx];
+            inner = inner + 1u;
+        }}
+        workgroupBarrier();
+        tile_start = tile_start + 16;
+    }}
+
+    if (row < m && col < n) {{
+        out[u32(row * ({out_row_stride}) + col)] = {out_val};
+    }}
+}}
+"#
+        );
+        Some(compile_shader(device, &source, "main"))
+    }
+
+    fn infer_output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        input_dtypes.first().copied().unwrap_or(DType::F32)
+    }
+
+    fn output_size(&self) -> Expression {
+        self.m * self.n
+    }
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        let m = self.m.exec(context.dyn_map).unwrap() as u32;
+        let n = self.n.exec(context.dyn_map).unwrap() as u32;
+        dispatch_2d(
+            context,
+            pipeline.get(0),
+            &[inputs[0], inputs[1], output],
+            m.saturating_mul(n),
+            n.div_ceil(16),
+            m.div_ceil(16),
+        );
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let m = self.m.exec(dyn_map).unwrap_or(0);
+        let n = self.n.exec(dyn_map).unwrap_or(0);
+        let k = self.k.exec(dyn_map).unwrap_or(0);
+        2 * m * n * k * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let m = self.m.exec(dyn_map).unwrap_or(0);
+        let n = self.n.exec(dyn_map).unwrap_or(0);
+        m * n * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let m = self.m.exec(dyn_map).unwrap_or(0);
+        let n = self.n.exec(dyn_map).unwrap_or(0);
+        let k = self.k.exec(dyn_map).unwrap_or(0);
+        2 * m * n * k
+    }
+
+    fn is_matmul(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct GenericMatmul {
+    pub out_shape: Vec<Expression>,
+    pub mul_shape: Vec<Expression>,
+    pub k: Expression,
+    pub lhs_strides: Vec<Expression>,
+    pub rhs_strides: Vec<Expression>,
+    pub sum_input_strides: Vec<Expression>,
+    pub sum_iter_stride: Expression,
+    pub out_strides: Vec<Expression>,
+}
+
+impl EgglogOp for GenericMatmul {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "GenericMatmul",
+            &[
+                ("out_shape", ELIST),
+                ("mul_shape", ELIST),
+                ("k", EXPRESSION),
+                ("lhs", IR),
+                ("lhs_strides", ELIST),
+                ("rhs", IR),
+                ("rhs_strides", ELIST),
+                ("sum_input_strides", ELIST),
+                ("sum_iter_stride", EXPRESSION),
+                ("out_strides", ELIST),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        let mul_shape = v("?generic_matmul_mul_shape");
+        let out_shape = v("?generic_matmul_out_shape");
+        let k = v("?generic_matmul_k");
+        let lhs = v("?generic_matmul_lhs");
+        let rhs = v("?generic_matmul_rhs");
+        let lhs_strides = v("?generic_matmul_lhs_strides");
+        let rhs_strides = v("?generic_matmul_rhs_strides");
+        let mul_output_strides = v("?generic_matmul_mul_output_strides");
+        let sum_input_strides = v("?generic_matmul_sum_input_strides");
+        let sum_iter_stride = v("?generic_matmul_sum_iter_stride");
+        let out_strides = v("?generic_matmul_out_strides");
+
+        let mul_op = op_term(
+            WebGpuMul::default().sort().call([
+                ("shape", mul_shape.clone()),
+                ("a_strides", lhs_strides.clone()),
+                ("b_strides", rhs_strides.clone()),
+                ("out_strides", mul_output_strides),
+            ]),
+            ilist(vec![lhs.clone(), rhs.clone()]),
+        );
+        let sum_op = op_term(
+            WebGpuSumReduce::default().sort().call([
+                ("shape", out_shape.clone()),
+                ("iters", k.clone()),
+                ("strides", sum_input_strides.clone()),
+                ("iter_stride", sum_iter_stride.clone()),
+                ("out_strides", out_strides.clone()),
+            ]),
+            ilist(vec![mul_op.clone()]),
+        );
+        let generic_op = GenericMatmul::default().sort().call([
+            ("out_shape", out_shape),
+            ("mul_shape", mul_shape),
+            ("k", k),
+            ("lhs", lhs),
+            ("lhs_strides", lhs_strides),
+            ("rhs", rhs),
+            ("rhs_strides", rhs_strides),
+            ("sum_input_strides", sum_input_strides),
+            ("sum_iter_stride", sum_iter_stride),
+            ("out_strides", out_strides),
+        ]);
+        let dt = v("?generic_matmul_dt");
+
+        vec![
+            rule(union(sum_op.clone(), generic_op.clone()))
+                .set(dtype(generic_op.clone()), dt.clone())
+                .fact(eq(dt, dtype(sum_op)))
+                .ruleset("matmul_backend")
+                .name("generic-matmul-webgpu-mul-sum"),
+            Rule::raw(
+                "(rule
+                    ((= ?mul (Op (WebGpuMul ?shape ?as ?bs ?os) ?inputs))
+                     (= ?sum (Op (WebGpuSum ?sshape ?sk ?ssi ?sks ?sso) (ICons ?mul (INil))))
+                     (= ?sum (GenericMatmul ?go ?gm ?gk ?gl ?glas ?gr ?grs ?gsis ?gsit ?gos)))
+                    ((delete (Op (WebGpuSum ?sshape ?sk ?ssi ?sks ?sso) (ICons ?mul (INil))))
+                     (delete (Op (WebGpuMul ?shape ?as ?bs ?os) ?inputs)))
+                    :ruleset cleanup
+                    :name \"delete-broadcast-mul-sum-when-webgpu-generic-matmul-exists\"
+                )",
+            ),
+        ]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::{extract_expr, extract_expr_list};
+        (
+            LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                out_shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache)
+                    .unwrap(),
+                mul_shape: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                k: extract_expr(egraph, kind_children[2], expr_cache).unwrap(),
+                lhs_strides: extract_expr_list(egraph, kind_children[4], list_cache, expr_cache)
+                    .unwrap(),
+                rhs_strides: extract_expr_list(egraph, kind_children[6], list_cache, expr_cache)
+                    .unwrap(),
+                sum_input_strides: extract_expr_list(
+                    egraph,
+                    kind_children[7],
+                    list_cache,
+                    expr_cache,
+                )
+                .unwrap(),
+                sum_iter_stride: extract_expr(egraph, kind_children[8], expr_cache).unwrap(),
+                out_strides: extract_expr_list(egraph, kind_children[9], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            vec![kind_children[3], kind_children[5]],
+        )
+    }
+}
+
+impl WebGpuKernelOp for GenericMatmul {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<WebGpuPipeline> {
+        let lhs_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
+        let rhs_dtype = input_dtypes.get(1).copied().unwrap_or(lhs_dtype);
+        let lhs_ty = webgpu_buffer_type(lhs_dtype);
+        let rhs_ty = webgpu_buffer_type(rhs_dtype);
+        let out_ty = webgpu_buffer_type(output_dtype);
+        let sum_base_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.out_shape, &self.sum_input_strides),
+            "gid",
+        );
+        let iter_offset = lower_expression_for_webgpu(&self.sum_iter_stride, "i");
+        let lhs_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.mul_shape, &self.lhs_strides),
+            "mul_idx",
+        );
+        let rhs_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.mul_shape, &self.rhs_strides),
+            "mul_idx",
+        );
+        let out_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.out_shape, &self.out_strides),
+            "gid",
+        );
+        let iters = lower_expression_for_webgpu(&self.k, "gid");
+        let lhs_val = webgpu_numeric_read(lhs_dtype, "lhs", &lhs_idx);
+        let rhs_val = webgpu_numeric_read(rhs_dtype, "rhs", &rhs_idx);
+        let out_val = webgpu_numeric_write(output_dtype, "block_sum");
+        let prelude = shader_prelude();
+        let source = format!(
+            r#"
+{prelude}
+@group(0) @binding(0) var<storage, read> lhs: array<{lhs_ty}>;
+@group(0) @binding(1) var<storage, read> rhs: array<{rhs_ty}>;
+@group(0) @binding(2) var<storage, read_write> out: array<{out_ty}>;
+@group(0) @binding(3) var<storage, read> params: Params;
+
+var<workgroup> partials: array<f32, {workgroup_size}>;
+
+@compute @workgroup_size({workgroup_size})
+fn main(
+    @builtin(workgroup_id) workgroup_id: vec3<u32>,
+    @builtin(local_invocation_id) local_id: vec3<u32>
+) {{
+    let gid = i32(workgroup_id.x) + params.offset;
+    if (gid >= params.n) {{
+        return;
+    }}
+    let tid = i32(local_id.x);
+    let base_idx = {sum_base_idx};
+    let iters = {iters};
+
+    var sum = 0.0;
+    var i = tid;
+    loop {{
+        if (i >= iters) {{
+            break;
+        }}
+        let mul_idx = base_idx + {iter_offset};
+        sum = sum + ({lhs_val}) * ({rhs_val});
+        i = i + i32({workgroup_size});
+    }}
+
+    partials[local_id.x] = sum;
+    workgroupBarrier();
+
+    var stride = {half_workgroup}u;
+    loop {{
+        if (stride == 0u) {{
+            break;
+        }}
+        if (local_id.x < stride) {{
+            partials[local_id.x] = partials[local_id.x] + partials[local_id.x + stride];
+        }}
+        workgroupBarrier();
+        stride = stride / 2u;
+    }}
+
+    if (local_id.x == 0u) {{
+        let block_sum = partials[0u];
+        out[{out_idx}] = {out_val};
+    }}
+}}
+"#,
+            workgroup_size = WORKGROUP_SIZE,
+            half_workgroup = WORKGROUP_SIZE / 2,
+            out_idx = buffer_index(&out_idx),
+        );
+        Some(compile_shader(device, &source, "main"))
+    }
+
+    fn infer_output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        input_dtypes.first().copied().unwrap_or(DType::F32)
+    }
+
+    fn output_size(&self) -> Expression {
+        self.out_shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        let n_outputs = self.output_size().exec(context.dyn_map).unwrap() as u32;
+        dispatch_workgroups(
+            context,
+            pipeline.get(0),
+            &[inputs[0], inputs[1], output],
+            n_outputs,
+            n_outputs,
+        );
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n_outputs = self.output_size().exec(dyn_map).unwrap_or(0);
+        let k = self.k.exec(dyn_map).unwrap_or(0);
+        2 * n_outputs * k * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+
+    fn flops(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n_outputs = self.output_size().exec(dyn_map).unwrap_or(0);
+        let k = self.k.exec(dyn_map).unwrap_or(0);
+        2 * n_outputs * k
+    }
+
+    fn is_matmul(&self) -> bool {
+        true
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct WebGpuConstant {
+    value: f32,
+}
+
+impl EgglogOp for WebGpuConstant {
+    fn sort(&self) -> SortDef {
+        sort(IR, "WebGpuConstant", &[("value", F64)])
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        let (args, const_match) = new_op_call(&Constant::default().sort(), &[]);
+        let webgpu_op = call_sort_from_args(&self.sort(), &args);
+        vec![
+            rule(union(const_match.clone(), webgpu_op.clone()))
+                .subsume(const_match)
+                .set(dtype(webgpu_op), app(&SORTS.f32_dt, vec![]))
+                .ruleset("kernel_lower"),
+        ]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        _: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        (
+            LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                value: egraph.enodes[children[0]]
+                    .0
+                    .replace('"', "")
+                    .parse::<f32>()
+                    .unwrap(),
+            })),
+            vec![],
+        )
+    }
+}
+
+impl WebGpuKernelOp for WebGpuConstant {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) -> Option<WebGpuPipeline> {
+        let value = if self.value.fract() == 0.0 {
+            format!("{:.1}", self.value)
+        } else {
+            self.value.to_string()
+        };
+        let prelude = shader_prelude();
+        let source = format!(
+            r#"
+{prelude}
+@group(0) @binding(0) var<storage, read_write> out: array<f32>;
+@group(0) @binding(1) var<storage, read> params: Params;
+
+@compute @workgroup_size(1)
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {{
+    if (global_id.x == 0u && params.n > 0) {{
+        out[0u] = {value};
+    }}
+}}
+"#
+        );
+        Some(compile_shader(device, &source, "main"))
+    }
+
+    fn output_size(&self) -> Expression {
+        Expression::from(1)
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        DType::F32
+    }
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        _inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        dispatch_workgroups(context, pipeline.get(0), &[output], 1, 1);
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct WebGpuIota {
+    expr: Expression,
+    range: Expression,
+}
+
+impl EgglogOp for WebGpuIota {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "WebGpuIota",
+            &[("expr", EXPRESSION), ("range", EXPRESSION)],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        let (args, iota_match) = new_op_call(&Iota::default().sort(), &[]);
+        let webgpu_op = call_sort_from_args(&self.sort(), &args);
+        vec![
+            rule(union(iota_match.clone(), webgpu_op.clone()))
+                .subsume(iota_match)
+                .set(dtype(webgpu_op), app(&SORTS.int_dt, vec![]))
+                .ruleset("kernel_lower"),
+        ]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::extract_expr;
+        (
+            LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                expr: extract_expr(egraph, children[0], expr_cache).unwrap(),
+                range: extract_expr(egraph, children[1], expr_cache).unwrap(),
+            })),
+            vec![],
+        )
+    }
+}
+
+impl WebGpuKernelOp for WebGpuIota {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) -> Option<WebGpuPipeline> {
+        let expr_code = lower_expression_for_webgpu(&self.expr, "idx");
+        let prelude = shader_prelude();
+        let source = format!(
+            r#"
+{prelude}
+@group(0) @binding(0) var<storage, read_write> out: array<i32>;
+@group(0) @binding(1) var<storage, read> params: Params;
+
+@compute @workgroup_size({workgroup_size})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {{
+    let idx = i32(global_id.x) + params.offset;
+    if (idx < params.n) {{
+        out[u32(idx)] = {expr_code};
+    }}
+}}
+"#,
+            workgroup_size = WORKGROUP_SIZE,
+        );
+        Some(compile_shader(device, &source, "main"))
+    }
+
+    fn output_size(&self) -> Expression {
+        self.range
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        DType::Int
+    }
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        _inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        let n_elements = self.range.exec(context.dyn_map).unwrap() as u32;
+        dispatch_1d(context, pipeline.get(0), &[output], n_elements);
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct WebGpuGather {
+    out_shape: Vec<Expression>,
+    index_stride: Vec<Expression>,
+    data_shape: Vec<Expression>,
+    data_stride: Vec<Expression>,
+    out_stride: Vec<Expression>,
+}
+
+impl EgglogOp for WebGpuGather {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "WebGpuGather",
+            &[
+                ("out_shape", ELIST),
+                ("indexes", IR),
+                ("index_strides", ELIST),
+                ("data", IR),
+                ("data_shape", ELIST),
+                ("data_strides", ELIST),
+                ("out_strides", ELIST),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        let (gather_args, gather_match) =
+            new_op_call(&Gather::default().sort(), &["indexes", "data"]);
+        let out_strides = SORTS
+            .row_major
+            .call([("list".to_string(), gather_args["index_shape"].clone())]);
+        let dt = v("?__dt");
+        let webgpu_args = [
+            ("out_shape".to_string(), gather_args["index_shape"].clone()),
+            ("indexes".to_string(), gather_args["indexes"].clone()),
+            (
+                "index_strides".to_string(),
+                gather_args["index_strides"].clone(),
+            ),
+            ("data".to_string(), gather_args["data"].clone()),
+            ("data_shape".to_string(), gather_args["data_shape"].clone()),
+            (
+                "data_strides".to_string(),
+                gather_args["data_strides"].clone(),
+            ),
+            ("out_strides".to_string(), out_strides),
+        ];
+        let webgpu_op = self.sort().call(webgpu_args);
+        vec![
+            rule(union(gather_match.clone(), webgpu_op.clone()))
+                .subsume(gather_match)
+                .set(dtype(webgpu_op), dt.clone())
+                .fact(eq(dt, dtype(gather_args["data"].clone())))
+                .ruleset("kernel_lower"),
+        ]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::extract_expr_list;
+        (
+            LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                out_shape: extract_expr_list(egraph, children[0], list_cache, expr_cache).unwrap(),
+                index_stride: extract_expr_list(egraph, children[2], list_cache, expr_cache)
+                    .unwrap(),
+                data_shape: extract_expr_list(egraph, children[4], list_cache, expr_cache).unwrap(),
+                data_stride: extract_expr_list(egraph, children[5], list_cache, expr_cache)
+                    .unwrap(),
+                out_stride: extract_expr_list(egraph, children[6], list_cache, expr_cache).unwrap(),
+            })),
+            vec![children[1], children[3]],
+        )
+    }
+}
+
+impl WebGpuKernelOp for WebGpuGather {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<WebGpuPipeline> {
+        let data_dtype = input_dtypes.get(1).copied().unwrap_or(DType::F32);
+        let data_ty = webgpu_buffer_type(data_dtype);
+        let out_ty = webgpu_buffer_type(output_dtype);
+        let out_idx =
+            lower_expression_for_webgpu(&flatten_strides(&self.out_shape, &self.out_stride), "idx");
+        let index_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.out_shape, &self.index_stride),
+            "idx",
+        );
+        let data_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.data_shape, &self.data_stride),
+            "gathered_index",
+        );
+        let gathered_val = webgpu_copy_value(data_dtype, "data", &data_idx);
+        let prelude = shader_prelude();
+        let source = format!(
+            r#"
+{prelude}
+@group(0) @binding(0) var<storage, read> indexes: array<i32>;
+@group(0) @binding(1) var<storage, read> data: array<{data_ty}>;
+@group(0) @binding(2) var<storage, read_write> out: array<{out_ty}>;
+@group(0) @binding(3) var<storage, read> params: Params;
+
+@compute @workgroup_size({workgroup_size})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {{
+    let idx = i32(global_id.x) + params.offset;
+    if (idx < params.n) {{
+        let gathered_index = indexes[{index_idx}];
+        out[{out_idx}] = {gathered_val};
+    }}
+}}
+"#,
+            index_idx = buffer_index(&index_idx),
+            out_idx = buffer_index(&out_idx),
+            workgroup_size = WORKGROUP_SIZE,
+        );
+        Some(compile_shader(device, &source, "main"))
+    }
+
+    fn output_size(&self) -> Expression {
+        self.out_shape
+            .iter()
+            .cloned()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn infer_output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        input_dtypes.get(1).copied().unwrap_or(DType::F32)
+    }
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        let n_elements = self.output_size().exec(context.dyn_map).unwrap() as u32;
+        dispatch_1d(
+            context,
+            pipeline.get(0),
+            &[inputs[0], inputs[1], output],
+            n_elements,
+        );
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n = self.output_size().exec(dyn_map).unwrap_or(0);
+        n * std::mem::size_of::<i32>() + n * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct WebGpuScatter {
+    dest_shape: Vec<Expression>,
+    dest_strides: Vec<Expression>,
+    index_shape: Vec<Expression>,
+    index_strides: Vec<Expression>,
+    src_strides: Vec<Expression>,
+    out_strides: Vec<Expression>,
+}
+
+impl EgglogOp for WebGpuScatter {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "WebGpuScatter",
+            &[
+                ("dest_shape", ELIST),
+                ("dest_strides", ELIST),
+                ("dest", IR),
+                ("indexes", IR),
+                ("index_shape", ELIST),
+                ("index_strides", ELIST),
+                ("src", IR),
+                ("src_strides", ELIST),
+                ("out_strides", ELIST),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        let (scatter_args, scatter_match) =
+            new_op_call(&Scatter::default().sort(), &["dest", "indexes", "src"]);
+        let out_strides = SORTS
+            .row_major
+            .call([("list".to_string(), scatter_args["dest_shape"].clone())]);
+        let dt = v("?__dt");
+        let webgpu_args = [
+            ("dest_shape".to_string(), scatter_args["dest_shape"].clone()),
+            (
+                "dest_strides".to_string(),
+                scatter_args["dest_strides"].clone(),
+            ),
+            ("dest".to_string(), scatter_args["dest"].clone()),
+            ("indexes".to_string(), scatter_args["indexes"].clone()),
+            (
+                "index_shape".to_string(),
+                scatter_args["index_shape"].clone(),
+            ),
+            (
+                "index_strides".to_string(),
+                scatter_args["index_strides"].clone(),
+            ),
+            ("src".to_string(), scatter_args["src"].clone()),
+            (
+                "src_strides".to_string(),
+                scatter_args["src_strides"].clone(),
+            ),
+            ("out_strides".to_string(), out_strides),
+        ];
+        let webgpu_op = self.sort().call(webgpu_args);
+        vec![
+            rule(union(scatter_match.clone(), webgpu_op.clone()))
+                .subsume(scatter_match)
+                .set(dtype(webgpu_op), dt.clone())
+                .fact(eq(dt, dtype(scatter_args["src"].clone())))
+                .ruleset("kernel_lower"),
+        ]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::extract_expr_list;
+        (
+            LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                dest_shape: extract_expr_list(egraph, children[0], list_cache, expr_cache).unwrap(),
+                dest_strides: extract_expr_list(egraph, children[1], list_cache, expr_cache)
+                    .unwrap(),
+                index_shape: extract_expr_list(egraph, children[4], list_cache, expr_cache)
+                    .unwrap(),
+                index_strides: extract_expr_list(egraph, children[5], list_cache, expr_cache)
+                    .unwrap(),
+                src_strides: extract_expr_list(egraph, children[7], list_cache, expr_cache)
+                    .unwrap(),
+                out_strides: extract_expr_list(egraph, children[8], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            vec![children[2], children[3], children[6]],
+        )
+    }
+}
+
+impl WebGpuKernelOp for WebGpuScatter {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<WebGpuPipeline> {
+        let dest_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
+        let src_dtype = input_dtypes.get(2).copied().unwrap_or(output_dtype);
+        let dest_ty = webgpu_buffer_type(dest_dtype);
+        let src_ty = webgpu_buffer_type(src_dtype);
+        let out_ty = webgpu_buffer_type(output_dtype);
+        let dest_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.dest_shape, &self.dest_strides),
+            "idx",
+        );
+        let out_copy_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.dest_shape, &self.out_strides),
+            "idx",
+        );
+        let index_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.index_shape, &self.index_strides),
+            "idx",
+        );
+        let src_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.index_shape, &self.src_strides),
+            "idx",
+        );
+        let prelude = shader_prelude();
+        let copy_source = format!(
+            r#"
+{prelude}
+@group(0) @binding(0) var<storage, read_write> out: array<{out_ty}>;
+@group(0) @binding(1) var<storage, read> dest: array<{dest_ty}>;
+@group(0) @binding(2) var<storage, read> params: Params;
+
+@compute @workgroup_size({workgroup_size})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {{
+    let idx = i32(global_id.x) + params.offset;
+    if (idx < params.n) {{
+        out[{out_copy_idx}] = dest[{dest_idx}];
+    }}
+}}
+"#,
+            out_copy_idx = buffer_index(&out_copy_idx),
+            dest_idx = buffer_index(&dest_idx),
+            workgroup_size = WORKGROUP_SIZE,
+        );
+        let prelude = shader_prelude();
+        let scatter_source = format!(
+            r#"
+{prelude}
+@group(0) @binding(0) var<storage, read_write> out: array<{out_ty}>;
+@group(0) @binding(1) var<storage, read> indexes: array<i32>;
+@group(0) @binding(2) var<storage, read> src: array<{src_ty}>;
+@group(0) @binding(3) var<storage, read> params: Params;
+
+@compute @workgroup_size({workgroup_size})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {{
+    let idx = i32(global_id.x) + params.offset;
+    if (idx < params.n) {{
+        let scatter_idx = indexes[{index_idx}];
+        out[u32(scatter_idx)] = src[{src_idx}];
+    }}
+}}
+"#,
+            index_idx = buffer_index(&index_idx),
+            src_idx = buffer_index(&src_idx),
+            workgroup_size = WORKGROUP_SIZE,
+        );
+        Some(WebGpuPipeline::new(vec![
+            compile_shader_raw(device, &copy_source, "main"),
+            compile_shader_raw(device, &scatter_source, "main"),
+        ]))
+    }
+
+    fn output_size(&self) -> Expression {
+        self.dest_shape
+            .iter()
+            .cloned()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        let n_dest = self
+            .dest_shape
+            .iter()
+            .cloned()
+            .product::<Expression>()
+            .exec(context.dyn_map)
+            .unwrap() as u32;
+        let n_src = self
+            .index_shape
+            .iter()
+            .cloned()
+            .product::<Expression>()
+            .exec(context.dyn_map)
+            .unwrap() as u32;
+        dispatch_1d(context, pipeline.get(0), &[output, inputs[0]], n_dest);
+        dispatch_1d(
+            context,
+            pipeline.get(1),
+            &[output, inputs[1], inputs[2]],
+            n_src,
+        );
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        let n_dest = self.output_size().exec(dyn_map).unwrap_or(0);
+        let n_src = self
+            .index_shape
+            .iter()
+            .cloned()
+            .product::<Expression>()
+            .exec(dyn_map)
+            .unwrap_or(0);
+        n_dest * std::mem::size_of::<f32>()
+            + n_src * std::mem::size_of::<i32>()
+            + n_src * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.output_size().exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+#[allow(dead_code)]
+pub struct WebGpuScatterNoCopy {
+    dest_shape: Vec<Expression>,
+    dest_strides: Vec<Expression>,
+    index_shape: Vec<Expression>,
+    index_strides: Vec<Expression>,
+    src_strides: Vec<Expression>,
+    out_strides: Vec<Expression>,
+}
+
+impl EgglogOp for WebGpuScatterNoCopy {
+    fn sort(&self) -> SortDef {
+        sort(
+            luminal::egglog_utils::base::OP_KIND,
+            "WebGpuScatterNoCopy",
+            &[
+                ("dest_shape", ELIST),
+                ("dest_strides", ELIST),
+                ("index_shape", ELIST),
+                ("index_strides", ELIST),
+                ("src_strides", ELIST),
+                ("out_strides", ELIST),
+            ],
+        )
+    }
+
+    fn ir_defs(&self) -> Vec<String> {
+        vec!["(ConsumedBuffer IR)".to_string()]
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![
+            Rule::raw("(relation webgpu_consumed_buffer_ilist_contains (IList IR))"),
+            Rule::raw(
+                "(rule
+                    ((= ?list (ICons ?head ?tail)))
+                    ((webgpu_consumed_buffer_ilist_contains ?list ?head))
+                    :ruleset cleanup
+                    :name \"webgpu-consumed-buffer-ilist-contains-head\"
+                )",
+            ),
+            Rule::raw(
+                "(rule
+                    ((= ?list (ICons ?head ?tail))
+                     (webgpu_consumed_buffer_ilist_contains ?tail ?item))
+                    ((webgpu_consumed_buffer_ilist_contains ?list ?item))
+                    :ruleset cleanup
+                    :name \"webgpu-consumed-buffer-ilist-contains-tail\"
+                )",
+            ),
+            Rule::raw(
+                "(rule
+                    ((= ?scatter (WebGpuScatter ?ds ?dst ?dest ?indexes ?is ?istr ?src ?ss ?os))
+                     (= ?dst ?os)
+                     (= ?dt (dtype ?src)))
+                    ((let ?consumed (ConsumedBuffer ?dest))
+                     (let ?nocopy (Op (WebGpuScatterNoCopy ?ds ?dst ?is ?istr ?ss ?os)
+                         (ICons ?consumed (ICons ?indexes (ICons ?src (INil))))))
+                     (union ?scatter ?nocopy)
+                     (set (dtype ?nocopy) ?dt))
+                    :ruleset buffer_reuse
+                    :name \"webgpu-scatter-to-scatter-no-copy\"
+                )",
+            ),
+            Rule::raw(
+                "(rule
+                    ((= ?cb (ConsumedBuffer ?a))
+                     (= ?dt (dtype ?a)))
+                    ((set (dtype ?cb) ?dt))
+                    :ruleset dtype_prop
+                    :name \"webgpu-consumed-buffer-dtype\"
+                )",
+            ),
+            Rule::raw(
+                "(rule
+                    ((= ?cb (ConsumedBuffer ?a))
+                     (= ?op1 (Op ?k1 ?ilist1))
+                     (webgpu_consumed_buffer_ilist_contains ?ilist1 ?cb)
+                     (= ?op2 (Op ?k2 ?ilist2))
+                     (!= ?op1 ?op2)
+                     (webgpu_consumed_buffer_ilist_contains ?ilist2 ?a))
+                    ((delete (ConsumedBuffer ?a)))
+                    :ruleset cleanup
+                    :name \"webgpu-consumed-buffer-cleanup-shared-op-use\"
+                )",
+            ),
+            Rule::raw(
+                "(rule
+                    ((= ?cb (ConsumedBuffer ?dest))
+                     (= ?scatter (WebGpuScatter ?ds ?dst ?dest ?indexes ?is ?istr ?src ?ss ?os))
+                     (= ?nocopy (Op (WebGpuScatterNoCopy ?ds ?dst ?is ?istr ?ss ?os)
+                         (ICons ?cb (ICons ?indexes (ICons ?src (INil)))))))
+                    ((subsume (WebGpuScatter ?ds ?dst ?dest ?indexes ?is ?istr ?src ?ss ?os)))
+                    :ruleset post_cleanup
+                    :name \"webgpu-scatter-no-copy-dominates-valid-consumed-buffer\"
+                )",
+            ),
+            Rule::raw(
+                "(rule
+                    ((= ?cb (ConsumedBuffer ?a)))
+                    ((union ?cb ?a)
+                     (delete (ConsumedBuffer ?a)))
+                    :ruleset base_cleanup
+                    :name \"webgpu-consumed-buffer-resolve\"
+                )",
+            ),
+        ]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::extract_expr_list;
+        (
+            LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                dest_shape: extract_expr_list(egraph, kind_children[0], list_cache, expr_cache)
+                    .unwrap(),
+                dest_strides: extract_expr_list(egraph, kind_children[1], list_cache, expr_cache)
+                    .unwrap(),
+                index_shape: extract_expr_list(egraph, kind_children[2], list_cache, expr_cache)
+                    .unwrap(),
+                index_strides: extract_expr_list(egraph, kind_children[3], list_cache, expr_cache)
+                    .unwrap(),
+                src_strides: extract_expr_list(egraph, kind_children[4], list_cache, expr_cache)
+                    .unwrap(),
+                out_strides: extract_expr_list(egraph, kind_children[5], list_cache, expr_cache)
+                    .unwrap(),
+            })),
+            input_enodes,
+        )
+    }
+}
+
+impl WebGpuKernelOp for WebGpuScatterNoCopy {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<WebGpuPipeline> {
+        let src_dtype = input_dtypes.get(2).copied().unwrap_or(output_dtype);
+        let src_ty = webgpu_buffer_type(src_dtype);
+        let out_ty = webgpu_buffer_type(output_dtype);
+        let index_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.index_shape, &self.index_strides),
+            "idx",
+        );
+        let src_idx = lower_expression_for_webgpu(
+            &flatten_strides(&self.index_shape, &self.src_strides),
+            "idx",
+        );
+        let prelude = shader_prelude();
+        let source = format!(
+            r#"
+{prelude}
+@group(0) @binding(0) var<storage, read_write> out: array<{out_ty}>;
+@group(0) @binding(1) var<storage, read> indexes: array<i32>;
+@group(0) @binding(2) var<storage, read> src: array<{src_ty}>;
+@group(0) @binding(3) var<storage, read> params: Params;
+
+@compute @workgroup_size({workgroup_size})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {{
+    let idx = i32(global_id.x) + params.offset;
+    if (idx < params.n) {{
+        let scatter_idx = indexes[{index_idx}];
+        out[u32(scatter_idx)] = src[{src_idx}];
+    }}
+}}
+"#,
+            index_idx = buffer_index(&index_idx),
+            src_idx = buffer_index(&src_idx),
+            workgroup_size = WORKGROUP_SIZE,
+        );
+        Some(compile_shader(device, &source, "main"))
+    }
+
+    fn infer_output_dtype(&self, input_dtypes: &[DType]) -> DType {
+        input_dtypes.first().copied().unwrap_or(DType::F32)
+    }
+
+    fn output_size(&self) -> Expression {
+        self.dest_shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .max(Expression::from(1))
+    }
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        let n_src = self
+            .index_shape
+            .iter()
+            .copied()
+            .product::<Expression>()
+            .exec(context.dyn_map)
+            .unwrap() as u32;
+        dispatch_1d(
+            context,
+            pipeline.get(0),
+            &[output, inputs[1], inputs[2]],
+            n_src,
+        );
+    }
+
+    fn output_aliases_input(&self) -> Option<usize> {
+        Some(0)
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct WebGpuCast {
+    size: Expression,
+    target_dtype: DType,
+}
+
+impl EgglogOp for WebGpuCast {
+    fn sort(&self) -> SortDef {
+        sort(
+            IR,
+            "WebGpuCast",
+            &[("inp", IR), ("size", EXPRESSION), ("dtype", DTYPE)],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        let (args, cast_match) = new_op_call(&Cast::default().sort(), &["inp"]);
+        let webgpu_op = call_sort_from_args(&self.sort(), &args);
+        vec![
+            rule(union(cast_match.clone(), webgpu_op.clone()))
+                .subsume(cast_match)
+                .set(dtype(webgpu_op), args["dtype"].clone())
+                .ruleset("kernel_lower"),
+        ]
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        children: &[&'a ENodeId],
+        _input_enodes: Vec<&'a ENodeId>,
+        _list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        use luminal::egglog_utils::{extract_dtype, extract_expr};
+        (
+            LLIROp::new::<dyn WebGpuKernelOp>(Box::new(Self {
+                size: extract_expr(egraph, children[1], expr_cache).unwrap(),
+                target_dtype: extract_dtype(egraph, children[2]),
+            })),
+            vec![children[0]],
+        )
+    }
+}
+
+impl WebGpuKernelOp for WebGpuCast {
+    fn compile(
+        &self,
+        device: &wgpu::Device,
+        input_dtypes: &[DType],
+        output_dtype: DType,
+    ) -> Option<WebGpuPipeline> {
+        let input_dtype = input_dtypes.first().copied().unwrap_or(DType::F32);
+        let input_ty = webgpu_buffer_type(input_dtype);
+        let output_ty = webgpu_buffer_type(output_dtype);
+        let cast_expr = match (input_dtype, output_dtype) {
+            (DType::F32 | DType::TF32, DType::F32 | DType::TF32) | (DType::Int, DType::Int) => {
+                "inp[u32(idx)]".to_string()
+            }
+            (DType::F32 | DType::TF32, DType::Int) => "i32(inp[u32(idx)])".to_string(),
+            (DType::Int, DType::F32 | DType::TF32) => "f32(inp[u32(idx)])".to_string(),
+            _ => panic!(
+                "WebGpuCast does not support runtime cast from {input_dtype:?} to {output_dtype:?}"
+            ),
+        };
+        let prelude = shader_prelude();
+        let source = format!(
+            r#"
+{prelude}
+@group(0) @binding(0) var<storage, read> inp: array<{input_ty}>;
+@group(0) @binding(1) var<storage, read_write> out: array<{output_ty}>;
+@group(0) @binding(2) var<storage, read> params: Params;
+
+@compute @workgroup_size({workgroup_size})
+fn main(@builtin(global_invocation_id) global_id: vec3<u32>) {{
+    let idx = i32(global_id.x) + params.offset;
+    if (idx < params.n) {{
+        out[u32(idx)] = {cast_expr};
+    }}
+}}
+"#,
+            workgroup_size = WORKGROUP_SIZE,
+        );
+        Some(compile_shader(device, &source, "main"))
+    }
+
+    fn output_size(&self) -> Expression {
+        self.size
+    }
+
+    fn infer_output_dtype(&self, _input_dtypes: &[DType]) -> DType {
+        self.target_dtype
+    }
+
+    fn encode_compute(
+        &self,
+        context: &mut WebGpuEncodeContext<'_>,
+        pipeline: &WebGpuPipeline,
+        inputs: &[&WebGpuBuffer],
+        output: &WebGpuBuffer,
+        _input_dtypes: &[DType],
+        _output_dtype: DType,
+    ) {
+        let n_elements = self.size.exec(context.dyn_map).unwrap_or(0) as u32;
+        dispatch_1d(context, pipeline.get(0), &[inputs[0], output], n_elements);
+    }
+
+    fn bytes_loaded(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.size.exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+
+    fn bytes_stored(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.size.exec(dyn_map).unwrap_or(0) * std::mem::size_of::<f32>()
+    }
+}

--- a/crates/luminal_webgpu/src/lib.rs
+++ b/crates/luminal_webgpu/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod dyn_backend;
+pub mod kernel;
+mod memory_analysis;
+pub mod runtime;
+
+#[cfg(test)]
+mod tests;
+
+pub use runtime::{WebGpuBuffer, WebGpuRuntime};
+
+// Re-export kernel ops
+pub use kernel::WebGpuOps;

--- a/crates/luminal_webgpu/src/memory_analysis.rs
+++ b/crates/luminal_webgpu/src/memory_analysis.rs
@@ -1,0 +1,1456 @@
+#![allow(dead_code)]
+
+use std::sync::Arc;
+
+use itertools::Itertools;
+use luminal::{
+    dtype::DType,
+    egglog_utils::{
+        ClassId, EGraphChoiceSet, LateEgglogPass, NodeId, SerializedEGraph, api::SortDef,
+        extract_dtype, extract_expr, extract_expr_list,
+    },
+    op::EgglogOp,
+    prelude::*,
+};
+
+const MEMORY_ANALYSIS_RULESET: &str = "webgpu_memory_analysis";
+const MAX_EXACT_MEMORY_STATES_PER_CLASS: usize = 64;
+
+const DTYPE_BITS: &[(&str, usize)] = &[
+    ("F32", 32),
+    ("F16", 16),
+    ("Bf16", 16),
+    ("Int", 32),
+    ("Bool", 8),
+    ("I4", 4),
+    ("TF32", 19),
+];
+
+pub(crate) fn webgpu_memory_analysis_pass(
+    ops: &[Arc<Box<dyn EgglogOp>>],
+    max_memory_bytes: Option<usize>,
+    _dyn_map: &FxHashMap<char, usize>,
+) -> LateEgglogPass {
+    let mut sorts = ops
+        .iter()
+        .map(|op| op.sort())
+        .filter(|sort| sort.class == "OpKind")
+        .collect_vec();
+    sorts.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let mut program = String::from(
+        r#"
+(ruleset webgpu_memory_analysis)
+(relation webgpu_output_bytes (OpKind Expression))
+(relation webgpu_local_memory (IR Expression))
+
+(rule ((= ?node (Input ?id ?label ?dtype)))
+      ((webgpu_local_memory ?node (MNum 0)))
+      :ruleset webgpu_memory_analysis
+      :name "webgpu-memory-input")
+
+(rule ((= ?node (Output ?inp ?id)))
+      ((webgpu_local_memory ?node (MNum 0)))
+      :ruleset webgpu_memory_analysis
+      :name "webgpu-memory-output")
+
+(rule ((= ?node (OutputJoin ?a ?b)))
+      ((webgpu_local_memory ?node (MNum 0)))
+      :ruleset webgpu_memory_analysis
+      :name "webgpu-memory-output-join")
+
+(rule ((= ?node (Op ?kind ?inputs))
+       (webgpu_output_bytes ?kind ?bytes))
+      ((webgpu_local_memory ?node ?bytes))
+      :ruleset webgpu_memory_analysis
+      :name "webgpu-memory-op-local")
+"#,
+    );
+
+    for sort in &sorts {
+        for rule in output_bytes_rules(sort) {
+            program.push('\n');
+            program.push_str(&rule);
+        }
+    }
+
+    let pass = LateEgglogPass::new(
+        program,
+        format!("(run-schedule (saturate {MEMORY_ANALYSIS_RULESET}))"),
+    );
+
+    let _ = max_memory_bytes;
+    pass
+}
+
+pub(crate) fn estimate_graph_memory_bytes<'a>(
+    egraph: &'a SerializedEGraph,
+    choices: &EGraphChoiceSet<'a>,
+    dyn_map: &FxHashMap<char, usize>,
+) -> Option<usize> {
+    ChoiceMemoryEstimator::new(egraph, choices, dyn_map)
+        .root_state()
+        .map(|state| state.peak)
+}
+
+/// A memory state for one possible way to produce an IR enode.
+///
+/// `live` is the intermediate memory that must remain live after the enode is
+/// produced. `peak` is the maximum intermediate memory needed while producing
+/// it. Frontiers keep only Pareto-minimal states under the configured limit.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct MemoryState {
+    live: usize,
+    peak: usize,
+}
+
+impl MemoryState {
+    fn zero() -> Self {
+        Self { live: 0, peak: 0 }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+struct ListMemoryState {
+    lives: Vec<usize>,
+    peak: usize,
+}
+
+impl ListMemoryState {
+    fn empty() -> Self {
+        Self {
+            lives: Vec::new(),
+            peak: 0,
+        }
+    }
+
+    fn live(&self) -> usize {
+        self.lives
+            .iter()
+            .fold(0usize, |acc, live| acc.saturating_add(*live))
+    }
+}
+
+fn list_state_dominates(a: &ListMemoryState, b: &ListMemoryState) -> bool {
+    a.peak <= b.peak
+        && a.lives.len() == b.lives.len()
+        && a.lives
+            .iter()
+            .zip(&b.lives)
+            .all(|(a_live, b_live)| a_live <= b_live)
+}
+
+fn pareto_memory_states(states: Vec<(MemoryState, ClassId)>) -> Vec<(MemoryState, ClassId)> {
+    let mut frontier: Vec<(MemoryState, ClassId)> = Vec::new();
+    for (state, class) in states {
+        if frontier
+            .iter()
+            .any(|(existing, _)| existing.live <= state.live && existing.peak <= state.peak)
+        {
+            continue;
+        }
+        frontier
+            .retain(|(existing, _)| !(state.live <= existing.live && state.peak <= existing.peak));
+        frontier.push((state, class));
+    }
+    frontier
+}
+
+fn bound_memory_states(states: Vec<(MemoryState, ClassId)>) -> Vec<(MemoryState, ClassId)> {
+    if states.len() <= MAX_EXACT_MEMORY_STATES_PER_CLASS {
+        return states;
+    }
+    let mut states = pareto_memory_states(states);
+    states.sort_by_key(|(state, _)| (state.peak, state.live));
+    states.truncate(MAX_EXACT_MEMORY_STATES_PER_CLASS);
+    states
+}
+
+fn pareto_list_states(states: Vec<(ListMemoryState, ClassId)>) -> Vec<(ListMemoryState, ClassId)> {
+    let mut frontier: Vec<(ListMemoryState, ClassId)> = Vec::new();
+    for (state, class) in states {
+        if frontier
+            .iter()
+            .any(|(existing, _)| list_state_dominates(existing, &state))
+        {
+            continue;
+        }
+        frontier.retain(|(existing, _)| !list_state_dominates(&state, existing));
+        frontier.push((state, class));
+    }
+    frontier
+}
+
+fn bound_list_states(states: Vec<(ListMemoryState, ClassId)>) -> Vec<(ListMemoryState, ClassId)> {
+    if states.len() <= MAX_EXACT_MEMORY_STATES_PER_CLASS {
+        return states;
+    }
+    let mut states = pareto_list_states(states);
+    states.sort_by_key(|(state, _)| (state.peak, state.live(), state.lives.clone()));
+    states.truncate(MAX_EXACT_MEMORY_STATES_PER_CLASS);
+    states
+}
+
+#[derive(Debug, Clone, Copy)]
+struct KindMemory {
+    output_bytes: usize,
+    alias_input: Option<usize>,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct MemorySplitStats {
+    pub original_enodes: usize,
+    pub split_enodes: usize,
+    pub original_eclasses: usize,
+    pub split_eclasses: usize,
+}
+
+/// Rewrite the serialized e-graph into a product e-graph keyed by memory state.
+///
+/// Each remaining IR/IList enode points only to child state classes whose
+/// concrete combination fits `limit`, so ordinary extraction over the rewritten
+/// e-graph cannot construct an over-limit graph for the supplied dyn map.
+pub(crate) fn split_egraph_by_memory_limit(
+    egraph: &mut SerializedEGraph,
+    limit: usize,
+    dyn_map: &FxHashMap<char, usize>,
+) -> MemorySplitStats {
+    let original_enodes = egraph.enodes.len();
+    let original_eclasses = egraph.eclasses.len();
+    let splitter = StateSplitter::new(egraph, limit, dyn_map);
+    let mut split = splitter.split();
+
+    compact_egraph_after_prune(&mut split);
+    validate_unique_loop_markers(&split);
+    let stats = MemorySplitStats {
+        original_enodes,
+        split_enodes: split.enodes.len(),
+        original_eclasses,
+        split_eclasses: split.eclasses.len(),
+    };
+    *egraph = split;
+    stats
+}
+
+struct StateSplitter<'a> {
+    original: &'a SerializedEGraph,
+    split: SerializedEGraph,
+    limit: usize,
+    dyn_map: &'a FxHashMap<char, usize>,
+    sort_by_name: FxHashMap<String, SortDef>,
+    ir_memo: FxHashMap<ClassId, Vec<(MemoryState, ClassId)>>,
+    list_memo: FxHashMap<ClassId, Vec<(ListMemoryState, ClassId)>>,
+    ir_states_by_owner: FxHashMap<ClassId, Vec<(MemoryState, ClassId)>>,
+    list_states_by_owner: FxHashMap<ClassId, Vec<(ListMemoryState, ClassId)>>,
+    visiting_ir: FxHashSet<ClassId>,
+    visiting_list: FxHashSet<ClassId>,
+    ir_state_classes: FxHashMap<(ClassId, MemoryState), ClassId>,
+    list_state_classes: FxHashMap<(ClassId, ListMemoryState), ClassId>,
+    kind_singletons: FxHashMap<NodeId, ClassId>,
+    node_memo: FxHashMap<(ClassId, String, Vec<ClassId>, bool), NodeId>,
+    next_class: usize,
+    next_node: usize,
+}
+
+impl<'a> StateSplitter<'a> {
+    fn new(
+        original: &'a SerializedEGraph,
+        limit: usize,
+        dyn_map: &'a FxHashMap<char, usize>,
+    ) -> Self {
+        let mut split = SerializedEGraph {
+            enodes: FxHashMap::default(),
+            eclasses: FxHashMap::default(),
+            node_to_class: FxHashMap::default(),
+            roots: Vec::new(),
+        };
+
+        for (class, (sort, nodes)) in &original.eclasses {
+            if sort == "IR" || sort == "IList" {
+                continue;
+            }
+            let kept_nodes = nodes
+                .iter()
+                .filter(|node| original.enodes.contains_key(*node))
+                .cloned()
+                .collect_vec();
+            if kept_nodes.is_empty() {
+                continue;
+            }
+            split
+                .eclasses
+                .insert(class.clone(), (sort.clone(), kept_nodes.clone()));
+            for node in kept_nodes {
+                if let Some(enode) = original.enodes.get(&node) {
+                    split.enodes.insert(node.clone(), enode.clone());
+                    split.node_to_class.insert(node, class.clone());
+                }
+            }
+        }
+
+        Self {
+            original,
+            split,
+            limit,
+            dyn_map,
+            sort_by_name: webgpu_sort_map(),
+            ir_memo: FxHashMap::default(),
+            list_memo: FxHashMap::default(),
+            ir_states_by_owner: FxHashMap::default(),
+            list_states_by_owner: FxHashMap::default(),
+            visiting_ir: FxHashSet::default(),
+            visiting_list: FxHashSet::default(),
+            ir_state_classes: FxHashMap::default(),
+            list_state_classes: FxHashMap::default(),
+            kind_singletons: FxHashMap::default(),
+            node_memo: FxHashMap::default(),
+            next_class: 0,
+            next_node: 0,
+        }
+    }
+
+    fn split(mut self) -> SerializedEGraph {
+        let Some(root) = self.original.roots.first().cloned() else {
+            return self.split;
+        };
+        let root_states = self.split_ir_class(&root);
+        if root_states.is_empty() {
+            return self.split;
+        }
+
+        let root_class = self.fresh_class_id("mem_root");
+        self.split
+            .eclasses
+            .insert(root_class.clone(), ("IR".to_string(), Vec::new()));
+
+        for (_, state_class) in root_states {
+            let root_nodes = self
+                .split
+                .eclasses
+                .get(&state_class)
+                .map(|(_, nodes)| nodes.clone())
+                .unwrap_or_default();
+            for node in root_nodes {
+                let Some((label, children)) = self.split.enodes.get(&node).cloned() else {
+                    continue;
+                };
+                self.add_node(
+                    root_class.clone(),
+                    label,
+                    children,
+                    node.as_ref().starts_with("synth_"),
+                );
+            }
+        }
+
+        self.split.roots = vec![root_class];
+        self.split
+    }
+
+    fn split_ir_class(&mut self, class: &ClassId) -> Vec<(MemoryState, ClassId)> {
+        if let Some(states) = self.ir_memo.get(class) {
+            return states.clone();
+        }
+        if !self.visiting_ir.insert(class.clone()) {
+            return Vec::new();
+        }
+
+        let nodes = match self.original.eclasses.get(class) {
+            Some((sort, nodes)) if sort == "IR" => nodes.clone(),
+            _ => {
+                self.visiting_ir.remove(class);
+                return Vec::new();
+            }
+        };
+
+        for node in nodes {
+            if self.original.enodes.contains_key(&node) {
+                self.split_ir_node(class, &node);
+            }
+        }
+
+        self.visiting_ir.remove(class);
+        let mut states = bound_memory_states(
+            self.ir_states_by_owner
+                .get(class)
+                .cloned()
+                .unwrap_or_default(),
+        );
+        states.sort_by_key(|(state, _)| *state);
+        self.ir_memo.insert(class.clone(), states.clone());
+        states
+    }
+
+    fn split_ir_node(&mut self, owner_class: &ClassId, node: &NodeId) {
+        let Some((label, children)) = self.original.enodes.get(node).cloned() else {
+            return;
+        };
+
+        match label.as_str() {
+            "Input" => {
+                self.add_ir_state_node(owner_class, MemoryState::zero(), label, children, node);
+            }
+            "Output" => {
+                let Some(input_class) = children.first() else {
+                    return;
+                };
+                for (state, state_class) in self.split_ir_class(input_class) {
+                    let mut split_children = children.clone();
+                    split_children[0] = state_class;
+                    self.add_ir_state_node(owner_class, state, label.clone(), split_children, node);
+                }
+            }
+            "OutputJoin" => {
+                let Some(a_class) = children.first() else {
+                    return;
+                };
+                let Some(b_class) = children.get(1) else {
+                    return;
+                };
+                for (a_state, a_split_class) in self.split_ir_class(a_class) {
+                    for (b_state, b_split_class) in self.split_ir_class(b_class) {
+                        let state = best_join_state(a_state, b_state);
+                        if state.peak > self.limit {
+                            continue;
+                        }
+                        let mut split_children = children.clone();
+                        split_children[0] = a_split_class.clone();
+                        split_children[1] = b_split_class;
+                        self.add_ir_state_node(
+                            owner_class,
+                            state,
+                            label.clone(),
+                            split_children,
+                            node,
+                        );
+                    }
+                }
+            }
+            "Op" => self.split_op_node(owner_class, node, label, children),
+            label if direct_loop_marker(label) => {
+                self.split_direct_loop_marker_node(owner_class, node, label.to_string(), children)
+            }
+            _ => {
+                let Some((idx, child_class)) =
+                    first_child_with_sort_index(self.original, &children, "IR")
+                else {
+                    return;
+                };
+                for (state, state_class) in self.split_ir_class(&child_class) {
+                    let mut split_children = children.clone();
+                    split_children[idx] = state_class;
+                    self.add_ir_state_node(owner_class, state, label.clone(), split_children, node);
+                }
+            }
+        }
+    }
+
+    fn split_op_node(
+        &mut self,
+        owner_class: &ClassId,
+        source_node: &NodeId,
+        label: String,
+        children: Vec<ClassId>,
+    ) {
+        let Some(kind_class) = children.first() else {
+            return;
+        };
+        let Some(inputs_class) = children.get(1) else {
+            return;
+        };
+        let Some((sort, kind_nodes)) = self.original.eclasses.get(kind_class) else {
+            return;
+        };
+        if sort != "OpKind" {
+            return;
+        }
+
+        let input_states = self.split_list_class(inputs_class);
+        for kind_node in kind_nodes {
+            let Some((kind_label, _)) = self.original.enodes.get(kind_node) else {
+                continue;
+            };
+            let Some(kind) =
+                kind_memory_for_node(self.original, &self.sort_by_name, kind_node, self.dyn_map)
+            else {
+                continue;
+            };
+            if kind.output_bytes > self.limit {
+                continue;
+            }
+            let kind_split_class = self.kind_singleton_class(kind_node);
+            if loop_op_kind(kind_label) {
+                // Loop OpKinds are structural markers. Keep the marker singleton and
+                // pick one feasible state for the data flowing through it.
+                let Some((state, input_split_class)) = input_states
+                    .iter()
+                    .filter_map(|(input_state, input_split_class)| {
+                        let state = op_memory_state(kind, input_state)?;
+                        (state.peak <= self.limit).then(|| (state, input_split_class.clone()))
+                    })
+                    .min_by_key(|(state, _)| (state.peak, state.live))
+                else {
+                    continue;
+                };
+
+                let mut split_children = children.clone();
+                split_children[0] = kind_split_class;
+                split_children[1] = input_split_class;
+                self.add_ir_state_node(
+                    owner_class,
+                    state,
+                    label.clone(),
+                    split_children,
+                    source_node,
+                );
+                continue;
+            }
+
+            for (input_state, input_split_class) in &input_states {
+                let Some(state) = op_memory_state(kind, input_state) else {
+                    continue;
+                };
+                if state.peak > self.limit {
+                    continue;
+                }
+                let mut split_children = children.clone();
+                split_children[0] = kind_split_class.clone();
+                split_children[1] = input_split_class.clone();
+                self.add_ir_state_node(
+                    owner_class,
+                    state,
+                    label.clone(),
+                    split_children,
+                    source_node,
+                );
+            }
+        }
+    }
+
+    fn split_direct_loop_marker_node(
+        &mut self,
+        owner_class: &ClassId,
+        source_node: &NodeId,
+        label: String,
+        children: Vec<ClassId>,
+    ) {
+        let Some((idx, child_class)) = first_child_with_sort_index(self.original, &children, "IR")
+        else {
+            return;
+        };
+        // LoopStart/LoopEnd identity is part of the loop scaffold, so state
+        // splitting must not clone the marker across child-state variants.
+        let Some((state, state_class)) = self
+            .split_ir_class(&child_class)
+            .into_iter()
+            .filter(|(state, _)| state.peak <= self.limit)
+            .min_by_key(|(state, _)| (state.peak, state.live))
+        else {
+            return;
+        };
+
+        let mut split_children = children;
+        split_children[idx] = state_class;
+        self.add_ir_state_node(owner_class, state, label, split_children, source_node);
+    }
+
+    fn split_list_class(&mut self, class: &ClassId) -> Vec<(ListMemoryState, ClassId)> {
+        if let Some(states) = self.list_memo.get(class) {
+            return states.clone();
+        }
+        if !self.visiting_list.insert(class.clone()) {
+            return Vec::new();
+        }
+
+        let nodes = match self.original.eclasses.get(class) {
+            Some((sort, nodes)) if sort == "IList" => nodes.clone(),
+            _ => {
+                self.visiting_list.remove(class);
+                return Vec::new();
+            }
+        };
+
+        for node in nodes {
+            if self.original.enodes.contains_key(&node) {
+                self.split_list_node(class, &node);
+            }
+        }
+
+        self.visiting_list.remove(class);
+        let mut states = bound_list_states(
+            self.list_states_by_owner
+                .get(class)
+                .cloned()
+                .unwrap_or_default(),
+        );
+        states.sort_by_key(|(state, _)| state.clone());
+        self.list_memo.insert(class.clone(), states.clone());
+        states
+    }
+
+    fn split_list_node(&mut self, owner_class: &ClassId, node: &NodeId) {
+        let Some((label, children)) = self.original.enodes.get(node).cloned() else {
+            return;
+        };
+
+        match label.as_str() {
+            "INil" => {
+                self.add_list_state_node(
+                    owner_class,
+                    ListMemoryState::empty(),
+                    label,
+                    children,
+                    node,
+                );
+            }
+            "ICons" => {
+                let Some(head_class) = children.first() else {
+                    return;
+                };
+                let Some(tail_class) = children.get(1) else {
+                    return;
+                };
+                for (head_state, head_split_class) in self.split_ir_class(head_class) {
+                    for (tail_state, tail_split_class) in self.split_list_class(tail_class) {
+                        let state = best_cons_state(head_state, tail_state);
+                        if state.peak > self.limit {
+                            continue;
+                        }
+                        let mut split_children = children.clone();
+                        split_children[0] = head_split_class.clone();
+                        split_children[1] = tail_split_class;
+                        self.add_list_state_node(
+                            owner_class,
+                            state,
+                            label.clone(),
+                            split_children,
+                            node,
+                        );
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn add_ir_state_node(
+        &mut self,
+        owner_class: &ClassId,
+        state: MemoryState,
+        label: String,
+        children: Vec<ClassId>,
+        source_node: &NodeId,
+    ) {
+        let state_class = self.ir_state_class(owner_class, state);
+        self.add_node(
+            state_class,
+            label,
+            children,
+            source_node.as_ref().starts_with("synth_"),
+        );
+    }
+
+    fn add_list_state_node(
+        &mut self,
+        owner_class: &ClassId,
+        state: ListMemoryState,
+        label: String,
+        children: Vec<ClassId>,
+        source_node: &NodeId,
+    ) {
+        let state_class = self.list_state_class(owner_class, state);
+        self.add_node(
+            state_class,
+            label,
+            children,
+            source_node.as_ref().starts_with("synth_"),
+        );
+    }
+
+    fn ir_state_class(&mut self, owner_class: &ClassId, state: MemoryState) -> ClassId {
+        let key = (owner_class.clone(), state);
+        if let Some(class) = self.ir_state_classes.get(&key) {
+            return class.clone();
+        }
+        let class = self.fresh_class_id("mem_ir");
+        self.split
+            .eclasses
+            .insert(class.clone(), ("IR".to_string(), Vec::new()));
+        self.ir_state_classes.insert(key, class.clone());
+        self.ir_states_by_owner
+            .entry(owner_class.clone())
+            .or_default()
+            .push((state, class.clone()));
+        class
+    }
+
+    fn list_state_class(&mut self, owner_class: &ClassId, state: ListMemoryState) -> ClassId {
+        let key = (owner_class.clone(), state.clone());
+        if let Some(class) = self.list_state_classes.get(&key) {
+            return class.clone();
+        }
+        let class = self.fresh_class_id("mem_ilist");
+        self.split
+            .eclasses
+            .insert(class.clone(), ("IList".to_string(), Vec::new()));
+        self.list_state_classes.insert(key, class.clone());
+        self.list_states_by_owner
+            .entry(owner_class.clone())
+            .or_default()
+            .push((state, class.clone()));
+        class
+    }
+
+    fn kind_singleton_class(&mut self, kind_node: &NodeId) -> ClassId {
+        if let Some(class) = self.kind_singletons.get(kind_node) {
+            return class.clone();
+        }
+        let Some((label, children)) = self.original.enodes.get(kind_node).cloned() else {
+            return self.fresh_class_id("missing_kind");
+        };
+        let class = self.fresh_class_id("mem_kind");
+        let node = self.fresh_node_id("mem_kind_node");
+        self.split
+            .eclasses
+            .insert(class.clone(), ("OpKind".to_string(), vec![node.clone()]));
+        self.split.enodes.insert(node.clone(), (label, children));
+        self.split.node_to_class.insert(node, class.clone());
+        self.kind_singletons
+            .insert(kind_node.clone(), class.clone());
+        class
+    }
+
+    fn add_node(
+        &mut self,
+        class: ClassId,
+        label: String,
+        children: Vec<ClassId>,
+        prefer_synth: bool,
+    ) -> NodeId {
+        let key = (class.clone(), label.clone(), children.clone(), prefer_synth);
+        if let Some(node) = self.node_memo.get(&key) {
+            return node.clone();
+        }
+        let node = self.fresh_node_id(if prefer_synth {
+            "synth_mem_node"
+        } else {
+            "mem_node"
+        });
+        self.split.enodes.insert(node.clone(), (label, children));
+        self.split.node_to_class.insert(node.clone(), class.clone());
+        if let Some((_, nodes)) = self.split.eclasses.get_mut(&class) {
+            nodes.push(node.clone());
+        }
+        self.node_memo.insert(key, node.clone());
+        node
+    }
+
+    fn fresh_class_id(&mut self, prefix: &str) -> ClassId {
+        let id = ClassId::from(format!("{prefix}_{}", self.next_class));
+        self.next_class += 1;
+        id
+    }
+
+    fn fresh_node_id(&mut self, prefix: &str) -> NodeId {
+        let id = NodeId::from(format!("{prefix}_{}", self.next_node));
+        self.next_node += 1;
+        id
+    }
+}
+
+struct ChoiceMemoryEstimator<'a> {
+    egraph: &'a SerializedEGraph,
+    choices: &'a EGraphChoiceSet<'a>,
+    dyn_map: &'a FxHashMap<char, usize>,
+    sort_by_name: FxHashMap<String, SortDef>,
+    ir_cache: FxHashMap<ClassId, MemoryState>,
+    list_cache: FxHashMap<ClassId, ListMemoryState>,
+    visiting_ir: FxHashSet<ClassId>,
+    visiting_list: FxHashSet<ClassId>,
+}
+
+impl<'a> ChoiceMemoryEstimator<'a> {
+    fn new(
+        egraph: &'a SerializedEGraph,
+        choices: &'a EGraphChoiceSet<'a>,
+        dyn_map: &'a FxHashMap<char, usize>,
+    ) -> Self {
+        Self {
+            egraph,
+            choices,
+            dyn_map,
+            sort_by_name: webgpu_sort_map(),
+            ir_cache: FxHashMap::default(),
+            list_cache: FxHashMap::default(),
+            visiting_ir: FxHashSet::default(),
+            visiting_list: FxHashSet::default(),
+        }
+    }
+
+    fn root_state(&mut self) -> Option<MemoryState> {
+        let root = self.egraph.roots.first()?;
+        self.ir_class_state(root)
+    }
+
+    fn ir_class_state(&mut self, class: &ClassId) -> Option<MemoryState> {
+        if let Some(state) = self.ir_cache.get(class) {
+            return Some(*state);
+        }
+        if !self.visiting_ir.insert(class.clone()) {
+            return Some(MemoryState::zero());
+        }
+        let Some(&node) = self.choices.get(class) else {
+            self.visiting_ir.remove(class);
+            return None;
+        };
+        let mut state = self.ir_node_state(node);
+        if state.is_none()
+            && let Some((_, nodes)) = self.egraph.eclasses.get(class)
+        {
+            state = nodes
+                .iter()
+                .filter(|candidate| **candidate != *node)
+                .filter_map(|candidate| self.ir_node_state(candidate))
+                .min_by_key(|state| (state.peak, state.live));
+        }
+        self.visiting_ir.remove(class);
+        if let Some(state) = state {
+            self.ir_cache.insert(class.clone(), state);
+        }
+        state
+    }
+
+    fn ir_node_state(&mut self, node: &NodeId) -> Option<MemoryState> {
+        let (label, children) = self.egraph.enodes.get(node)?.clone();
+        match label.as_str() {
+            "Input" => Some(MemoryState::zero()),
+            "Output" => self.ir_class_state(children.first()?),
+            "OutputJoin" => {
+                let a = self.ir_class_state(children.first()?)?;
+                let b = self.ir_class_state(children.get(1)?)?;
+                Some(best_join_state(a, b))
+            }
+            "Op" => self.op_state(&children),
+            _ => {
+                let child = first_child_with_sort(self.egraph, &children, "IR")?;
+                self.ir_class_state(&child)
+            }
+        }
+    }
+
+    fn op_state(&mut self, children: &[ClassId]) -> Option<MemoryState> {
+        let kind_class = children.first()?;
+        let inputs_class = children.get(1)?;
+        let kind_node = choose_kind_node(self.egraph, kind_class)?;
+        let kind = kind_memory_for_node(self.egraph, &self.sort_by_name, kind_node, self.dyn_map)?;
+        let Some(inputs) = self.list_class_state(inputs_class) else {
+            return Some(MemoryState {
+                live: kind.output_bytes,
+                peak: kind.output_bytes,
+            });
+        };
+        op_memory_state(kind, &inputs)
+    }
+
+    fn list_class_state(&mut self, class: &ClassId) -> Option<ListMemoryState> {
+        if let Some(state) = self.list_cache.get(class) {
+            return Some(state.clone());
+        }
+        if !self.visiting_list.insert(class.clone()) {
+            return Some(ListMemoryState::empty());
+        }
+        let Some(&node) = self.choices.get(class) else {
+            self.visiting_list.remove(class);
+            return None;
+        };
+        let mut state = self.list_node_state(node);
+        if state.is_none()
+            && let Some((_, nodes)) = self.egraph.eclasses.get(class)
+        {
+            state = nodes
+                .iter()
+                .filter(|candidate| **candidate != *node)
+                .filter_map(|candidate| self.list_node_state(candidate))
+                .min_by_key(|state| (state.peak, state.live()));
+        }
+        self.visiting_list.remove(class);
+        if let Some(state) = &state {
+            self.list_cache.insert(class.clone(), state.clone());
+        }
+        state
+    }
+
+    fn list_node_state(&mut self, node: &NodeId) -> Option<ListMemoryState> {
+        let (label, children) = self.egraph.enodes.get(node)?.clone();
+        match label.as_str() {
+            "INil" => Some(ListMemoryState::empty()),
+            "ICons" => {
+                let head = self.ir_class_state(children.first()?)?;
+                let tail = self.list_class_state(children.get(1)?)?;
+                Some(best_cons_state(head, tail))
+            }
+            _ => None,
+        }
+    }
+}
+
+fn best_join_state(a: MemoryState, b: MemoryState) -> MemoryState {
+    let live = a.live.saturating_add(b.live);
+    let a_first_peak = a.peak.max(a.live.saturating_add(b.peak));
+    let b_first_peak = b.peak.max(b.live.saturating_add(a.peak));
+    MemoryState {
+        live,
+        peak: a_first_peak.min(b_first_peak),
+    }
+}
+
+fn best_cons_state(head: MemoryState, tail: ListMemoryState) -> ListMemoryState {
+    let mut lives = Vec::with_capacity(tail.lives.len() + 1);
+    lives.push(head.live);
+    lives.extend_from_slice(&tail.lives);
+    let head_first_peak = head.peak.max(head.live.saturating_add(tail.peak));
+    let tail_first_peak = tail.peak.max(tail.live().saturating_add(head.peak));
+    ListMemoryState {
+        lives,
+        peak: head_first_peak.min(tail_first_peak),
+    }
+}
+
+fn op_memory_state(kind: KindMemory, inputs: &ListMemoryState) -> Option<MemoryState> {
+    if let Some(alias_input) = kind.alias_input {
+        return inputs.lives.get(alias_input).map(|live| MemoryState {
+            live: *live,
+            peak: inputs.peak,
+        });
+    }
+
+    Some(MemoryState {
+        live: kind.output_bytes,
+        peak: inputs
+            .peak
+            .max(inputs.live().saturating_add(kind.output_bytes)),
+    })
+}
+
+fn kind_memory_for_node(
+    egraph: &SerializedEGraph,
+    sort_by_name: &FxHashMap<String, SortDef>,
+    node: &NodeId,
+    dyn_map: &FxHashMap<char, usize>,
+) -> Option<KindMemory> {
+    let (kind_label, kind_child_classes) = egraph.enodes.get(node)?;
+    if zero_local_op_kind(kind_label) {
+        return Some(KindMemory {
+            output_bytes: 0,
+            alias_input: None,
+        });
+    }
+    let sort = sort_by_name.get(kind_label.as_str())?;
+    let kind_children = kind_child_classes
+        .iter()
+        .map(|class| first_data_node(egraph, class))
+        .collect::<Option<Vec<_>>>()?;
+    let mut list_cache = FxHashMap::default();
+    let mut expr_cache = FxHashMap::default();
+    let bytes_expr = local_output_bytes(
+        egraph,
+        sort,
+        &kind_children,
+        &mut list_cache,
+        &mut expr_cache,
+    )?;
+    Some(KindMemory {
+        output_bytes: eval_bytes(bytes_expr, dyn_map)?,
+        alias_input: output_alias_input_for_kind(kind_label),
+    })
+}
+
+fn first_data_node<'a>(egraph: &'a SerializedEGraph, class: &'a ClassId) -> Option<&'a NodeId> {
+    let (_, nodes) = egraph.eclasses.get(class)?;
+    nodes.iter().find(|node| egraph.enodes.contains_key(*node))
+}
+
+fn eval_bytes(expr: Expression, dyn_map: &FxHashMap<char, usize>) -> Option<usize> {
+    let mut dyn_map = dyn_map.clone();
+    dyn_map.entry('z').or_insert(1);
+    expr.simplify().exec(&dyn_map)
+}
+
+fn output_alias_input_for_kind(kind: &str) -> Option<usize> {
+    match kind {
+        "WebGpuScatterNoCopy" => Some(0),
+        _ => None,
+    }
+}
+
+fn first_child_with_sort(
+    egraph: &SerializedEGraph,
+    children: &[ClassId],
+    sort: &str,
+) -> Option<ClassId> {
+    children
+        .iter()
+        .find(|class| egraph.eclasses.get(*class).is_some_and(|(s, _)| s == sort))
+        .cloned()
+}
+
+fn first_child_with_sort_index(
+    egraph: &SerializedEGraph,
+    children: &[ClassId],
+    sort: &str,
+) -> Option<(usize, ClassId)> {
+    children
+        .iter()
+        .enumerate()
+        .find(|(_, class)| egraph.eclasses.get(*class).is_some_and(|(s, _)| s == sort))
+        .map(|(idx, class)| (idx, class.clone()))
+}
+
+fn choose_kind_node<'a>(egraph: &'a SerializedEGraph, kind_class: &ClassId) -> Option<&'a NodeId> {
+    let kind_enodes = &egraph.eclasses.get(kind_class)?.1;
+    let extractor_length = |eclass_id: &ClassId| -> Option<usize> {
+        let mut len = 0usize;
+        let mut cur_eclass = eclass_id.clone();
+        let mut visited = FxHashSet::default();
+        loop {
+            if !visited.insert(cur_eclass.clone()) {
+                return None;
+            }
+            let (label, enodes) = egraph.eclasses.get(&cur_eclass)?;
+            if !label.contains("List") {
+                return Some(len);
+            }
+            let head_enode = enodes.first()?;
+            let head_label = &egraph.enodes.get(head_enode)?.0;
+            if head_label == "ENil" || head_label == "INil" {
+                return Some(len);
+            }
+            if head_label != "ECons" && head_label != "ICons" {
+                return Some(len);
+            }
+            len += 1;
+            let children = &egraph.enodes.get(head_enode)?.1;
+            if children.len() < 2 {
+                return Some(len);
+            }
+            cur_eclass = children[1].clone();
+        }
+    };
+    let elist_lens_for = |node: &NodeId| -> Vec<usize> {
+        egraph
+            .enodes
+            .get(node)
+            .map(|(_, children)| {
+                children
+                    .iter()
+                    .filter_map(|class| {
+                        let label = &egraph.eclasses.get(class)?.0;
+                        label.contains("List").then(|| extractor_length(class))?
+                    })
+                    .collect()
+            })
+            .unwrap_or_default()
+    };
+    let is_consistent = |node: &&NodeId| -> bool {
+        let lens = elist_lens_for(node);
+        lens.is_empty() || lens.iter().all(|len| *len == lens[0])
+    };
+    let is_kernel = |node: &&NodeId| -> bool {
+        let label = &egraph.enodes[*node].0;
+        label.starts_with("WebGpu")
+            || label == "GenericMatmul"
+            || label == "FusionStart"
+            || label == "FusionEnd"
+    };
+
+    kind_enodes
+        .iter()
+        .find(|node| egraph.enodes.contains_key(*node) && is_kernel(node) && is_consistent(node))
+        .or_else(|| {
+            kind_enodes
+                .iter()
+                .find(|node| egraph.enodes.contains_key(*node) && is_consistent(node))
+        })
+        .or_else(|| {
+            kind_enodes
+                .iter()
+                .find(|node| egraph.enodes.contains_key(*node) && is_kernel(node))
+        })
+        .or_else(|| {
+            kind_enodes
+                .iter()
+                .find(|node| egraph.enodes.contains_key(*node))
+        })
+}
+
+fn compact_egraph_after_prune(egraph: &mut SerializedEGraph) {
+    loop {
+        let mut to_remove = Vec::new();
+        for (id, (_, children)) in &egraph.enodes {
+            if children.iter().any(|class| {
+                egraph.eclasses.get(class).is_none_or(|(_, nodes)| {
+                    !nodes.iter().any(|node| egraph.enodes.contains_key(node))
+                })
+            }) {
+                to_remove.push(id.clone());
+            }
+        }
+        if to_remove.is_empty() {
+            break;
+        }
+        for node in to_remove {
+            egraph.enodes.remove(&node);
+        }
+    }
+
+    for (_, nodes) in egraph.eclasses.values_mut() {
+        nodes.retain(|node| egraph.enodes.contains_key(node));
+    }
+    egraph.eclasses.retain(|_, (_, nodes)| !nodes.is_empty());
+    egraph
+        .node_to_class
+        .retain(|node, _| egraph.enodes.contains_key(node));
+
+    let mut reachable_classes = FxHashSet::default();
+    let mut reachable_nodes = FxHashSet::default();
+    let mut stack = egraph.roots.clone();
+    while let Some(class) = stack.pop() {
+        if !reachable_classes.insert(class.clone()) {
+            continue;
+        }
+        let Some((_, nodes)) = egraph.eclasses.get(&class) else {
+            continue;
+        };
+        for node in nodes {
+            if !egraph.enodes.contains_key(node) || !reachable_nodes.insert(node.clone()) {
+                continue;
+            }
+            stack.extend(egraph.enodes[node].1.iter().cloned());
+        }
+    }
+
+    egraph
+        .eclasses
+        .retain(|class, _| reachable_classes.contains(class));
+    egraph
+        .enodes
+        .retain(|node, _| reachable_nodes.contains(node));
+    egraph
+        .node_to_class
+        .retain(|node, class| reachable_nodes.contains(node) && reachable_classes.contains(class));
+    for (_, nodes) in egraph.eclasses.values_mut() {
+        nodes.retain(|node| egraph.enodes.contains_key(node));
+    }
+    egraph
+        .roots
+        .retain(|class| egraph.eclasses.contains_key(class));
+}
+
+fn zero_local_op_kind(kind: &str) -> bool {
+    loop_op_kind(kind)
+}
+
+fn loop_op_kind(kind: &str) -> bool {
+    matches!(
+        kind,
+        "LoopInput" | "LoopInputStatic" | "LoopOutput" | "LoopOutputSelect"
+    )
+}
+
+fn direct_loop_marker(kind: &str) -> bool {
+    matches!(kind, "LoopStart" | "LoopEnd")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct LoopMarkerKey {
+    label: String,
+    fields: Vec<String>,
+}
+
+fn validate_unique_loop_markers(egraph: &SerializedEGraph) {
+    let mut seen = FxHashMap::default();
+    for node in egraph.enodes.keys() {
+        for key in loop_marker_keys_for_node(egraph, node) {
+            if let Some(previous) = seen.insert(key.clone(), node.clone()) {
+                panic!(
+                    "WebGpu memory splitter duplicated loop marker {key:?}: {previous:?} and {node:?}"
+                );
+            }
+        }
+    }
+}
+
+fn loop_marker_keys_for_node(egraph: &SerializedEGraph, node: &NodeId) -> Vec<LoopMarkerKey> {
+    let Some((label, children)) = egraph.enodes.get(node) else {
+        return Vec::new();
+    };
+    if direct_loop_marker(label) {
+        return vec![LoopMarkerKey {
+            label: label.clone(),
+            fields: field_signature(egraph, children.iter().skip(1)),
+        }];
+    }
+    if label != "Op" {
+        return Vec::new();
+    }
+    let Some(kind_class) = children.first() else {
+        return Vec::new();
+    };
+    let Some((sort, kind_nodes)) = egraph.eclasses.get(kind_class) else {
+        return Vec::new();
+    };
+    if sort != "OpKind" {
+        return Vec::new();
+    }
+
+    kind_nodes
+        .iter()
+        .filter_map(|kind_node| {
+            let (kind_label, kind_children) = egraph.enodes.get(kind_node)?;
+            loop_op_kind(kind_label).then(|| LoopMarkerKey {
+                label: kind_label.clone(),
+                fields: field_signature(egraph, kind_children.iter()),
+            })
+        })
+        .collect()
+}
+
+fn field_signature<'a>(
+    egraph: &SerializedEGraph,
+    fields: impl Iterator<Item = &'a ClassId>,
+) -> Vec<String> {
+    fields
+        .map(|class| {
+            let node_label = egraph
+                .eclasses
+                .get(class)
+                .and_then(|(_, nodes)| {
+                    nodes
+                        .iter()
+                        .find_map(|node| egraph.enodes.get(node).map(|(label, _)| label.clone()))
+                })
+                .unwrap_or_else(|| "<missing>".to_string());
+            format!("{}:{node_label}", class.as_ref())
+        })
+        .collect()
+}
+
+fn webgpu_sort_map() -> FxHashMap<String, SortDef> {
+    <crate::kernel::WebGpuOps as luminal::op::IntoEgglogOp>::into_vec()
+        .into_iter()
+        .map(|op| {
+            let sort = op.sort();
+            (sort.name.clone(), sort)
+        })
+        .collect()
+}
+
+fn local_output_bytes<'a>(
+    egraph: &'a SerializedEGraph,
+    sort: &SortDef,
+    kind_children: &[&'a ENodeId],
+    list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+    expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+) -> Option<Expression> {
+    match sort.name.as_str() {
+        name if zero_local_op_kind(name) => Some(0.into()),
+        "FusionStart" => Some(0.into()),
+        "WebGpuConstant" => Some(4.into()),
+        "WebGpuIota" => Some(expr_field(egraph, sort, kind_children, "range", expr_cache)? * 4),
+        "WebGpuLessThan" => Some(n_elements_field(
+            egraph,
+            sort,
+            kind_children,
+            "shape",
+            list_cache,
+            expr_cache,
+        )?),
+        "WebGpuCast" => {
+            let size = expr_field(egraph, sort, kind_children, "size", expr_cache)?;
+            let dtype = dtype_field(egraph, sort, kind_children, "dtype")?;
+            Some(bytes_for_elements(size, dtype))
+        }
+        _ => {
+            let shape_field = ["shape", "out_shape", "dest_shape"]
+                .into_iter()
+                .find(|name| field_index(sort, name).is_some())?;
+            let elems = n_elements_field(
+                egraph,
+                sort,
+                kind_children,
+                shape_field,
+                list_cache,
+                expr_cache,
+            )?;
+            Some(elems * 4)
+        }
+    }
+}
+
+fn bytes_for_elements(elements: Expression, dtype: DType) -> Expression {
+    (elements * dtype.bits()).ceil_div(8)
+}
+
+fn field_index(sort: &SortDef, name: &str) -> Option<usize> {
+    sort.fields.iter().position(|field| field.name == name)
+}
+
+fn expr_field<'a>(
+    egraph: &'a SerializedEGraph,
+    sort: &SortDef,
+    kind_children: &[&'a ENodeId],
+    field: &str,
+    expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+) -> Option<Expression> {
+    let node = kind_children.get(field_index(sort, field)?)?;
+    extract_expr(egraph, node, expr_cache)
+}
+
+fn dtype_field<'a>(
+    egraph: &'a SerializedEGraph,
+    sort: &SortDef,
+    kind_children: &[&'a ENodeId],
+    field: &str,
+) -> Option<DType> {
+    let node = kind_children.get(field_index(sort, field)?)?;
+    Some(extract_dtype(egraph, node))
+}
+
+fn n_elements_field<'a>(
+    egraph: &'a SerializedEGraph,
+    sort: &SortDef,
+    kind_children: &[&'a ENodeId],
+    field: &str,
+    list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+    expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+) -> Option<Expression> {
+    let node = kind_children.get(field_index(sort, field)?)?;
+    Some(
+        extract_expr_list(egraph, node, list_cache, expr_cache)?
+            .into_iter()
+            .product::<Expression>()
+            .max(1),
+    )
+}
+
+fn output_bytes_rules(sort: &SortDef) -> Vec<String> {
+    match sort.name.as_str() {
+        name if zero_local_op_kind(name) => vec![output_bytes_rule(sort, "(MNum 0)", "zero")],
+        "FusionStart" => vec![output_bytes_rule(sort, "(MNum 0)", "zero")],
+        "WebGpuConstant" => vec![output_bytes_rule(sort, "(MNum 4)", "f32-scalar")],
+        "WebGpuIota" => vec![output_bytes_rule(
+            sort,
+            "(MMul ?range (MNum 4))",
+            "int-range",
+        )],
+        "WebGpuLessThan" => vec![output_bytes_rule_with_facts(
+            sort,
+            "?__webgpu_elems",
+            "bool-shape",
+            None,
+            &["(= ?__webgpu_elems (n_elements ?shape))"],
+        )],
+        "WebGpuCast" => dtype_output_bytes_rules(sort, "size", "dtype"),
+        _ => {
+            let Some(shape_field) = ["shape", "out_shape", "dest_shape"]
+                .into_iter()
+                .find(|name| field_index(sort, name).is_some())
+            else {
+                return vec![];
+            };
+            output_bytes_rule_for_shape(sort, shape_field)
+        }
+    }
+}
+
+fn output_bytes_rule_for_shape(sort: &SortDef, shape_field: &str) -> Vec<String> {
+    let elem_fact = format!("(= ?__webgpu_elems (n_elements ?{shape_field}))");
+    vec![output_bytes_rule_with_facts(
+        sort,
+        "(MMul ?__webgpu_elems (MNum 4))",
+        "f32-shape",
+        None,
+        &[elem_fact.as_str()],
+    )]
+}
+
+fn dtype_output_bytes_rules(sort: &SortDef, elem_field: &str, dtype_field: &str) -> Vec<String> {
+    dtype_output_bytes_rules_for_expr(sort, &format!("?{elem_field}"), dtype_field)
+}
+
+fn dtype_output_bytes_rules_for_expr(
+    sort: &SortDef,
+    elements_expr: &str,
+    dtype_field: &str,
+) -> Vec<String> {
+    DTYPE_BITS
+        .iter()
+        .map(|(dtype, bits)| {
+            output_bytes_rule_with_field_value(
+                sort,
+                &ceil_bytes_expr(elements_expr, *bits),
+                &format!("{dtype}-bytes"),
+                dtype_field,
+                &format!("({dtype})"),
+            )
+        })
+        .collect()
+}
+
+fn ceil_bytes_expr(elements_expr: &str, bits: usize) -> String {
+    format!("(MCeilDiv (MMul {elements_expr} (MNum {bits})) (MNum 8))")
+}
+
+fn output_bytes_rule(sort: &SortDef, bytes_expr: &str, suffix: &str) -> String {
+    output_bytes_rule_with_facts(sort, bytes_expr, suffix, None, &[])
+}
+
+fn output_bytes_rule_with_field_value(
+    sort: &SortDef,
+    bytes_expr: &str,
+    suffix: &str,
+    field: &str,
+    value: &str,
+) -> String {
+    output_bytes_rule_with_facts(sort, bytes_expr, suffix, Some((field, value)), &[])
+}
+
+fn output_bytes_rule_with_facts(
+    sort: &SortDef,
+    bytes_expr: &str,
+    suffix: &str,
+    override_field: Option<(&str, &str)>,
+    extra_facts: &[&str],
+) -> String {
+    let args = sort
+        .fields
+        .iter()
+        .map(|field| {
+            if override_field
+                .as_ref()
+                .is_some_and(|(name, _)| *name == field.name)
+            {
+                override_field.unwrap().1.to_string()
+            } else {
+                format!("?{}", field.name)
+            }
+        })
+        .join(" ");
+    let pattern = if args.is_empty() {
+        format!("({})", sort.name)
+    } else {
+        format!("({} {args})", sort.name)
+    };
+    let facts = std::iter::once(format!("(= ?kind {pattern})"))
+        .chain(extra_facts.iter().map(|fact| (*fact).to_string()))
+        .join("\n     ");
+    format!(
+        "(rule
+    ({facts})
+    ((webgpu_output_bytes ?kind {bytes_expr}))
+    :ruleset {MEMORY_ANALYSIS_RULESET}
+    :name \"webgpu-memory-{}-{suffix}\"
+)",
+        sort.name
+    )
+}

--- a/crates/luminal_webgpu/src/runtime.rs
+++ b/crates/luminal_webgpu/src/runtime.rs
@@ -1,0 +1,833 @@
+use crate::kernel::{WebGpuEncodeContext, WebGpuKernelOp, WebGpuPipeline};
+use half::{bf16, f16};
+use itertools::Itertools;
+use luminal::{
+    dtype::DType,
+    egglog_utils::SerializedEGraph,
+    graph::{BucketLLIR, DimBucket, Graph, LLIRGraph},
+    hlir::{Input, NativeData, Output},
+    op::{ExecutionStats, Runtime, RuntimeStats, TimingMethod},
+    prelude::{
+        FxHashMap, NodeIndex, ToId,
+        petgraph::{Direction, algo::toposort, prelude::StableGraph, visit::EdgeRef},
+    },
+};
+use memmap2::MmapOptions;
+use safetensors::{Dtype, SafeTensors};
+use std::{fs::File, sync::Arc, time::Duration};
+use wgpu::util::DeviceExt;
+
+#[derive(Clone)]
+pub struct WebGpuBuffer {
+    buffer: Arc<wgpu::Buffer>,
+    length: u64,
+}
+
+impl WebGpuBuffer {
+    pub fn raw(&self) -> &wgpu::Buffer {
+        &self.buffer
+    }
+
+    pub fn length(&self) -> u64 {
+        self.length
+    }
+}
+
+#[derive(Clone)]
+struct WebGpuExecutionStep {
+    node: NodeIndex,
+    input_nodes: Vec<NodeIndex>,
+    input_dtypes: Vec<DType>,
+    output_dtype: DType,
+}
+
+#[derive(Clone)]
+struct WebGpuCompiledBucket {
+    bucket_indices: FxHashMap<char, usize>,
+    llir_graph: LLIRGraph,
+    llir_to_hlir: FxHashMap<NodeIndex, NodeIndex>,
+    node_dtypes: FxHashMap<NodeIndex, DType>,
+    pipelines: FxHashMap<NodeIndex, WebGpuPipeline>,
+    output_alias_map: FxHashMap<NodeIndex, NodeIndex>,
+    output_data_map: FxHashMap<NodeIndex, NodeIndex>,
+    execution_plan: Vec<WebGpuExecutionStep>,
+}
+
+pub struct WebGpuRuntime {
+    device: wgpu::Device,
+    queue: wgpu::Queue,
+    max_compute_workgroups_per_dimension: u32,
+    input_data: FxHashMap<NodeIndex, NativeData>,
+    pub hlir_buffers: FxHashMap<NodeIndex, WebGpuBuffer>,
+    pub buffers: FxHashMap<NodeIndex, WebGpuBuffer>,
+    buffer_lengths: FxHashMap<NodeIndex, u64>,
+    llir_graph: LLIRGraph,
+    llir_to_hlir: FxHashMap<NodeIndex, NodeIndex>,
+    node_dtypes: FxHashMap<NodeIndex, DType>,
+    pipelines: FxHashMap<NodeIndex, WebGpuPipeline>,
+    output_alias_map: FxHashMap<NodeIndex, NodeIndex>,
+    output_data_map: FxHashMap<NodeIndex, NodeIndex>,
+    execution_plan: Vec<WebGpuExecutionStep>,
+    dim_buckets: FxHashMap<char, Vec<DimBucket>>,
+    compiled_buckets: Vec<WebGpuCompiledBucket>,
+    active_bucket: usize,
+}
+
+impl WebGpuRuntime {
+    fn buffer_usage() -> wgpu::BufferUsages {
+        wgpu::BufferUsages::STORAGE | wgpu::BufferUsages::COPY_DST | wgpu::BufferUsages::COPY_SRC
+    }
+
+    fn aligned_size(size: u64) -> u64 {
+        let size = size.max(4);
+        size.div_ceil(wgpu::COPY_BUFFER_ALIGNMENT) * wgpu::COPY_BUFFER_ALIGNMENT
+    }
+
+    fn create_buffer(&self, size: u64) -> WebGpuBuffer {
+        let length = Self::aligned_size(size);
+        WebGpuBuffer {
+            buffer: Arc::new(self.device.create_buffer(&wgpu::BufferDescriptor {
+                label: None,
+                size: length,
+                usage: Self::buffer_usage(),
+                mapped_at_creation: false,
+            })),
+            length,
+        }
+    }
+
+    fn create_buffer_with_data(&self, bytes: &[u8]) -> WebGpuBuffer {
+        let length = Self::aligned_size(bytes.len() as u64);
+        let mut padded = vec![0u8; length as usize];
+        padded[..bytes.len()].copy_from_slice(bytes);
+        WebGpuBuffer {
+            buffer: Arc::new(
+                self.device
+                    .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                        label: None,
+                        contents: &padded,
+                        usage: Self::buffer_usage(),
+                    }),
+            ),
+            length,
+        }
+    }
+
+    fn input_dtype(&self, id: NodeIndex) -> Option<DType> {
+        self.llir_graph.node_indices().find_map(|node| {
+            self.llir_graph[node]
+                .to_op::<Input>()
+                .and_then(|input| (input.node == id.index()).then_some(input.dtype))
+        })
+    }
+
+    fn output_data_node(&self, id: NodeIndex) -> NodeIndex {
+        self.output_data_map
+            .get(&id)
+            .copied()
+            .unwrap_or_else(|| panic!("Cannot find output tensor {id:?}!"))
+    }
+
+    fn follow_aliases(&self, mut node: NodeIndex) -> NodeIndex {
+        while let Some(target) = self.output_alias_map.get(&node) {
+            node = *target;
+        }
+        node
+    }
+
+    fn buffer_for_llir_node<'a>(
+        &'a self,
+        node: NodeIndex,
+        llir_to_hlir: &FxHashMap<NodeIndex, NodeIndex>,
+    ) -> &'a WebGpuBuffer {
+        let data_node = self.follow_aliases(node);
+        if let Some(hlir_node) = llir_to_hlir.get(&data_node) {
+            self.hlir_buffers
+                .get(hlir_node)
+                .expect("Input buffer not set!")
+        } else {
+            self.buffers
+                .get(&data_node)
+                .expect("Intermediate buffer not found!")
+        }
+    }
+
+    fn buffer_from_slice<T: bytemuck::NoUninit>(&self, values: &[T]) -> WebGpuBuffer {
+        self.create_buffer_with_data(bytemuck::cast_slice(values))
+    }
+
+    fn buffer_from_safetensor(
+        &self,
+        tensor: &safetensors::tensor::TensorView<'_>,
+        dtype: DType,
+    ) -> WebGpuBuffer {
+        match (tensor.dtype(), dtype) {
+            (Dtype::F32, DType::F32) => self.create_buffer_with_data(tensor.data()),
+            (Dtype::F16, DType::F32) => {
+                let values: Vec<f32> = bytemuck::cast_slice::<u8, f16>(tensor.data())
+                    .iter()
+                    .map(|v| v.to_f32())
+                    .collect();
+                self.buffer_from_slice(&values)
+            }
+            (Dtype::BF16, DType::F32) => {
+                let values: Vec<f32> = bytemuck::cast_slice::<u8, bf16>(tensor.data())
+                    .iter()
+                    .map(|v| v.to_f32())
+                    .collect();
+                self.buffer_from_slice(&values)
+            }
+            (Dtype::F32, DType::F16) => {
+                let values: Vec<f16> = bytemuck::cast_slice::<u8, f32>(tensor.data())
+                    .iter()
+                    .map(|v| f16::from_f32(*v))
+                    .collect();
+                self.buffer_from_slice(&values)
+            }
+            (Dtype::F16, DType::F16) => self.create_buffer_with_data(tensor.data()),
+            (Dtype::BF16, DType::F16) => {
+                let values: Vec<f16> = bytemuck::cast_slice::<u8, bf16>(tensor.data())
+                    .iter()
+                    .map(|v| f16::from_f32(v.to_f32()))
+                    .collect();
+                self.buffer_from_slice(&values)
+            }
+            (tensor_dtype, dtype) => {
+                panic!("Cannot load safetensor dtype {tensor_dtype:?} into WebGPU dtype {dtype:?}")
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn contains_matmul(&self) -> bool {
+        self.llir_graph.node_indices().any(|node| {
+            self.llir_graph[node]
+                .to_dialect::<dyn WebGpuKernelOp>()
+                .is_some_and(|op| op.is_matmul())
+        })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn debug_kernel_ops(&self) -> Vec<String> {
+        self.llir_graph
+            .node_indices()
+            .filter_map(|node| {
+                self.llir_graph[node]
+                    .to_dialect::<dyn WebGpuKernelOp>()
+                    .map(|op| format!("{op:?}"))
+            })
+            .collect()
+    }
+
+    pub fn load_safetensors(&mut self, cx: &Graph, file_path: &str) {
+        let f = File::open(file_path).unwrap();
+        let mmap = unsafe { MmapOptions::new().map(&f).unwrap() };
+        let st = SafeTensors::deserialize(&mmap).unwrap();
+
+        for node in cx.graph.node_indices() {
+            if let Some(input) = (*cx.graph[node]).as_any().downcast_ref::<Input>()
+                && let Ok(tensor) = st.tensor(&input.label)
+            {
+                let buffer = self.buffer_from_safetensor(&tensor, input.dtype);
+                self.input_data.remove(&node);
+                self.hlir_buffers.insert(node, buffer);
+            }
+        }
+    }
+
+    pub fn set_data(&mut self, id: impl ToId, data: impl Into<NativeData>) {
+        let id = id.to_id();
+        let data = data.into();
+        if let Some(dtype) = self.input_dtype(id) {
+            let buffer = self.create_input_buffer(&data, dtype);
+            self.hlir_buffers.insert(id, buffer);
+        }
+        self.input_data.insert(id, data);
+    }
+
+    pub fn set_zeros(&mut self, id: impl ToId, num_bytes: usize) {
+        let id = id.to_id();
+        let zeros = vec![0u8; num_bytes];
+        let buffer = self.create_buffer_with_data(&zeros);
+        self.input_data.remove(&id);
+        self.hlir_buffers.insert(id, buffer);
+    }
+
+    pub fn remove_buffer(&mut self, id: impl ToId) -> WebGpuBuffer {
+        let data_id = self.follow_aliases(self.output_data_node(id.to_id()));
+
+        if let Some(buffer) = self.buffers.remove(&data_id) {
+            self.buffer_lengths.remove(&data_id);
+            return buffer;
+        }
+
+        if let Some(Input { node, .. }) = self.llir_graph[data_id].to_op::<Input>() {
+            return self
+                .hlir_buffers
+                .remove(&NodeIndex::new(*node))
+                .expect("Cannot find input tensor in runtime!");
+        }
+
+        panic!("Cannot find tensor in runtime!");
+    }
+
+    pub fn set_buffer(&mut self, id: impl ToId, buffer: WebGpuBuffer) {
+        let id = id.to_id();
+        self.input_data.remove(&id);
+        self.hlir_buffers.insert(id, buffer);
+    }
+
+    pub fn get_f32(&self, id: impl ToId) -> Vec<f32> {
+        let data_id = self.follow_aliases(self.output_data_node(id.to_id()));
+
+        let buffer = self
+            .buffers
+            .get(&data_id)
+            .or_else(|| {
+                if let Some(Input { node, .. }) = self.llir_graph[data_id].to_op::<Input>() {
+                    self.hlir_buffers.get(&NodeIndex::new(*node))
+                } else {
+                    None
+                }
+            })
+            .expect("Cannot find tensor in runtime!");
+        let dtype = self
+            .node_dtypes
+            .get(&data_id)
+            .copied()
+            .or_else(|| {
+                self.llir_graph[data_id]
+                    .to_op::<Input>()
+                    .map(|inp| inp.dtype)
+            })
+            .unwrap_or(DType::F32);
+        let logical_bytes = self
+            .buffer_lengths
+            .get(&data_id)
+            .copied()
+            .unwrap_or_else(|| buffer.length());
+        assert!(
+            logical_bytes <= buffer.length(),
+            "Logical buffer size exceeds allocated WebGPU buffer size"
+        );
+
+        let bytes = self.read_buffer(buffer, logical_bytes);
+        match dtype {
+            DType::F16 => bytemuck::cast_slice::<u8, f16>(&bytes)
+                .iter()
+                .map(|v| v.to_f32())
+                .collect(),
+            DType::Int => bytemuck::cast_slice::<u8, i32>(&bytes)
+                .iter()
+                .map(|v| *v as f32)
+                .collect(),
+            _ => bytemuck::cast_slice::<u8, f32>(&bytes).to_vec(),
+        }
+    }
+
+    fn read_buffer(&self, buffer: &WebGpuBuffer, logical_bytes: u64) -> Vec<u8> {
+        let copy_bytes = Self::aligned_size(logical_bytes);
+        assert!(copy_bytes <= buffer.length());
+        let staging = self.device.create_buffer(&wgpu::BufferDescriptor {
+            label: None,
+            size: copy_bytes,
+            usage: wgpu::BufferUsages::MAP_READ | wgpu::BufferUsages::COPY_DST,
+            mapped_at_creation: false,
+        });
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        encoder.copy_buffer_to_buffer(buffer.raw(), 0, &staging, 0, copy_bytes);
+        self.queue.submit(Some(encoder.finish()));
+
+        let slice = staging.slice(..copy_bytes);
+        let (tx, rx) = std::sync::mpsc::channel();
+        slice.map_async(wgpu::MapMode::Read, move |result| {
+            tx.send(result).expect("readback receiver dropped");
+        });
+        self.device.poll(wgpu::Maintain::Wait);
+        rx.recv()
+            .expect("readback sender dropped")
+            .expect("failed to map WebGPU readback buffer");
+
+        let mapped = slice.get_mapped_range();
+        let bytes = mapped[..logical_bytes as usize].to_vec();
+        drop(mapped);
+        staging.unmap();
+        bytes
+    }
+
+    fn create_input_buffer(&self, data: &NativeData, dtype: DType) -> WebGpuBuffer {
+        match dtype {
+            DType::F32 | DType::TF32 => self.buffer_from_slice(&data.to_f32_vec()),
+            DType::F16 => self.buffer_from_slice(&data.to_f16_vec()),
+            DType::Int => self.buffer_from_slice(&data.to_i32_vec()),
+            unsupported => panic!("WebGPU input dtype {unsupported:?} is not supported yet"),
+        }
+    }
+
+    pub fn allocate_intermediate_buffers(&mut self, dyn_map: &FxHashMap<char, usize>) {
+        self.select_bucket(dyn_map);
+        self.allocate_active_intermediate_buffers(dyn_map);
+    }
+
+    fn allocate_active_intermediate_buffers(&mut self, dyn_map: &FxHashMap<char, usize>) {
+        let mut planned = Vec::new();
+        let capacity_dyn_map = self.active_capacity_dyn_map(dyn_map);
+
+        for node in self.llir_graph.node_indices() {
+            if self.llir_graph[node].to_op::<Input>().is_some() {
+                continue;
+            }
+
+            if let Some(kernel_op) = self.llir_graph[node].to_dialect::<dyn WebGpuKernelOp>() {
+                if kernel_op.output_aliases_input().is_some() {
+                    continue;
+                }
+                let dtype = self.node_dtypes.get(&node).copied().unwrap_or(DType::F32);
+                let requested_bytes =
+                    Self::output_bytes(kernel_op.as_ref().as_ref(), dtype, dyn_map);
+                let allocation_bytes =
+                    Self::output_bytes(kernel_op.as_ref().as_ref(), dtype, &capacity_dyn_map)
+                        .max(requested_bytes);
+                let needs_buffer = self
+                    .buffers
+                    .get(&node)
+                    .is_none_or(|buffer| requested_bytes > buffer.length());
+
+                planned.push((node, requested_bytes, allocation_bytes, needs_buffer));
+            }
+        }
+
+        for (node, requested_bytes, allocation_bytes, needs_buffer) in planned {
+            self.buffer_lengths.insert(node, requested_bytes);
+            if needs_buffer {
+                self.buffers
+                    .insert(node, self.create_buffer(allocation_bytes));
+            }
+        }
+    }
+
+    fn output_bytes(
+        kernel_op: &dyn WebGpuKernelOp,
+        dtype: DType,
+        dyn_map: &FxHashMap<char, usize>,
+    ) -> u64 {
+        let size = kernel_op.output_size().exec(dyn_map).unwrap();
+        (size * dtype.bits().div_ceil(8)) as u64
+    }
+
+    fn active_capacity_dyn_map(&self, dyn_map: &FxHashMap<char, usize>) -> FxHashMap<char, usize> {
+        let mut capacity_dyn_map = dyn_map.clone();
+        let Some(active_bucket) = self.compiled_buckets.get(self.active_bucket) else {
+            return capacity_dyn_map;
+        };
+
+        for (&dim, buckets) in &self.dim_buckets {
+            if let Some(&bucket_index) = active_bucket.bucket_indices.get(&dim)
+                && let Some(bucket) = buckets.get(bucket_index)
+            {
+                capacity_dyn_map.insert(dim, bucket.max);
+            }
+        }
+
+        capacity_dyn_map
+    }
+
+    fn compile_bucket(
+        &self,
+        bucket_indices: FxHashMap<char, usize>,
+        llir_graph: &LLIRGraph,
+    ) -> WebGpuCompiledBucket {
+        let mut node_dtypes = FxHashMap::default();
+        let mut pipelines = FxHashMap::default();
+        let mut output_alias_map = FxHashMap::default();
+        let mut output_data_map = FxHashMap::default();
+        let mut execution_plan = Vec::new();
+        let mut llir_to_hlir = FxHashMap::default();
+        let llir_graph = llir_graph.clone();
+
+        let topo_order = toposort(&llir_graph, None).expect("Graph has cycles!");
+        for node in &topo_order {
+            let node = *node;
+            if let Some(input) = llir_graph[node].to_op::<Input>() {
+                node_dtypes.insert(node, input.dtype);
+                llir_to_hlir.insert(node, NodeIndex::new(input.node));
+                continue;
+            }
+
+            if llir_graph[node].to_op::<Output>().is_some() {
+                continue;
+            }
+
+            if let Some(kernel_op) = llir_graph[node].to_dialect::<dyn WebGpuKernelOp>() {
+                let input_nodes: Vec<NodeIndex> = llir_graph
+                    .edges_directed(node, Direction::Incoming)
+                    .sorted_by_key(|e| e.id())
+                    .map(|e| e.source())
+                    .collect();
+                let input_dtypes: Vec<DType> = input_nodes
+                    .iter()
+                    .map(|n| {
+                        node_dtypes
+                            .get(n)
+                            .copied()
+                            .unwrap_or_else(|| panic!("Missing inferred dtype for node {n:?}"))
+                    })
+                    .collect();
+                let output_dtype = kernel_op.infer_output_dtype(&input_dtypes);
+                let pipeline = kernel_op.compile(&self.device, &input_dtypes, output_dtype);
+                node_dtypes.insert(node, output_dtype);
+                if let Some(pipeline) = pipeline {
+                    pipelines.insert(node, pipeline);
+                }
+                if let Some(input_idx) = kernel_op.output_aliases_input()
+                    && let Some(target) = input_nodes.get(input_idx).copied()
+                {
+                    output_alias_map.insert(node, target);
+                }
+                execution_plan.push(WebGpuExecutionStep {
+                    node,
+                    input_nodes,
+                    input_dtypes,
+                    output_dtype,
+                });
+            } else {
+                panic!("WebGPU runtime cannot execute unlowered LLIR node {node:?}");
+            }
+        }
+
+        for node in topo_order {
+            if let Some(Output { node: hlir_node }) = llir_graph[node].to_op::<Output>()
+                && let Some(data_node) = llir_graph
+                    .edges_directed(node, Direction::Incoming)
+                    .sorted_by_key(|e| e.id())
+                    .next()
+                    .map(|e| e.source())
+            {
+                output_data_map.insert(NodeIndex::new(*hlir_node), data_node);
+            }
+        }
+
+        WebGpuCompiledBucket {
+            bucket_indices,
+            llir_graph,
+            llir_to_hlir,
+            node_dtypes,
+            pipelines,
+            output_alias_map,
+            output_data_map,
+            execution_plan,
+        }
+    }
+
+    fn activate_bucket(&mut self, index: usize) {
+        let bucket = self
+            .compiled_buckets
+            .get(index)
+            .unwrap_or_else(|| panic!("WebGPU bucket index {index} is not compiled"))
+            .clone();
+        self.active_bucket = index;
+        self.llir_graph = bucket.llir_graph;
+        self.llir_to_hlir = bucket.llir_to_hlir;
+        self.node_dtypes = bucket.node_dtypes;
+        self.pipelines = bucket.pipelines;
+        self.output_alias_map = bucket.output_alias_map;
+        self.output_data_map = bucket.output_data_map;
+        self.execution_plan = bucket.execution_plan;
+        self.refresh_input_data_buffers();
+        self.buffers.clear();
+        self.buffer_lengths.clear();
+    }
+
+    fn refresh_input_data_buffers(&mut self) {
+        for node in self.llir_graph.node_indices() {
+            if let Some(input) = self.llir_graph[node].to_op::<Input>() {
+                let hlir_id = NodeIndex::new(input.node);
+                if let Some(data) = self.input_data.get(&hlir_id) {
+                    let buffer = self.create_input_buffer(data, input.dtype);
+                    self.hlir_buffers.insert(hlir_id, buffer);
+                }
+            }
+        }
+    }
+
+    fn select_bucket(&mut self, dyn_map: &FxHashMap<char, usize>) {
+        if self.compiled_buckets.len() <= 1 {
+            return;
+        }
+
+        let index = self.resolve_bucket(dyn_map);
+        if index != self.active_bucket {
+            self.activate_bucket(index);
+        }
+    }
+
+    fn resolve_bucket(&self, dyn_map: &FxHashMap<char, usize>) -> usize {
+        self.compiled_buckets
+            .iter()
+            .position(|bucket| {
+                self.dim_buckets.iter().all(|(dim, buckets)| {
+                    let value = dyn_map.get(dim).copied().unwrap_or(0);
+                    let bucket_index = bucket.bucket_indices.get(dim).copied().unwrap_or(0);
+                    buckets
+                        .get(bucket_index)
+                        .map(|bucket| bucket.contains(value))
+                        .unwrap_or(true)
+                })
+            })
+            .unwrap_or_else(|| {
+                panic!(
+                    "No WebGPU bucket matches dyn_map {:?}. Defined buckets: {:?}",
+                    dyn_map, self.dim_buckets
+                )
+            })
+    }
+
+    fn execute_timed(&mut self, dyn_map: &FxHashMap<char, usize>) -> (f64, TimingMethod) {
+        let start = std::time::Instant::now();
+        self.execute(dyn_map);
+        (
+            start.elapsed().as_secs_f64() * 1_000_000.0,
+            TimingMethod::WallClock,
+        )
+    }
+}
+
+impl Runtime for WebGpuRuntime {
+    type Ops = crate::kernel::WebGpuOps;
+    type CompileArg = ();
+    type ExecReturn = ();
+    type ProfileMetric = Duration;
+
+    fn late_egglog_passes(
+        ops: &[std::sync::Arc<Box<dyn luminal::op::EgglogOp>>],
+        options: &luminal::graph::CompileOptions,
+        dyn_map: &FxHashMap<char, usize>,
+    ) -> Vec<luminal::egglog_utils::LateEgglogPass> {
+        vec![crate::memory_analysis::webgpu_memory_analysis_pass(
+            ops,
+            options.max_memory_bytes,
+            dyn_map,
+        )]
+    }
+
+    fn estimate_graph_memory<'a>(
+        egraph: &'a SerializedEGraph,
+        choices: &luminal::egglog_utils::EGraphChoiceSet<'a>,
+        dyn_map: &FxHashMap<char, usize>,
+    ) -> Option<usize> {
+        crate::memory_analysis::estimate_graph_memory_bytes(egraph, choices, dyn_map)
+    }
+
+    fn initialize(_: Self::CompileArg) -> Self {
+        let instance = wgpu::Instance::default();
+        let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
+            power_preference: wgpu::PowerPreference::HighPerformance,
+            compatible_surface: None,
+            force_fallback_adapter: false,
+        }))
+        .expect("No WebGPU adapter found!");
+        let limits = adapter.limits();
+        let max_compute_workgroups_per_dimension = limits.max_compute_workgroups_per_dimension;
+        let (device, queue) = pollster::block_on(adapter.request_device(
+            &wgpu::DeviceDescriptor {
+                label: Some("luminal-webgpu-device"),
+                required_features: wgpu::Features::empty(),
+                required_limits: limits,
+            },
+            None,
+        ))
+        .expect("Failed to create WebGPU device!");
+
+        Self {
+            device,
+            queue,
+            max_compute_workgroups_per_dimension,
+            input_data: FxHashMap::default(),
+            hlir_buffers: FxHashMap::default(),
+            buffers: FxHashMap::default(),
+            buffer_lengths: FxHashMap::default(),
+            llir_graph: StableGraph::default(),
+            llir_to_hlir: FxHashMap::default(),
+            node_dtypes: FxHashMap::default(),
+            pipelines: FxHashMap::default(),
+            output_alias_map: FxHashMap::default(),
+            output_data_map: FxHashMap::default(),
+            execution_plan: vec![],
+            dim_buckets: FxHashMap::default(),
+            compiled_buckets: vec![],
+            active_bucket: 0,
+        }
+    }
+
+    fn aggregate_profile_metrics(metrics: &[Self::ProfileMetric]) -> Self::ProfileMetric {
+        metrics.iter().copied().sum()
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn load_llir(&mut self, llir_graph: &LLIRGraph) {
+        self.buffers.clear();
+        self.buffer_lengths.clear();
+        self.dim_buckets.clear();
+        self.compiled_buckets = vec![self.compile_bucket(FxHashMap::default(), llir_graph)];
+        self.activate_bucket(0);
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn profile(
+        &mut self,
+        llir_graph: &LLIRGraph,
+        dyn_map: &FxHashMap<char, usize>,
+        trials: usize,
+        timeout: Option<std::time::Duration>,
+    ) -> (Self::ProfileMetric, String) {
+        self.load_llir(llir_graph);
+        self.allocate_intermediate_buffers(dyn_map);
+
+        let trials = trials.max(1);
+        let profile_start = std::time::Instant::now();
+        let mut duration = Duration::default();
+        let mut completed_trials = 0;
+        for _ in 0..trials {
+            let start = std::time::Instant::now();
+            self.execute(dyn_map);
+            duration += start.elapsed();
+            completed_trials += 1;
+            if timeout.is_some_and(|timeout| profile_start.elapsed() >= timeout) {
+                break;
+            }
+        }
+        duration /= completed_trials as u32;
+
+        (duration, format!("{:.2?}", duration))
+    }
+
+    #[tracing::instrument(skip_all)]
+    fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) -> Self::ExecReturn {
+        self.select_bucket(dyn_map);
+        self.allocate_active_intermediate_buffers(dyn_map);
+
+        const STEPS_PER_SUBMIT: usize = 64;
+        let mut encoder = self
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+        let mut encoded_steps = 0usize;
+
+        for step in &self.execution_plan {
+            let mut encode_context = WebGpuEncodeContext {
+                device: &self.device,
+                encoder: &mut encoder,
+                dyn_map,
+                max_compute_workgroups_per_dimension: self.max_compute_workgroups_per_dimension,
+            };
+
+            let kernel_op = self.llir_graph[step.node]
+                .to_dialect::<dyn WebGpuKernelOp>()
+                .expect("Execution plan referenced a non-WebGPU op");
+            let pipeline = self.pipelines.get(&step.node);
+
+            let input_buffers: Vec<&WebGpuBuffer> = step
+                .input_nodes
+                .iter()
+                .map(|&n| self.buffer_for_llir_node(n, &self.llir_to_hlir))
+                .collect();
+
+            let output_buffer = if let Some(alias_idx) = kernel_op.output_aliases_input() {
+                input_buffers[alias_idx]
+            } else {
+                self.buffers
+                    .get(&step.node)
+                    .expect("Output buffer not allocated!")
+            };
+
+            kernel_op.encode(
+                &mut encode_context,
+                pipeline,
+                &input_buffers,
+                output_buffer,
+                dyn_map,
+                &step.input_dtypes,
+                step.output_dtype,
+            );
+
+            encoded_steps += 1;
+            if encoded_steps == STEPS_PER_SUBMIT {
+                self.queue.submit(Some(encoder.finish()));
+                encoder = self
+                    .device
+                    .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: None });
+                encoded_steps = 0;
+            }
+        }
+
+        if encoded_steps > 0 {
+            self.queue.submit(Some(encoder.finish()));
+        }
+        self.device.poll(wgpu::Maintain::Wait);
+    }
+
+    fn clear_intermediate_buffers(&mut self) {
+        self.buffers.clear();
+        self.buffer_lengths.clear();
+    }
+
+    fn intermediate_buffer_bytes(&self) -> usize {
+        self.buffers
+            .values()
+            .map(|buffer| buffer.length() as usize)
+            .sum()
+    }
+
+    fn planned_intermediate_buffer_bytes(&self) -> Option<usize> {
+        Some(self.intermediate_buffer_bytes())
+    }
+
+    fn allocated_intermediate_buffer_bytes(&self) -> Option<usize> {
+        Some(self.intermediate_buffer_bytes())
+    }
+
+    fn load_llir_buckets(
+        &mut self,
+        dim_buckets: &FxHashMap<char, Vec<DimBucket>>,
+        bucket_llirs: &[BucketLLIR],
+    ) {
+        self.buffers.clear();
+        self.buffer_lengths.clear();
+        self.dim_buckets = dim_buckets.clone();
+        self.compiled_buckets = bucket_llirs
+            .iter()
+            .map(|(bucket_indices, _, llir)| self.compile_bucket(bucket_indices.clone(), llir))
+            .collect();
+        assert!(
+            !self.compiled_buckets.is_empty(),
+            "WebGPU runtime received no bucketed LLIRs"
+        );
+        self.activate_bucket(0);
+    }
+}
+
+impl RuntimeStats for WebGpuRuntime {
+    fn execute_with_stats(&mut self, dyn_map: &FxHashMap<char, usize>) -> Option<ExecutionStats> {
+        let mut total_bytes_loaded = 0usize;
+        let mut total_bytes_stored = 0usize;
+        let mut total_flops = 0usize;
+
+        for node in self.llir_graph.node_indices() {
+            if let Some(kernel_op) = self.llir_graph[node].to_dialect::<dyn WebGpuKernelOp>() {
+                total_bytes_loaded += kernel_op.bytes_loaded(dyn_map);
+                total_bytes_stored += kernel_op.bytes_stored(dyn_map);
+                total_flops += kernel_op.flops(dyn_map);
+            }
+        }
+        let (time_us, timing_method) = self.execute_timed(dyn_map);
+
+        Some(ExecutionStats::with_timing_method(
+            time_us,
+            total_bytes_loaded,
+            total_bytes_stored,
+            total_flops,
+            timing_method,
+        ))
+    }
+}

--- a/crates/luminal_webgpu/src/tests.rs
+++ b/crates/luminal_webgpu/src/tests.rs
@@ -1,0 +1,116 @@
+use crate::{
+    kernel::{lower_expression_for_webgpu, lower_scalar_expression_for_webgpu},
+    runtime::WebGpuRuntime,
+};
+use luminal::prelude::*;
+
+fn assert_close(actual: &[f32], expected: &[f32], tolerance: f32) {
+    assert_eq!(
+        actual.len(),
+        expected.len(),
+        "Length mismatch: got {}, expected {}",
+        actual.len(),
+        expected.len()
+    );
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        let diff = (a - e).abs();
+        let rel_err = diff / e.abs().max(1.0);
+        assert!(
+            rel_err < tolerance,
+            "Mismatch at index {i}: got {a}, expected {e}, rel_err={rel_err}"
+        );
+    }
+}
+
+#[test]
+fn dynamic_const_codegen_uses_params_buffer() {
+    let expr = (Expression::from('a') * 2 + Expression::from('z')).simplify();
+    let code = lower_expression_for_webgpu(&expr, "idx");
+
+    assert!(
+        !code.contains("const_"),
+        "dynamic symbols should be lowered via params buffer, got: {code}"
+    );
+    assert!(
+        code.contains("params.dims["),
+        "expected generated kernel expression to reference params buffer, got: {code}"
+    );
+}
+
+#[test]
+fn scalar_codegen_treats_z_as_stride_unit() {
+    let expr = (Expression::from('a') * Expression::from('z')).simplify();
+    let code = lower_scalar_expression_for_webgpu(&expr);
+
+    assert!(
+        code.contains("params.dims["),
+        "dynamic symbols should still lower through params, got: {code}"
+    );
+    assert!(
+        !code.contains("idx"),
+        "scalar stride expressions should substitute z with one, got: {code}"
+    );
+}
+
+#[test]
+#[ignore = "requires a WebGPU adapter"]
+fn webgpu_simple_add_runs() {
+    let mut cx = Graph::default();
+    let a = cx.tensor(4);
+    let b = cx.tensor(4);
+    let output = (a + b).output();
+
+    cx.build_search_space::<WebGpuRuntime>(CompileOptions::default());
+    let mut rt = WebGpuRuntime::initialize(());
+    rt.set_data(a, &[1.0, 2.0, 3.0, 4.0]);
+    rt.set_data(b, &[5.0, 6.0, 7.0, 8.0]);
+    rt = cx.search(rt, CompileOptions::new(5));
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(output), &[6.0, 8.0, 10.0, 12.0], 0.001);
+}
+
+#[test]
+#[ignore = "requires a WebGPU adapter"]
+fn webgpu_generic_matmul_runs() {
+    let mut cx = Graph::default();
+    let a = cx.tensor((2, 3));
+    let b = cx.tensor((3, 2));
+    let output = a.matmul(b).output();
+
+    cx.build_search_space::<WebGpuRuntime>(CompileOptions::default());
+    let mut rt = WebGpuRuntime::initialize(());
+    rt.set_data(a, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
+    rt.set_data(b, &[7.0, 8.0, 9.0, 10.0, 11.0, 12.0]);
+    rt = cx.search(rt, CompileOptions::new(10));
+    rt.execute(&cx.dyn_map);
+
+    assert_close(&rt.get_f32(output), &[58.0, 64.0, 139.0, 154.0], 0.001);
+    assert!(
+        rt.contains_matmul(),
+        "expected WebGPU search to select a matmul kernel, got {:?}",
+        rt.debug_kernel_ops()
+    );
+}
+
+#[test]
+#[ignore = "requires a WebGPU adapter"]
+fn webgpu_large_reduce_dispatch_chunks() {
+    const ROWS: usize = 128_256;
+
+    let mut cx = Graph::default();
+    let input = cx.tensor((ROWS, 2));
+    let output = input.sum(1).output();
+
+    cx.build_search_space::<WebGpuRuntime>(CompileOptions::default());
+    let mut rt = WebGpuRuntime::initialize(());
+    let data = vec![1.0f32; ROWS * 2];
+    rt.set_data(input, data);
+    rt = cx.search(rt, CompileOptions::new(5));
+    rt.execute(&cx.dyn_map);
+
+    let result = rt.get_f32(output);
+    assert_eq!(result.len(), ROWS);
+    assert_close(&result[..8], &[2.0; 8], 0.001);
+    assert_close(&result[ROWS - 8..], &[2.0; 8], 0.001);
+}

--- a/crates/luminal_webgpu/src/tests.rs
+++ b/crates/luminal_webgpu/src/tests.rs
@@ -64,7 +64,13 @@ fn webgpu_simple_add_runs() {
     let mut rt = WebGpuRuntime::initialize(());
     rt.set_data(a, &[1.0, 2.0, 3.0, 4.0]);
     rt.set_data(b, &[5.0, 6.0, 7.0, 8.0]);
-    rt = cx.search(rt, CompileOptions::new(5));
+    rt = cx.search(
+        rt,
+        CompileOptions {
+            limit: 5,
+            ..CompileOptions::default()
+        },
+    );
     rt.execute(&cx.dyn_map);
 
     assert_close(&rt.get_f32(output), &[6.0, 8.0, 10.0, 12.0], 0.001);
@@ -82,7 +88,13 @@ fn webgpu_generic_matmul_runs() {
     let mut rt = WebGpuRuntime::initialize(());
     rt.set_data(a, &[1.0, 2.0, 3.0, 4.0, 5.0, 6.0]);
     rt.set_data(b, &[7.0, 8.0, 9.0, 10.0, 11.0, 12.0]);
-    rt = cx.search(rt, CompileOptions::new(10));
+    rt = cx.search(
+        rt,
+        CompileOptions {
+            limit: 10,
+            ..CompileOptions::default()
+        },
+    );
     rt.execute(&cx.dyn_map);
 
     assert_close(&rt.get_f32(output), &[58.0, 64.0, 139.0, 154.0], 0.001);
@@ -106,7 +118,13 @@ fn webgpu_large_reduce_dispatch_chunks() {
     let mut rt = WebGpuRuntime::initialize(());
     let data = vec![1.0f32; ROWS * 2];
     rt.set_data(input, data);
-    rt = cx.search(rt, CompileOptions::new(5));
+    rt = cx.search(
+        rt,
+        CompileOptions {
+            limit: 5,
+            ..CompileOptions::default()
+        },
+    );
     rt.execute(&cx.dyn_map);
 
     let result = rt.get_f32(output);


### PR DESCRIPTION
The WebGPU runtime is modeled after the Metal and Cuda runtime and supports the basic kernel set needed to run `examples/llama_1b.rs`, including `elementwise` ops, `reductions`, `constants/iota`, `gather/scatter`, `casts`, safetensor loading, memory analysis, dynamic shape buckets, and a copied WebGPU `llama_1b` example.

this will enable luminal to work basically on every major platform/arch  e.g android/wasm/amd/intel

things worth mentioning :
- Query WebGPU adapter limits and request the device with those limits.
- Chunk large 1D/reduction dispatches against `max_compute_workgroups_per_dimension` instead of assuming the default i.e `65535`.
- Add `WebGpuMatmul` lowering through egglog, plus a tiled WGSL matmul kernel for projection/logits paths.
- Split long executions into bounded command-buffer submissions to avoid one huge command buffer for the llama graph.


i did some benchmarking between metal and WebGPU on m-chip and metal is 19%~ faster 