### PR TITLE
cuda_lite: bf16 NVRTC ambiguity fixes (Recip and reduce_max_k)

### DIFF
--- a/crates/luminal_cuda_lite/src/kernel/fusion/region_codegen.rs
+++ b/crates/luminal_cuda_lite/src/kernel/fusion/region_codegen.rs
@@ -362,7 +362,7 @@ fn elementwise_body(op: &str, locals: &[&str], dtype: DType) -> String {
         "Exp" => format!("expf({})", a()),
         "Exp2" => format!("exp2f({})", a()),
         "Log2" => format!("log2f({})", a()),
-        "Recip" => format!("1.0f / {}", a()),
+        "Recip" => format!("static_cast<{}>(1.0f) / {}", cuda_dtype(dtype), a()),
         "Sigmoid" => format!("1.0f / (1.0f + expf(-{}))", a()),
         "Add" => format!("{} + {}", a(), b()),
         "Mul" => format!("{} * {}", a(), b()),

--- a/crates/luminal_cuda_lite/src/kernel/hlir.rs
+++ b/crates/luminal_cuda_lite/src/kernel/hlir.rs
@@ -196,7 +196,7 @@ extern \"C\" {{
         long long in_start = {in_index};
         long long iters = {iters};
 
-        {dtype} max_value = NEG_INF_F;
+        {dtype} max_value = ({dtype})NEG_INF_F;
         for (long long i = tid; i < iters; i += THREADS_PER_BLOCK) {{
             max_value = fmaxf(max_value, in[in_start + {iter_stride_of_i}]);
         }}
@@ -213,7 +213,7 @@ extern \"C\" {{
 
         if (warp_id == 0) {{
             int cnt = THREADS_PER_BLOCK / WARP_SIZE;
-            {dtype} block_max = tid < cnt ? warp_sums[tid] : NEG_INF_F;
+            {dtype} block_max = tid < cnt ? warp_sums[tid] : ({dtype})NEG_INF_F;
 
             #pragma unroll
             for (int s = cnt / 2; s > 0; s /= 2) {{


### PR DESCRIPTION
## Summary

- `region_codegen.rs::Recip`: cast the `1.0f` literal to the input dtype so `/` resolves unambiguously for bf16 inputs (NVRTC otherwise can't pick between `operator/(bf16, bf16)` and `operator/(float, float)`).
- `hlir.rs::reduce_max_k`: cast `NEG_INF_F` to the input dtype at both use sites (initializer + warp-reduce ternary) for the same reason.

Two files, three line changes total.

## Test plan

- [x] `./run_tests_cuda.sh --include-slow` — 494 passed, 2 skipped, 4 xfailed, 23 min
- [x] Build clean on CUDA 12.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)