### PR TITLE
feat(egglog): let backends publish extra egglog after the op defs

### DIFF
--- a/src/egglog_utils/mod.rs
+++ b/src/egglog_utils/mod.rs
@@ -168,6 +168,10 @@ pub fn full_egglog(program: &str, ops: &[Arc<Box<dyn EgglogOp>>], cleanup: bool)
 /// trait objects in `ops`.
 pub struct OpTextParts {
     op_defs: String,
+    /// Backend-provided egglog text (see [`crate::op::Runtime::extra_egglog`]),
+    /// spliced in right after `op_defs` and before the rewrite rules. Empty for
+    /// core / the reference backend.
+    extra_egglog: String,
     cleanups: String,
     /// Names of op kinds that are eligible for cleanup (cleanup() == true).
     /// Used by the Rust post-processing pass to safely strip HLIR ops only
@@ -196,6 +200,9 @@ impl OpTextParts {
             .collect();
         Self {
             op_defs: op_defs_string(ops),
+            // Default empty; the backend's Runtime::extra_egglog() is spliced in
+            // by the Rt-aware callers (build_search_space) after construction.
+            extra_egglog: String::new(),
             // The egglog `cleanup` ruleset deletes HLIR ops unconditionally,
             // even when no kernel rewrite fired in their eclass. On large
             // graphs (e.g. YOLO v11) that produces empty eclasses and the
@@ -371,6 +378,7 @@ fn egglog_setup_with_options(
         egglog_ruleset_declarations(),
         base_program,
         parts.op_defs.clone(),
+        parts.extra_egglog.clone(),
         parts.cleanups.clone(),
         base::base_cleanup_egglog(),
         parts.rewrites.clone(),
@@ -1208,28 +1216,34 @@ pub fn run_egglog_with_report_late_passes_and_interval_analysis(
     late_passes: &[LateEgglogPass],
     use_interval_analysis: bool,
 ) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
+    // This convenience wrapper doesn't expose the backend extra-egglog hook;
+    // the Rt-aware path (Graph::build_search_space) is what threads it.
     run_egglog_with_report_late_passes_interval_analysis_and_log(
         program,
         root,
         ops,
         cleanup,
         late_passes,
+        "",
         use_interval_analysis,
         log_channel_enabled(false, "EGGLOG_LOG"),
     )
 }
 
 #[tracing::instrument(skip_all)]
+#[allow(clippy::too_many_arguments)]
 pub fn run_egglog_with_report_late_passes_interval_analysis_and_log(
     program: &str,
     root: &str,
     ops: &[Arc<Box<dyn EgglogOp>>],
     cleanup: bool,
     late_passes: &[LateEgglogPass],
+    extra_egglog: &str,
     use_interval_analysis: bool,
     log: bool,
 ) -> Result<(SerializedEGraph, EgglogRunReport), egglog::Error> {
-    let op_parts = OpTextParts::new_with_late_passes(ops, cleanup, late_passes);
+    let mut op_parts = OpTextParts::new_with_late_passes(ops, cleanup, late_passes);
+    op_parts.extra_egglog = extra_egglog.to_string();
     run_egglog_with_report_parts_impl(program, root, &op_parts, use_interval_analysis, log)
 }
 
@@ -1574,12 +1588,14 @@ pub fn run_egglog_with_late_passes_and_interval_analysis(
 }
 
 #[tracing::instrument(skip_all)]
+#[allow(clippy::too_many_arguments)]
 pub fn run_egglog_with_late_passes_interval_analysis_and_log(
     program: &str,
     root: &str,
     ops: &[Arc<Box<dyn EgglogOp>>],
     cleanup: bool,
     late_passes: &[LateEgglogPass],
+    extra_egglog: &str,
     use_interval_analysis: bool,
     log: bool,
 ) -> Result<SerializedEGraph, egglog::Error> {
@@ -1589,6 +1605,7 @@ pub fn run_egglog_with_late_passes_interval_analysis_and_log(
         ops,
         cleanup,
         late_passes,
+        extra_egglog,
         use_interval_analysis,
         log,
     )
@@ -2399,11 +2416,34 @@ pub fn egglog_to_llir_from_root<'a>(
 #[cfg(test)]
 mod tests {
     use super::{
-        LateEgglogPass, SerializedEGraph, count_choice_sets_up_to, run_egglog_with_late_passes,
+        LateEgglogPass, OpTextParts, SerializedEGraph, count_choice_sets_up_to,
+        egglog_setup_with_options, run_egglog_with_late_passes,
     };
     use crate::prelude::FxHashMap;
     use crate::{hlir::HLIROps, op::IntoEgglogOp};
     use egraph_serialize::{ClassId, NodeId};
+
+    // The backend extra-egglog hook (Runtime::extra_egglog) is carried on
+    // OpTextParts.extra_egglog and must be spliced into the program exactly once,
+    // after the op constructor defs and before the rewrite rules.
+    #[test]
+    fn extra_egglog_is_spliced_between_op_defs_and_rewrites() {
+        let marker = "(function tron_is_attn_softmax (IR IR) bool :merge (or old new))";
+
+        // Default: no extra egglog → marker absent.
+        let parts = OpTextParts::new(&[], false);
+        assert!(parts.extra_egglog.is_empty());
+        let plain = egglog_setup_with_options("", &parts, false);
+        assert!(!plain.contains(marker));
+
+        // With a backend declaration set, it appears in the program exactly once.
+        // (Its position — after op_defs, before the rewrite rules — is fixed by
+        // the array-literal order in egglog_setup_with_options.)
+        let mut parts = OpTextParts::new(&[], false);
+        parts.extra_egglog = marker.to_string();
+        let program = egglog_setup_with_options("", &parts, false);
+        assert_eq!(program.matches(marker).count(), 1, "spliced exactly once");
+    }
 
     fn eclass(id: &str, label: &str, n_nodes: usize) -> (ClassId, (String, Vec<NodeId>)) {
         (

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -1208,6 +1208,7 @@ impl Graph {
         let dim_buckets = options.dim_buckets.clone();
         let late_pass_dyn_map = self.late_pass_dyn_map(&dim_buckets);
         let late_passes = Rt::late_egglog_passes(&ops, &options, &late_pass_dyn_map);
+        let extra_egglog = Rt::extra_egglog();
 
         let (program, root) = hlir_to_egglog(self);
         let contexts = self.search_space_contexts(&dim_buckets);
@@ -1222,6 +1223,7 @@ impl Graph {
                     &ops,
                     cleanup_hlir,
                     &late_passes,
+                    &extra_egglog,
                     use_interval_analysis,
                     options.egglog_log_enabled(),
                 )
@@ -1307,6 +1309,7 @@ impl Graph {
         let dim_buckets = options.dim_buckets.clone();
         let late_pass_dyn_map = self.late_pass_dyn_map(&dim_buckets);
         let late_passes = Rt::late_egglog_passes(&ops, &options, &late_pass_dyn_map);
+        let extra_egglog = Rt::extra_egglog();
 
         let (program, root) = hlir_to_egglog(self);
         let contexts = self.search_space_contexts(&dim_buckets);
@@ -1321,6 +1324,7 @@ impl Graph {
                     &ops,
                     cleanup_hlir,
                     &late_passes,
+                    &extra_egglog,
                     use_interval_analysis,
                     options.egglog_log_enabled(),
                 )

--- a/src/op.rs
+++ b/src/op.rs
@@ -76,6 +76,18 @@ pub trait Runtime {
     {
         vec![]
     }
+    /// Backend-provided egglog text spliced in immediately after the op
+    /// constructor definitions and before the rewrite rules. Core keeps this
+    /// empty; runtimes can use it to declare shared egglog relations/functions
+    /// that their rewrite rules read and write across multiple ops — declarations
+    /// that the per-op rewrite hook cannot emit exactly-once — without adding
+    /// those declarations to Luminal core.
+    fn extra_egglog() -> String
+    where
+        Self: Sized,
+    {
+        String::new()
+    }
     fn initialize(arg: Self::CompileArg) -> Self;
     fn load_llir(&mut self, llir_graph: &LLIRGraph);
     fn execute(&mut self, dyn_map: &FxHashMap<char, usize>) -> Self::ExecReturn;


### PR DESCRIPTION
Add `Runtime::extra_egglog() -> String` (default empty), a backend hook whose text is spliced into the egglog program immediately after the op constructor definitions and before the rewrite rules.

This fills a gap in the plugin egglog surface: today a backend can contribute per-op constructor defs and per-op rewrite rules, but there is nowhere to declare *shared* egglog relations/functions that those rules read and write across multiple ops (e.g. `(function is_attn_softmax (IR IR) bool :merge (or old new))` used as a cross-rule tag — one op's rule sets it, another op's rule matches it). Emitting such a declaration from a per-op rewrite hook either duplicates it (egglog errors: already declared) or has no single owner. The only correct spot — declared exactly once, after the base/op defs, before all the plugin rewrites — was inside core's program assembly, which previously forced a local patch.

Mirrors the existing `Runtime::late_egglog_passes` backend hook: threaded from `Graph::build_search_space`/`build_search_space_exclude_ops` through the `run_egglog_*_late_passes_*` chain onto `OpTextParts.extra_egglog`, spliced in `egglog_setup_with_options` between `op_defs` and `cleanups`/`rewrites`. Core and the reference backend return empty, so behavior is unchanged. Unit test asserts the splice (absent by default; present exactly once when set).