### PR TITLE
test_llama3: relax decode-loop-dynamic atol to 5e-5

### DIFF
--- a/crates/luminal_python/tests/test_llama3.py
+++ b/crates/luminal_python/tests/test_llama3.py
@@ -265,7 +265,12 @@ def test_hf_llama3_1b_decode_loop_dynamic(device: torch.device):
         with torch.no_grad():
             ref = model(input_ids)
             out = compiled(input_ids)
-        assert torch.allclose(out.logits, ref.logits, atol=1e-5), (
+        # f32 reduction-order noise floor on a 16-layer Llama-3.2-1B: hidden
+        # states peak around magnitude 220 (1 ULP ~ 2.6e-5 at f32), LM head
+        # compresses to logit magnitudes ~21. Per-process max_diff sampled
+        # across H100+A100 lands in [1.30, 1.62] x 1e-5; atol=5e-5 leaves ~3x
+        # headroom while remaining 100x tighter than bf16 noise would be.
+        assert torch.allclose(out.logits, ref.logits, atol=5e-5), (
             f"step {step}: max_diff={torch.max(torch.abs(out.logits - ref.logits)).item():.2e}"
         )
         next_token = ref.logits[0, -1, :].argmax().item()


### PR DESCRIPTION
## Summary

- Relax `atol` from `1e-5` to `5e-5` on `test_hf_llama3_1b_decode_loop_dynamic`'s logits assertion.
- The test runs a 3-step recompile-each-step decode loop on Llama-3.2-1B in **f32** and asserts `torch.allclose(out.logits, ref.logits, atol=1e-5)` at each step. That tolerance is below the f32 reduction-order noise floor for a 16-layer transformer.

## Evidence

`conftest.py:20` already sets `torch.set_float32_matmul_precision("highest")` so TF32 is off on both eager and luminal. `cublaslt/mod.rs:463` confirms luminal uses full `CUBLAS_COMPUTE_32F` for f32 inputs. Neither side is losing precision via FAST modes.

Per-layer bisect (script at `/tmp/llama_f32_per_layer.py` from investigation):

| Stage              | max_diff   | rel       | ref_max |
|--------------------|------------|-----------|---------|
| layer 0 output     | 2.09e-7    | 8.7e-9    | 23.9    |
| layer 3 output     | 2.38e-6    | 1.1e-8    | 218     |
| layer 7 output     | 3.05e-5    | 1.4e-7    | 219     |
| layer 11 output    | 2.38e-6    | 1.1e-8    | 220     |
| layer 15 output    | 1.53e-5    | 1.1e-7    | 143     |
| full logits        | 1.05e-5    | 5.0e-7    | 20.9    |

Hidden states reach magnitudes ~220 (1 ULP ≈ 2.6e-5 at f32). LM head matmul (k=2048) compresses to logit magnitudes ~21; relative noise of ~5e-7 lands at ~1e-5 absolute. Cross-process egglog non-determinism samples different cuBLAS algorithms with different reduction trees, putting max_diff in the 1.3-1.6 × 10⁻⁵ band.

## Empirical samples

| Configuration                                                | Observed max_diff |
|--------------------------------------------------------------|-------------------|
| H100 local, 10 runs on a related WIP branch                  | 8 / 10 passed; failures at 1.30e-5, 1.34e-5 |
| Modal A100 CI, recent samples                                | 1.62e-5, 1.53e-5  |
| **Combined empirical max across ~13 runs**                   | **1.62e-5**       |

`atol=5e-5` gives ~3× headroom over the observed worst, while remaining 100× tighter than the bf16 noise floor (~5e-3) so a regression to bf16-grade precision would still trip it.

## Test plan

- [x] 10 runs locally on H100 with relaxed atol: 10 / 10 PASSED
- [ ] CI sweep on PR

## Out of scope

- The deeper precision question (pinning egglog's `random_initial_choice` at `src/egglog_utils/mod.rs:1765`, or matching PyTorch's cuBLAS algorithm IDs) is a separate effort.
- Tolerances on other Llama tests are unchanged; each has its own calibration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)