### PR TITLE
Cuda lite: Fixing Flaky embed tests, adding guard to egglog for KernelEmbed

### DIFF
--- a/crates/luminal_cuda_lite/src/kernel/hlir.rs
+++ b/crates/luminal_cuda_lite/src/kernel/hlir.rs
@@ -2270,7 +2270,9 @@ impl EgglogOp for KernelEmbed {
                     ; token_stride lengths differ -> flatten_strides panic.
                     (= (len ?token_cast_stride) 1)
                     (= ?token_ids_cast (Op (Cast ?cast_size ?cast_dtype) (ICons ?token_ids (INil))))
+                    (= ?mul_const (Op (Iota ?mul_iota_expr ?mul_iota_range) (INil)))
                     (= ?embed_dim (nth_from_end ?embed_shape 0))
+                    (= ?mul_iota_expr ?embed_dim)
                     (= ?embed_dt (dtype ?embed_table))
                 )
                 (
@@ -2298,7 +2300,9 @@ impl EgglogOp for KernelEmbed {
                     ; token_stride lengths differ -> flatten_strides panic.
                     (= (len ?token_cast_stride) 1)
                     (= ?token_ids_cast (Op (Cast ?cast_size ?cast_dtype) (ICons ?token_ids (INil))))
+                    (= ?mul_const (Op (Iota ?mul_iota_expr ?mul_iota_range) (INil)))
                     (= ?embed_dim (nth_from_end ?embed_shape 0))
+                    (= ?mul_iota_expr ?embed_dim)
                     (= ?embed_dt (dtype ?embed_table))
                 )
                 (
@@ -2323,7 +2327,9 @@ impl EgglogOp for KernelEmbed {
                     ; batch_shape and token_stride lengths agree and the rule
                     ; doesn't mis-fire on non-embedding 2D gathers.
                     (= (len ?token_stride) 1)
+                    (= ?mul_const (Op (Iota ?mul_iota_expr ?mul_iota_range) (INil)))
                     (= ?embed_dim (nth_from_end ?embed_shape 0))
+                    (= ?mul_iota_expr ?embed_dim)
                     (= ?embed_dt (dtype ?embed_table))
                 )
                 (
@@ -2348,7 +2354,9 @@ impl EgglogOp for KernelEmbed {
                     ; batch_shape and token_stride lengths agree and the rule
                     ; doesn't mis-fire on non-embedding 2D gathers.
                     (= (len ?token_stride) 1)
+                    (= ?mul_const (Op (Iota ?mul_iota_expr ?mul_iota_range) (INil)))
                     (= ?embed_dim (nth_from_end ?embed_shape 0))
+                    (= ?mul_iota_expr ?embed_dim)
                     (= ?embed_dt (dtype ?embed_table))
                 )
                 (

--- a/crates/luminal_cuda_lite/src/tests/dtype_contract.rs
+++ b/crates/luminal_cuda_lite/src/tests/dtype_contract.rs
@@ -1463,3 +1463,22 @@ fn moe_gemv_matches_hlir_reference() {
         );
     }
 }
+
+#[test]
+fn test_embed_rule_rejects_non_embedding_gather() {
+    // Strided gather whose stride (8) differs from the flattened table's
+    // last dim (320): KernelEmbed must not match (LUM-679).
+    let (rows, cols, seq_len) = (40usize, 8usize, 6usize);
+    let mut cx = Graph::default();
+    let idx = cx.tensor(seq_len).as_dtype(DType::Int);
+    let table = cx.tensor(rows * cols).as_dtype(DType::F32); // 1-D flattened
+    let _out = table
+        .gather((idx * cols).expand_dim(1, cols) + cx.arange(cols).expand_dim(0, seq_len))
+        .output();
+
+    cx.build_search_space::<CudaRuntime>(CompileOptions::default());
+    assert!(
+        !egraph_has_enode(&cx, "KernelEmbed", None),
+        "embed rewrite must not match a gather whose stride differs from the table row length"
+    );
+}


### PR DESCRIPTION
Our kernel embed egglog rules would match any Gather(Add(Mul(ids, Const), iota)). The mul here is what drives the kernel index, and the kernel itself derives length of the row last dimension of the embedding shape

(nth_from_end ?emded_shape 0) 

this could disagree with what the value that the index would be multiplied by

this change adds guards that say to only treat the Gather(Add(Mul(Iota)) pattern as valid if the embedding dimension matches what expression in the Iota, which is what embedding gets incremented by each loop iteration

we would only see this some times as Gather patterns would get picked, but it was random, this should prevent this in the future

test_gather_2d_axis0/test_gather_negative_indices where the tests that this fixes.