### PR TITLE
Disable qwen3_moe tiny/small/medium tests (egglog matching slowdown)

### DIFF
--- a/crates/luminal_python/tests/test_qwen3_moe.py
+++ b/crates/luminal_python/tests/test_qwen3_moe.py
@@ -94,6 +94,17 @@ def _run_hf_qwen3_moe_test(config, device: torch.device, atol: float):
 # ────────────────────────────────────────────────────────────────────────
 
 
+# Disabled: extreme slowdown in egglog matching on these whole-model MoE
+# compiles (99.5% of test time is inside process_pt2). Re-enable when the
+# upstream fix lands:
+#   https://github.com/egraphs-good/egglog/issues/946#issuecomment-4917917418
+#   https://github.com/egraphs-good/egglog/issues/872
+_EGGLOG_SLOWDOWN = pytest.mark.skip(
+    reason="egglog matching slowdown (egglog#946, egglog#872)"
+)
+
+
+@_EGGLOG_SLOWDOWN
 def test_hf_qwen3_moe_tiny(device: torch.device):
     """HuggingFace Qwen3MoeForCausalLM — tiny: 2 experts, top-1 routing.
 
@@ -115,6 +126,7 @@ def test_hf_qwen3_moe_tiny(device: torch.device):
     _run_hf_qwen3_moe_test(config, device, atol=1e-5)
 
 
+@_EGGLOG_SLOWDOWN
 def test_hf_qwen3_moe_small(device: torch.device):
     """HuggingFace Qwen3MoeForCausalLM — small: 4 experts, top-2 routing."""
     config = _make_qwen3_moe_config(
@@ -131,6 +143,7 @@ def test_hf_qwen3_moe_small(device: torch.device):
     _run_hf_qwen3_moe_test(config, device, atol=1e-4)
 
 
+@_EGGLOG_SLOWDOWN
 def test_hf_qwen3_moe_medium(device: torch.device):
     """HuggingFace Qwen3MoeForCausalLM — medium: 8 experts, top-2, 2 layers.
 


### PR DESCRIPTION
disabled these tests due to extreme slow down in egglog matching. Will reenable when egglog crew come back with a fix for us

https://github.com/egraphs-good/egglog/issues/946#issuecomment-4917917418 https://github.com/egraphs-good/egglog/issues/872

These three dominated the Test Python CUDA job (62 of ~75 profiled minutes, 99.5% of each inside process_pt2). tiny_bf16 and real_config_1layer stay enabled as cheap MoE-path sentinels.


Claude-Session: https://claude.ai/code/session_01UpaXYQ7vPR6bnnQwGFb7mU