### PR TITLE
hlir: serialize egglog constants round-trip exact ({:.6} -> {:?})

### DIFF
--- a/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_epilogue_rewrite.egg
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/cublaslt_epilogue_rewrite.egg
@@ -351,7 +351,10 @@
         (= ?gelu_inner_quad (Op (Mul ?gelu_inner_quad_shape ?gelu_inner_quad_a_stride ?gelu_inner_quad_b_stride ?gelu_inner_quad_out_stride) (ICons ?gelu_inner_scaled (ICons ?matmul (INil)))))
         (= ?gelu_one (Op (Constant 1.000000) (INil)))
         (= ?gelu_poly (Op (Add ?gelu_poly_shape ?gelu_poly_a_stride ?gelu_poly_b_stride ?gelu_poly_out_stride) (ICons ?gelu_inner_quad (ICons ?gelu_one (INil)))))
-        (= ?gelu_coeff_outer (Op (Constant 1.595769) (INil)))
+        ; sqrt(2/pi): tolerance window, not exact text match
+        (= ?gelu_coeff_outer (Op (Constant ?gelu_outer_val) (INil)))
+        (> ?gelu_outer_val 1.59576)
+        (< ?gelu_outer_val 1.59578)
         (= ?gelu_outer_scaled (Op (Mul ?gelu_outer_scaled_shape ?gelu_outer_scaled_a_stride ?gelu_outer_scaled_b_stride ?gelu_outer_scaled_out_stride) (ICons ?matmul (ICons ?gelu_coeff_outer (INil)))))
         (= ?gelu_scaled (Op (Mul ?gelu_scaled_shape ?gelu_scaled_a_stride ?gelu_scaled_b_stride ?gelu_scaled_out_stride) (ICons ?gelu_outer_scaled (ICons ?gelu_poly (INil)))))
         (= ?neg1 (Op (Constant -1.000000) (INil)))
@@ -401,7 +404,10 @@
         (= ?gelu_inner_quad (Op (Mul ?gelu_inner_quad_shape ?gelu_inner_quad_a_stride ?gelu_inner_quad_b_stride ?gelu_inner_quad_out_stride) (ICons ?gelu_inner_scaled (ICons ?matmul (INil)))))
         (= ?gelu_one (Op (Constant 1.000000) (INil)))
         (= ?gelu_poly (Op (Add ?gelu_poly_shape ?gelu_poly_a_stride ?gelu_poly_b_stride ?gelu_poly_out_stride) (ICons ?gelu_inner_quad (ICons ?gelu_one (INil)))))
-        (= ?gelu_coeff_outer (Op (Constant 1.595769) (INil)))
+        ; sqrt(2/pi): tolerance window, not exact text match
+        (= ?gelu_coeff_outer (Op (Constant ?gelu_outer_val) (INil)))
+        (> ?gelu_outer_val 1.59576)
+        (< ?gelu_outer_val 1.59578)
         (= ?gelu_outer_scaled (Op (Mul ?gelu_outer_scaled_shape ?gelu_outer_scaled_a_stride ?gelu_outer_scaled_b_stride ?gelu_outer_scaled_out_stride) (ICons ?matmul (ICons ?gelu_coeff_outer (INil)))))
         (= ?gelu_scaled (Op (Mul ?gelu_scaled_shape ?gelu_scaled_a_stride ?gelu_scaled_b_stride ?gelu_scaled_out_stride) (ICons ?gelu_outer_scaled (ICons ?gelu_poly (INil)))))
         (= ?neg1 (Op (Constant -1.000000) (INil)))

--- a/crates/luminal_cuda_lite/src/host/moe/glumoe_rewrite.egg
+++ b/crates/luminal_cuda_lite/src/host/moe/glumoe_rewrite.egg
@@ -2,7 +2,7 @@
 ;
 ; One fused op supports two activation modes:
 ;   mode=0: Qwen-style SwiGLU (silu(gate) * up)
-;   mode=1: Gemma-style GELU (gate * sigmoid(1.595769 * gate * (1 + 0.044715 * gate^2)))
+;   mode=1: Gemma-style GELU (gate * sigmoid(1.5957692 * gate * (1 + 0.044715 * gate^2)))
 ;
 ; To keep matching fast, we stage through marker states:
 ;   1) Shared expert index/gather markers
@@ -129,7 +129,10 @@
         (= ?gelu_inner_quad (Op (Mul ?gelu_inner_quad_shape ?gelu_inner_quad_a_stride ?gelu_inner_quad_b_stride ?gelu_inner_quad_out_stride) (ICons ?gelu_inner_scaled (ICons ?gu_matmul (INil)))))
         (= ?gelu_one (Op (Constant 1.000000) (INil)))
         (= ?gelu_poly (Op (Add ?gelu_poly_shape ?gelu_poly_a_stride ?gelu_poly_b_stride ?gelu_poly_out_stride) (ICons ?gelu_inner_quad (ICons ?gelu_one (INil)))))
-        (= ?gelu_coeff_outer (Op (Constant 1.595769) (INil)))
+        ; sqrt(2/pi): tolerance window, not exact text match
+        (= ?gelu_coeff_outer (Op (Constant ?gelu_outer_val) (INil)))
+        (> ?gelu_outer_val 1.59576)
+        (< ?gelu_outer_val 1.59578)
         (= ?gelu_outer_scaled (Op (Mul ?gelu_outer_scaled_shape ?gelu_outer_scaled_a_stride ?gelu_outer_scaled_b_stride ?gelu_outer_scaled_out_stride) (ICons ?gu_matmul (ICons ?gelu_coeff_outer (INil)))))
         (= ?gelu_scaled (Op (Mul ?gelu_scaled_shape ?gelu_scaled_a_stride ?gelu_scaled_b_stride ?gelu_scaled_out_stride) (ICons ?gelu_outer_scaled (ICons ?gelu_poly (INil)))))
         (= ?neg1 (Op (Constant -1.000000) (INil)))

--- a/crates/luminal_cuda_lite/src/kernel/rope.rs
+++ b/crates/luminal_cuda_lite/src/kernel/rope.rs
@@ -926,7 +926,10 @@ impl EgglogOp for KernelRoPE {
                     (= ?m1c (Op (Constant -1.000000) (INil)))
                     (= ?shift (Op (Add ?sh_sh ?sh_a ?sh_b ?sh_o)
                         (ICons ?neg (ICons ?hpi (INil)))))
-                    (= ?hpi (Op (Constant 1.570796) (INil)))
+                    ; pi/2: tolerance window, not exact text match
+                    (= ?hpi (Op (Constant ?hpi_val) (INil)))
+                    (> ?hpi_val 1.57078)
+                    (< ?hpi_val 1.57081)
                     (= ?cosv (Op (Sin ?s2_sh ?s2_in ?s2_out) (ICons ?shift (INil))))
                     (= ?cosb (Op (Cast ?cb_size (Bf16)) (ICons ?cosv (INil))))
                 )

--- a/src/hlir.rs
+++ b/src/hlir.rs
@@ -1040,7 +1040,7 @@ impl Display for Constant {
 
 impl HLIROp for Constant {
     fn to_egglog(&self, _: &[(NodeIndex, String)]) -> String {
-        format!("(Op (Constant {:.6}) (INil))", self.0)
+        format!("(Op (Constant {:?}) (INil))", self.0)
     }
 }
 
@@ -3088,5 +3088,48 @@ impl Iterator for StridedIterator {
 
         self.done = true;
         Some(fin)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn round_tripped(v: f32) -> f32 {
+        let s = Constant(v).to_egglog(&[]);
+        let inner = &s["(Op (Constant ".len()..s.len() - ") (INil))".len()];
+        // The egglog Constant sort stores f64: text -> f64 -> f32 is the
+        // path a constant takes through the e-graph and back.
+        inner
+            .parse::<f64>()
+            .unwrap_or_else(|_| panic!("unparseable constant text {inner:?}")) as f32
+    }
+
+    /// f32 -> serialized text -> f64 (egglog) -> f32 must be the identity.
+    /// `{:.6}` zeroed sub-5e-7 constants (gelu's sign epsilon -> NaN at
+    /// x==0) and shifted transcendental coefficients (LUM-631).
+    #[test]
+    fn constant_to_egglog_round_trips_exactly() {
+        let adversarial = [
+            0.0f32,
+            -0.0,
+            1e-10,
+            -1e-10,
+            f32::EPSILON,
+            f32::MIN_POSITIVE,
+            1e-45,       // smallest subnormal
+            1.595_769_2, // tanh-gelu outer coeff (frontend 1.5957691216 as f32)
+            0.044715,
+            std::f32::consts::LOG2_E,
+            std::f32::consts::FRAC_PI_2,
+            std::f32::consts::PI,
+            1e38,
+            -1e-38,
+            0.1,
+            1.0 / 3.0,
+        ];
+        for &v in &adversarial {
+            assert_eq!(round_tripped(v).to_bits(), v.to_bits(), "constant {v:?}");
+        }
     }
 }


### PR DESCRIPTION
Change how we serialize constants into egglog

previously we where using .6, and so was losing some decimal points. 

Changes to just serialization the entire constant

updated some egglog rules where we look for exact constants to make sure they still match

In support of imagegen pipelines, broken out into its own PR because it is an issue unto itself 