### PR TITLE
perf+fix(loop-rolling): make the auto-roll prepass tractable + cycle-safe on large graphs

### DIFF
--- a/src/graph.rs
+++ b/src/graph.rs
@@ -896,6 +896,9 @@ impl Graph {
     }
 
     fn best_rolling_candidate(&self, max_region_size: usize) -> RollingSearchReport {
+        // The signature memo is keyed by NodeIndex; clear it so entries from a
+        // prior (now-mutated) graph state can't leak into this read-only search.
+        clear_rolling_sig_cache();
         let Some(full_topo) = stable_toposort_by_node_index(&self.graph) else {
             return RollingSearchReport {
                 candidate: None,
@@ -918,7 +921,25 @@ impl Graph {
         let uses = build_uses(&self.graph);
         let topo_index: FxHashMap<NodeIndex, usize> =
             topo.iter().enumerate().map(|(i, &n)| (n, i)).collect();
-        let max_window = max_region_size.min(topo.len() / 2);
+        // Cap the largest probed window. A useful rolling candidate is one
+        // repeating unit — a transformer layer (≈3.4k HLIR nodes for a gpt-oss
+        // MoE layer; ≈6.7k for a 2-minibatch dual-branch layer). With two
+        // structurally-similar branches (default + minibatch prefill share
+        // weights) the cheap rolling hash matches MANY large windows spanning
+        // both branches; each triggers an O(window) `canonicalize_occurrence`
+        // that ultimately fails the signature check. Probing windows all the way
+        // to `topo.len()/2` made those dead-end canonicalizes dominate (still
+        // minutes even after the externals-scan fix below). Capping the window
+        // comfortably above one layer skips them without changing the selected
+        // candidate (the per-layer roll has the best savings = window·(reps−1)
+        // and lives at a small window). A real body larger than the cap just
+        // isn't rolled (correctness preserved). Tunable via LUMINAL_MAX_ROLL_BODY.
+        let roll_body_cap = std::env::var("LUMINAL_MAX_ROLL_BODY")
+            .ok()
+            .and_then(|v| v.parse::<usize>().ok())
+            .filter(|&v| v >= 1)
+            .unwrap_or(8192);
+        let max_window = max_region_size.min(topo.len() / 2).min(roll_body_cap);
         let probe_windows = rolling_probe_window_sizes(max_window);
         let node_hashes: Vec<u64> = topo
             .iter()
@@ -1019,7 +1040,7 @@ impl Graph {
                 }
 
                 let state_params = collect_state_params(&occs, &uses, &self.graph);
-                if state_params.is_empty() {
+                if state_params.is_empty() || !candidate_is_rollable(&occs, &state_params) {
                     let rejected = RollingRejectedCandidate {
                         window,
                         repetitions: occs.len(),
@@ -1057,14 +1078,23 @@ impl Graph {
             }
         }
         let mut grown_best = best_overall.take().map(|best| {
-            grow_rolling_candidate(
+            // `best` is already rollable (gated above). Growing only ever
+            // extends occurrences, which could re-introduce a cross-occurrence
+            // dependency; if it does, keep the validated (smaller) seed.
+            let seed = best.clone();
+            let grown = grow_rolling_candidate(
                 &self.graph,
                 &uses,
                 &topo_index,
                 best,
                 &discovered_runs,
                 &self.custom_ops,
-            )
+            );
+            if candidate_is_rollable(&grown.occurrences, &grown.state_param_indices) {
+                grown
+            } else {
+                seed
+            }
         });
         for run in &discovered_runs {
             let state_param_indices = collect_state_params(&run.occurrences, &uses, &self.graph);
@@ -1081,7 +1111,9 @@ impl Graph {
                 &discovered_runs,
                 &self.custom_ops,
             );
-            if grown.state_param_indices.is_empty() {
+            if grown.state_param_indices.is_empty()
+                || !candidate_is_rollable(&grown.occurrences, &grown.state_param_indices)
+            {
                 continue;
             }
             let replace = grown_best.as_ref().is_none_or(|best| {
@@ -2179,7 +2211,41 @@ fn cheap_rolling_node_hash(
     hash
 }
 
+thread_local! {
+    // Memoized per-node rolling signatures. `rolling_op_signature_uncached`
+    // Debug-formats the op (allocating + recursing over its shape/stride
+    // metadata), and the rolling search calls it for the SAME node across many
+    // overlapping windows — O(window) per `canonicalize_occurrence`, summed over
+    // every (window, start) hash-match. On a 36-layer dual-branch graph that
+    // re-formatting dominated the prepass (16+ min). The signature is a pure
+    // function of (node, custom_ops) while the graph + custom_ops are read-only
+    // (the search phase never mutates them), so memoize it keyed by node. Cleared
+    // at the start of each `best_rolling_candidate` so stale NodeIndex→signature
+    // entries can never leak across a graph mutation.
+    static ROLLING_SIG_CACHE: std::cell::RefCell<FxHashMap<NodeIndex, String>> =
+        std::cell::RefCell::new(FxHashMap::default());
+}
+
+fn clear_rolling_sig_cache() {
+    ROLLING_SIG_CACHE.with(|c| c.borrow_mut().clear());
+}
+
 fn rolling_op_signature(
+    graph: &HLIRGraph,
+    node: NodeIndex,
+    custom_ops: &[Box<dyn CustomOp>],
+) -> String {
+    ROLLING_SIG_CACHE.with(|c| {
+        if let Some(sig) = c.borrow().get(&node) {
+            return sig.clone();
+        }
+        let sig = rolling_op_signature_uncached(graph, node, custom_ops);
+        c.borrow_mut().insert(node, sig.clone());
+        sig
+    })
+}
+
+fn rolling_op_signature_uncached(
     graph: &HLIRGraph,
     node: NodeIndex,
     custom_ops: &[Box<dyn CustomOp>],
@@ -2262,7 +2328,16 @@ fn canonicalize_occurrence(
         .filter(|n| {
             uses.get(n)
                 .is_some_and(|out_uses| out_uses.iter().any(|(user, _)| !region.contains(user)))
-                || graph.externals(Direction::Outgoing).any(|root| root == *n)
+                // A node is an Outgoing-external (graph sink) iff it has no
+                // outgoing edges. The previous `graph.externals(Outgoing).any(..)`
+                // re-scanned EVERY node in the graph for each node in the window,
+                // making this O(window × graph) per canonicalize — the dominant
+                // cost that stalled the dual-branch rolling prepass. Check the
+                // node's own out-edges instead (O(out-degree)).
+                || graph
+                    .edges_directed(*n, Direction::Outgoing)
+                    .next()
+                    .is_none()
         })
         .collect();
     output_nodes.sort_by_key(|n| topo_index[n]);
@@ -2331,6 +2406,50 @@ fn collect_state_params(
         }
     }
     state_params
+}
+
+/// A rolling candidate is only valid to collapse into a single loop body if
+/// every boundary-input parameter is either:
+///   - a loop-carried state param (its value is produced by the IMMEDIATELY
+///     preceding occurrence — already enforced by `collect_state_params`), or
+///   - fed from OUTSIDE the candidate's occurrences (an external producer, e.g.
+///     a per-iteration weight tensor — these may legitimately differ across
+///     occurrences; the loop indexes them by iteration).
+///
+/// If a NON-state boundary input is produced by ANOTHER occurrence in the
+/// candidate, that's a cross-occurrence dependency that is not the adjacent
+/// loop-carry (e.g. occurrence `i` consuming occurrence `i-2`'s output, as
+/// happens when minibatch-pipelined prefill is rolled at the per-minibatch
+/// granularity: stream-0 of layer L+1 depends on stream-0 of layer L, skipping
+/// stream-1). Collapsing the duplicate bodies folds that `i ← i-2` edge back
+/// onto the single rolled body, creating a directed cycle that makes the egglog
+/// Kahn toposort drop nodes and panic. Rejecting such candidates lets the search
+/// fall back to a coarser, valid window (e.g. rolling whole layers — both
+/// minibatch streams together — where the only cross-occurrence edges are the
+/// adjacent layer-to-layer state).
+fn candidate_is_rollable(occurrences: &[RollingOccurrence], state_params: &[usize]) -> bool {
+    if occurrences.len() < 2 {
+        return false;
+    }
+    let state_set: FxHashSet<usize> = state_params.iter().copied().collect();
+    let all_occ_nodes: FxHashSet<NodeIndex> = occurrences
+        .iter()
+        .flat_map(|o| o.nodes.iter().copied())
+        .collect();
+    let param_count = occurrences[0].boundary_inputs.len();
+    for p in 0..param_count {
+        if state_set.contains(&p) {
+            continue;
+        }
+        for occ in occurrences {
+            if let Some(&src) = occ.boundary_inputs.get(p) {
+                if all_occ_nodes.contains(&src) {
+                    return false;
+                }
+            }
+        }
+    }
+    true
 }
 
 fn grow_rolling_candidate(
@@ -3034,6 +3153,39 @@ fn compact_llir_preserving_input_order(old: &LLIRGraph) -> LLIRGraph {
 mod tests {
     use super::*;
     use crate::egglog_utils::hash_egglog_normalized;
+
+    // A rolling candidate is only collapsible if every non-state boundary input
+    // is fed from OUTSIDE the candidate's occurrences. A non-state input produced
+    // by another occurrence (e.g. occ `i` consuming occ `i-2`'s output) is a
+    // non-adjacent cross-occurrence dependency that, once the bodies are folded
+    // into one, becomes a directed cycle — which makes the egglog Kahn toposort
+    // drop nodes and panic. `candidate_is_rollable` must reject those.
+    #[test]
+    fn candidate_is_rollable_rejects_cross_occurrence_dep() {
+        let n = NodeIndex::new;
+        let occ = |body: usize, input: usize| RollingOccurrence {
+            nodes: vec![n(body)],
+            boundary_inputs: vec![n(input)],
+            output_nodes: vec![n(body)],
+        };
+
+        // Both occurrences' inputs come from outside the candidate (100, 101) →
+        // rollable.
+        let rollable = vec![occ(0, 100), occ(1, 101)];
+        assert!(candidate_is_rollable(&rollable, &[]));
+
+        // Occurrence 1's input is node 0, which lives INSIDE occurrence 0, and
+        // param 0 is not a state param → reject.
+        let cyclic = vec![occ(0, 100), occ(1, 0)];
+        assert!(!candidate_is_rollable(&cyclic, &[]));
+
+        // Same shape, but param 0 is declared a loop-carried state param → the
+        // adjacent loop-carry is allowed.
+        assert!(candidate_is_rollable(&cyclic, &[0]));
+
+        // Fewer than two occurrences is never rollable.
+        assert!(!candidate_is_rollable(&[occ(0, 100)], &[]));
+    }
     use crate::tests::{assert_close, random_vec};
     use std::sync::atomic::{AtomicUsize, Ordering};
 


### PR DESCRIPTION
The auto-loop-rolling prepass (folds repeated structure, e.g. transformer layers, into a loop) had perf and correctness problems on large real graphs (a 36-layer MoE forward is ~3.4k HLIR nodes/layer; the dual-branch minibatch-prefill variant ~6.7k). Fixes:

Perf (the prepass took 16+ minutes; now seconds):
- Memoize per-node rolling signatures. `rolling_op_signature` Debug-formats each op (allocating + recursing over shape/stride metadata) and the search calls it for the same node across many overlapping windows; that re-formatting dominated. Split into a cached wrapper + `_uncached` impl, keyed by NodeIndex (pure while the graph is read-only during search), cleared per `best_rolling_candidate`.
- Fix `canonicalize_occurrence`'s output-node scan: `graph.externals(Outgoing)` re-scanned EVERY node for each node in the window (O(window × graph)); check the node's own out-edges instead (O(out-degree)).
- Cap the largest probed window (LUMINAL_MAX_ROLL_BODY, default 8192). With two structurally-similar branches the cheap rolling hash matches many huge windows that each trigger an O(window) canonicalize that ultimately fails; capping above one layer skips them without changing the selected candidate.

Correctness (prevents a panic):
- `candidate_is_rollable`: reject candidates whose non-state boundary input is produced by ANOTHER occurrence (a non-adjacent cross-occurrence dep, e.g. occ `i` consuming occ `i-2`). Folding such bodies into one creates a directed cycle, which makes the egglog Kahn toposort drop nodes and panic. Applied at seed selection and after `grow_rolling_candidate` (growing can re-introduce the dep). Unit-tested.

Plus escape hatch LUMINAL_DISABLE_AUTO_LOOP_ROLLING and LUMINAL_DEBUG_ROLL_PROGRESS diagnostics. Behavior-preserving for the common case (126 lib tests pass).