### PR TITLE
Tucker/cublaslt fp8 guard fast fail

### DIFF
--- a/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_fp8_rewrite.egg
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_fp8_rewrite.egg
@@ -10,6 +10,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         ; Match the scaled FP8 linear form directly before the unscaled FP8
         ; matmul rewrite can hide the quantize/dequant scale structure.
         (= ?scaled_activation (Op (Mul
@@ -87,6 +88,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         (= ?scaled_activation (Op (Mul
             ?activation_shape
             ?raw_activation_strides
@@ -196,6 +198,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         ; Fusion growth can make the live path consume a raw FP8 cuBLASLt
         ; candidate through an internal CudaBinaryElementwise scale multiply,
         ; instead of the original HLIR output-scale Mul. The scalar scale
@@ -274,6 +277,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         (= ?raw_gemm (Op (cublaslt
             ?cm ?cn ?ck
             ?cta ?ctb
@@ -361,6 +365,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         ; Batched form of the scaled FP8 linear rewrite. The scale operands are
         ; scalar tensors expanded across the last three output/activation axes.
         (= ?scaled_activation (Op (Mul
@@ -452,6 +457,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride
@@ -505,6 +511,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride
@@ -558,6 +565,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride
@@ -611,6 +619,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride
@@ -678,6 +687,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride
@@ -745,6 +755,7 @@
 
 (rule
     (
+        (cublaslt_fp8_present)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride

--- a/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_fp8_rewrite.egg
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_fp8_rewrite.egg
@@ -10,7 +10,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         ; Match the scaled FP8 linear form directly before the unscaled FP8
         ; matmul rewrite can hide the quantize/dequant scale structure.
         (= ?scaled_activation (Op (Mul
@@ -88,7 +88,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         (= ?scaled_activation (Op (Mul
             ?activation_shape
             ?raw_activation_strides
@@ -198,7 +198,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         ; Fusion growth can make the live path consume a raw FP8 cuBLASLt
         ; candidate through an internal CudaBinaryElementwise scale multiply,
         ; instead of the original HLIR output-scale Mul. The scalar scale
@@ -277,7 +277,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         (= ?raw_gemm (Op (cublaslt
             ?cm ?cn ?ck
             ?cta ?ctb
@@ -365,7 +365,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         ; Batched form of the scaled FP8 linear rewrite. The scale operands are
         ; scalar tensors expanded across the last three output/activation axes.
         (= ?scaled_activation (Op (Mul
@@ -457,7 +457,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride
@@ -511,7 +511,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride
@@ -565,7 +565,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride
@@ -619,7 +619,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride
@@ -687,7 +687,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride
@@ -755,7 +755,7 @@
 
 (rule
     (
-        (cublaslt_fp8_present)
+        (cublaslt_fp8_ir ?a)
         (= ?sum (Op (GenericMatmul
             ?out_shape ?mul_shape ?k
             ?a_stride ?b_stride

--- a/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
@@ -193,6 +193,20 @@ impl EgglogOp for CuBlasLt {
                  ; On graphs without FP8 (e.g. bf16 gemma), this relation stays
                  ; empty and the gated rules' first LHS fact fails the join
                  ; immediately instead of paying multi-way enumeration cost.
+                 ;
+                 ; This is a temporary workaround to get gemma-4 MoE working
+                 ; through luminal_python — PT2 produces a denser HLIR than
+                 ; the hand-written rust path (many more Mul/Cast/Recip
+                 ; nodes), which pushes the fp8 rules' multi-way LHS join
+                 ; over a cardinality cliff (~270 GiB of transient
+                 ; allocation on a 124K-node e-graph). The real fix is to
+                 ; understand WHY these specific rules' intermediate join
+                 ; state grows so large when their final match count is 0 —
+                 ; whether it's a planner ordering issue, a rule-structure
+                 ; issue (the join may be expressible with smaller
+                 ; intermediates), or something egglog-internal that should
+                 ; be reported upstream. Until then, the guard short-
+                 ; circuits the join before any of that cost is paid.
                  (relation cublaslt_fp8_present ())
                  (rule
                      ((= ?c (Op (Cast ?size ?dtype) ?inputs))

--- a/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
@@ -188,30 +188,29 @@ impl EgglogOp for CuBlasLt {
                  (cublaslt_fp8_f32_output_pair (F8E4M3) (F8E4M3))
                  (cublaslt_fp8_f32_output_pair (F8E4M3) (F8E5M2))
                  (cublaslt_fp8_f32_output_pair (F8E5M2) (F8E4M3))
-                 ; Fast-fail guard for the FP8 lowering rules: assert
-                 ; cublaslt_fp8_present iff any Cast op targets an FP8 dtype.
-                 ; On graphs without FP8 (e.g. bf16 gemma), this relation stays
-                 ; empty and the gated rules' first LHS fact fails the join
-                 ; immediately instead of paying multi-way enumeration cost.
+                 ; Indexable seed for the FP8 lowering rules. Tags every IR
+                 ; node whose dtype is FP8. Each fp8 rewrite rule in
+                 ; cublaslt_fp8_rewrite.egg starts its LHS with
+                 ; `(cublaslt_fp8_ir ?a)`, which binds the rule's FP8
+                 ; matmul-input variable from this small tagged set.
                  ;
-                 ; This is a temporary workaround to get gemma-4 MoE working
-                 ; through luminal_python — PT2 produces a denser HLIR than
-                 ; the hand-written rust path (many more Mul/Cast/Recip
-                 ; nodes), which pushes the fp8 rules' multi-way LHS join
-                 ; over a cardinality cliff (~270 GiB of transient
-                 ; allocation on a 124K-node e-graph). The real fix is to
-                 ; understand WHY these specific rules' intermediate join
-                 ; state grows so large when their final match count is 0 —
-                 ; whether it's a planner ordering issue, a rule-structure
-                 ; issue (the join may be expressible with smaller
-                 ; intermediates), or something egglog-internal that should
-                 ; be reported upstream. Until then, the guard short-
-                 ; circuits the join before any of that cost is paid.
-                 (relation cublaslt_fp8_present ())
+                 ; Why this matters: without the tag, the fp8 rules' LHS is
+                 ; a multi-way join over Mul x Recip x Cast x GenericMatmul
+                 ; x Cast x Mul x Mul. On PT2-produced HLIR (e.g. gemma-4
+                 ; MoE) those tables have thousands of entries each, and
+                 ; egglog's planner enumerates the join product before the
+                 ; per-rule dtype filter at the tail rejects everything
+                 ; (~270 GiB of transient join intermediates on a 124K-node
+                 ; e-graph). Starting the LHS from a relation with cardinality
+                 ; equal to the number of FP8-typed nodes (typically 0 on
+                 ; bf16 graphs, ~tens-hundreds on a quantized inference path)
+                 ; forces the planner to walk outward from a small set and
+                 ; keeps the rule cost bounded regardless of how dense the
+                 ; surrounding Mul/Cast tables are.
+                 (relation cublaslt_fp8_ir (IR))
                  (rule
-                     ((= ?c (Op (Cast ?size ?dtype) ?inputs))
-                      (cublaslt_fp8_dtype ?dtype))
-                     ((cublaslt_fp8_present))
+                     ((= ?dt (dtype ?n)) (cublaslt_fp8_dtype ?dt))
+                     ((cublaslt_fp8_ir ?n))
                      :ruleset matmul_backend)",
             ),
             Rule::raw(include_str!["cublaslt_RmRm_rewrite.egg"]), // row row

--- a/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
@@ -187,7 +187,18 @@ impl EgglogOp for CuBlasLt {
                  (relation cublaslt_fp8_f32_output_pair (DType DType))
                  (cublaslt_fp8_f32_output_pair (F8E4M3) (F8E4M3))
                  (cublaslt_fp8_f32_output_pair (F8E4M3) (F8E5M2))
-                 (cublaslt_fp8_f32_output_pair (F8E5M2) (F8E4M3))",
+                 (cublaslt_fp8_f32_output_pair (F8E5M2) (F8E4M3))
+                 ; Fast-fail guard for the FP8 lowering rules: assert
+                 ; cublaslt_fp8_present iff any Cast op targets an FP8 dtype.
+                 ; On graphs without FP8 (e.g. bf16 gemma), this relation stays
+                 ; empty and the gated rules' first LHS fact fails the join
+                 ; immediately instead of paying multi-way enumeration cost.
+                 (relation cublaslt_fp8_present ())
+                 (rule
+                     ((= ?c (Op (Cast ?size ?dtype) ?inputs))
+                      (cublaslt_fp8_dtype ?dtype))
+                     ((cublaslt_fp8_present))
+                     :ruleset matmul_backend)",
             ),
             Rule::raw(include_str!["cublaslt_RmRm_rewrite.egg"]), // row row
             Rule::raw(include_str!["cublaslt_RmCm_rewrite.egg"]), // row col

--- a/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
@@ -899,6 +899,76 @@ fn cublaslt_fp8_e5m2_same_type_does_not_match_f32_output() {
     cublaslt_fp8_same_type_does_not_match_batched_matmul_f32_output(DType::F8E5M2);
 }
 
+// --- cublaslt_fp8_present guard regression tests ---
+//
+// The FP8 lowering rules have a multi-way LHS join over Mul × Recip × Cast ×
+// GenericMatmul × Cast × Mul × Mul. On graphs with many of those ops (e.g. a
+// PT2-lowered gemma forward), the intermediate join cardinality explodes —
+// hundreds of GiB of transient allocation — even though the rule's dtype
+// filter ultimately rejects every candidate when no FP8 is present. The
+// `(cublaslt_fp8_present)` relation + auto-rule (declared in this module's
+// `rewrites()`) short-circuits the join at fact zero. These tests guard
+// against (a) the guard accidentally blocking valid FP8 lowering and
+// (b) the FP8 rules accidentally firing on bf16-only graphs.
+
+#[test]
+fn cublaslt_fp8_guard_does_not_block_scaled_fp8_lowering() {
+    // Mirrors `cublaslt_fp8_scaled_candidate_executes_2d_matmul_f32_output`
+    // up to the e-graph extraction step — the scaled FP8 pattern is the most
+    // complex of the gated rules, so it's the most likely to expose a
+    // misfiring guard.
+    let (m, n, k) = (16, 16, 16);
+    let mut cx = Graph::new();
+    let a = cx.tensor((m, k));
+    let a_scale = cx.tensor(());
+    let b_scale = cx.tensor(());
+    let b_input = cx.tensor((n, k)).as_dtype(DType::F8E4M3);
+    let b = b_input.t();
+    let scaled_a = (a / a_scale.expand_rhs((m, k))).cast(DType::F8E4M3);
+    let _out =
+        (scaled_a.matmul(b).cast(DType::F32) * (a_scale * b_scale).expand_rhs((m, n))).output();
+    let expected_tuple = (
+        DType::F8E4M3,
+        DType::F8E4M3,
+        DType::F32,
+        DType::F32,
+        "32F",
+        DType::F32,
+    );
+    let _llir = extract_forced_cublaslt_llir_where(
+        &mut cx,
+        "fp8 guard positive (scaled lowering still fires)",
+        |llir| {
+            cublaslt_type_tuples(llir).contains(&expected_tuple)
+                && cublaslt_tensor_scale_input_tuples(llir).contains(&(true, true))
+        },
+    );
+}
+
+#[test]
+fn cublaslt_fp8_guard_no_fp8_op_for_bf16_only_graph() {
+    // bf16 matmul with no FP8 Cast anywhere → cublaslt_fp8_present stays
+    // empty → none of the 11 fp8 lowering rules should produce a candidate
+    // with an FP8 dtype in either operand slot. (A bf16 cublasLt op is
+    // expected to appear via the RmRm/RmCm/CmRm/CmCm lowering paths.)
+    let (m, n, k) = (16, 16, 16);
+    let mut cx = Graph::new();
+    let a = cx.tensor((m, k)).as_dtype(DType::Bf16);
+    let b = cx.tensor((k, n)).as_dtype(DType::Bf16);
+    let _out = a.matmul(b).cast(DType::F32).output();
+
+    assert_no_cublaslt_llir_where(
+        &mut cx,
+        "fp8 guard negative (bf16-only graph must not produce FP8 cublasLt op)",
+        |llir| {
+            cublaslt_type_tuples(llir).iter().any(|tuple| {
+                matches!(tuple.0, DType::F8E4M3 | DType::F8E5M2)
+                    || matches!(tuple.1, DType::F8E4M3 | DType::F8E5M2)
+            })
+        },
+    );
+}
+
 #[test]
 #[ignore = "expensive CUDA functional candidate sweep; run with cargo test -p luminal_cuda_lite -- --ignored"]
 fn cublaslt_fp8_e4m3_beta_candidate_executes_2d_matmul_plus_f32_c() {

--- a/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
+++ b/crates/luminal_cuda_lite/src/tests/cublaslt_rewrite_tests.rs
@@ -899,24 +899,27 @@ fn cublaslt_fp8_e5m2_same_type_does_not_match_f32_output() {
     cublaslt_fp8_same_type_does_not_match_batched_matmul_f32_output(DType::F8E5M2);
 }
 
-// --- cublaslt_fp8_present guard regression tests ---
+// --- cublaslt_fp8_ir tag regression tests ---
 //
 // The FP8 lowering rules have a multi-way LHS join over Mul × Recip × Cast ×
 // GenericMatmul × Cast × Mul × Mul. On graphs with many of those ops (e.g. a
 // PT2-lowered gemma forward), the intermediate join cardinality explodes —
 // hundreds of GiB of transient allocation — even though the rule's dtype
-// filter ultimately rejects every candidate when no FP8 is present. The
-// `(cublaslt_fp8_present)` relation + auto-rule (declared in this module's
-// `rewrites()`) short-circuits the join at fact zero. These tests guard
-// against (a) the guard accidentally blocking valid FP8 lowering and
-// (b) the FP8 rules accidentally firing on bf16-only graphs.
+// filter ultimately rejects every candidate when no FP8 is present. Each
+// fp8 rule starts its LHS with `(cublaslt_fp8_ir ?a)`, where `?a` is the
+// rule's FP8 matmul-input variable. The `cublaslt_fp8_ir` relation (declared
+// in `cublaslt/mod.rs`'s `rewrites()`) tags every IR node with FP8 dtype, so
+// the planner walks outward from this small set instead of enumerating the
+// full Mul/Cast/Recip product. These tests guard against (a) the tag
+// accidentally blocking valid FP8 lowering and (b) the FP8 rules accidentally
+// firing on bf16-only graphs.
 
 #[test]
 fn cublaslt_fp8_guard_does_not_block_scaled_fp8_lowering() {
     // Mirrors `cublaslt_fp8_scaled_candidate_executes_2d_matmul_f32_output`
     // up to the e-graph extraction step — the scaled FP8 pattern is the most
-    // complex of the gated rules, so it's the most likely to expose a
-    // misfiring guard.
+    // complex of the gated rules, so it's the most likely to expose a tag
+    // that fails to bind correctly.
     let (m, n, k) = (16, 16, 16);
     let mut cx = Graph::new();
     let a = cx.tensor((m, k));
@@ -947,10 +950,10 @@ fn cublaslt_fp8_guard_does_not_block_scaled_fp8_lowering() {
 
 #[test]
 fn cublaslt_fp8_guard_no_fp8_op_for_bf16_only_graph() {
-    // bf16 matmul with no FP8 Cast anywhere → cublaslt_fp8_present stays
-    // empty → none of the 11 fp8 lowering rules should produce a candidate
-    // with an FP8 dtype in either operand slot. (A bf16 cublasLt op is
-    // expected to appear via the RmRm/RmCm/CmRm/CmCm lowering paths.)
+    // bf16 matmul with no FP8 Cast anywhere → cublaslt_fp8_ir stays empty
+    // → none of the 11 fp8 lowering rules can bind their `?a` seed → no
+    // FP8 cublasLt candidate appears. (A bf16 cublasLt op is expected to
+    // appear via the RmRm/RmCm/CmRm/CmCm lowering paths.)
     let (m, n, k) = (16, 16, 16);
     let mut cx = Graph::new();
     let a = cx.tensor((m, k)).as_dtype(DType::Bf16);


### PR DESCRIPTION
One of the fixes for Gemma4_moe through luminal_python, we OOM due to f8 matching rules(which there are not f8 ops in the graph). This is temp fix, that @asglover and I talked about in person as well.