### PR TITLE
Update egglog to HEAD; keep tree-decomposition on (TimeOnly reports)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,9 +23,9 @@ as-any = "0.3.1"
 serde = { version = "1.0.202", features = ["derive"] }
 generational-box = "0.5.6"
 serde_json = "1.0.140"
-egglog = {git="https://github.com/egraphs-good/egglog", rev="0a8cc35a6c68d0460c20449d5fa19ca3caba2923"}
-egglog-ast = {git="https://github.com/egraphs-good/egglog", rev="0a8cc35a6c68d0460c20449d5fa19ca3caba2923"}
-egglog-reports = {git="https://github.com/egraphs-good/egglog", rev="0a8cc35a6c68d0460c20449d5fa19ca3caba2923"}
+egglog = {git="https://github.com/egraphs-good/egglog", rev="a2da717fd2f5eb8e8cd7c68163e5a160da05e637"}
+egglog-ast = {git="https://github.com/egraphs-good/egglog", rev="a2da717fd2f5eb8e8cd7c68163e5a160da05e637"}
+egglog-reports = {git="https://github.com/egraphs-good/egglog", rev="a2da717fd2f5eb8e8cd7c68163e5a160da05e637"}
 egraph-serialize = { version = "0.3.0", default-features = false, features = ["graphviz", "serde"]}
 tracing = "0.1.43"
 paste = "1.0.15"

--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -1207,7 +1207,12 @@ fn run_egglog_with_report_parts_impl(
     let setup_text_elapsed = setup_text_start.elapsed();
     let setup_lines = setup_code.lines().count();
     let mut egraph = egglog::EGraph::default();
-    egraph.set_report_level(ReportLevel::WithPlan);
+    // EXPERIMENT (egglog#900 tree decomposition ON): the DecomposedPlan report
+    // path (Plan::to_report) is an unimplemented todo!() that's only reached at
+    // ReportLevel::WithPlan/StageInfo. Keep decomposition ON (the actual
+    // speedup) and request only TimeOnly reports so we never hit it. Trade-off:
+    // per-rule query-plan diagnostics are dropped.
+    egraph.set_report_level(ReportLevel::TimeOnly);
     let setup_start = std::time::Instant::now();
     let setup_tuples_before = egraph.num_tuples();
     let parse_start = std::time::Instant::now();


### PR DESCRIPTION
Bumps the egglog/egglog-ast/egglog-reports git deps from `0a8cc35` to current `main` HEAD `a2da717` (539 commits) and adapts luminal to the new query planner.

## Why the `egglog_utils` change
Newer egglog (egraphs-good/egglog#900, "cardinality-aware tree decomposition") adds a `DecomposedPlan` whose report path (`Plan::to_report`) is an unimplemented `todo!()`. That stub is reached **only** at `ReportLevel::WithPlan` / `StageInfo`. luminal's main search egraph requested `WithPlan`, so every run panicked at `core-relations/free_join/plan.rs:235` — without this change the bump fails 74/122 core + 118/154 cuda_lite tests.

Fix: request **`ReportLevel::TimeOnly`** instead. This keeps tree-decomposition **on** (the actual speedup) while never constructing the unimplemented plan report.
- Trade-off: the per-rule **query-plan** diagnostics are dropped. The timing diagnostics luminal prints (setup / cycle / cleanup / summary) are unaffected.
- (An earlier attempt set `egraph.no_decomp = true` to dodge the panic, but that disables decomposition and *costs* ~12% egglog time — so `TimeOnly` is the better lever.)

## Validation
Full suite green on egglog HEAD (CUDA box):
- `cargo test -p luminal -p luminal_nn -p luminal_tracing -p luminal_python` → **122 passed, 0 failed**
- `cargo test -p luminal_cuda_lite` → **154 passed, 0 failed** (113 ignored)
- `crates/luminal_python/run_tests_cuda.sh` → **480 passed, 0 failed**

## Measured impact (llama-8b + qwen3-4b, A/B vs `0a8cc35`)
It's a **compile-time** win (faster e-graph saturation); **inference TPS is unchanged**.

| model | path | egglog compile (per build) | speedup | decode TPS |
|---|---|---|---|---|
| llama-8b | rust | ~13s → ~13s | ~1.0× (break-even) | 114.5 → 114.5 |
| llama-8b | luminal_python | ~4.4s → ~1.2s | ~3.7× | 51.8 → 50.8 |
| qwen3-4b | rust | ~2.87s → ~1.19s | ~2.4× | 96.9 → 96.6 |
| qwen3-4b | luminal_python | ~2.46s → ~1.30s | ~1.9× | 44.7 → 46.6 |

So: meaningfully faster **compilation** on most graphs (good for dev iteration / model load), no change to shipped inference speed. The benefit is query-shape dependent — llama-8b's rust graph is the one outlier that breaks even.

## Notes
- `Cargo.lock` is gitignored here, so only the `Cargo.toml` rev change is committed; cargo regenerates the lock from the pinned rev.
- Open question for reviewers: whether losing the `WithPlan` per-rule plan diagnostics is acceptable, or whether we want to keep them gated behind a debug flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)