### PR TITLE
luminal_python: support aten.upsample_nearest2d.vec in the PT2 translator

### DIFF
--- a/crates/luminal_python/run_test.sh
+++ b/crates/luminal_python/run_test.sh
@@ -16,7 +16,7 @@ uv run maturin develop --manifest-path rust/Cargo.toml
 echo "Step 3: Running pytest..."
 # it is best not to add the full model tests, they end up running billion parameter models
 # on the CPU and it takes far to long
-uv run pytest tests/test_hlir_ops.py tests/test_unary.py tests/test_dtype_boundary.py tests/test_torch_dtype_parity.py -v
+uv run pytest tests/test_hlir_ops.py tests/test_unary.py tests/test_dtype_boundary.py tests/test_torch_dtype_parity.py tests/test_upsample.py -v
 
 echo ""
 echo "=== Tests Complete ==="

--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -87,6 +87,7 @@ impl<'a> Translator<'a> {
 
             // Shape ops
             "torch.ops.aten.view.default" => self.translate_reshape(node)?,
+            "torch.ops.aten.upsample_nearest2d.vec" => self.translate_upsample_nearest2d(node)?,
             "torch.ops.aten.permute.default" => self.translate_permute(node)?,
             "torch.ops.aten.unsqueeze.default" => {
                 let a = self.get_input_tensor(node, 0)?;

--- a/crates/luminal_python/rust/src/translator/mod.rs
+++ b/crates/luminal_python/rust/src/translator/mod.rs
@@ -318,6 +318,22 @@ impl<'a> Translator<'a> {
             .collect()
     }
 
+    /// Shape of the node's first output, from its tensor metadata (for ops
+    /// whose output size isn't reliably readable from the args).
+    pub(crate) fn output_meta_shape(&self, node: &Node) -> Result<Vec<Expression>> {
+        let name = node
+            .outputs
+            .first()
+            .and_then(|output| output.as_tensor.as_ref())
+            .map(|tensor| tensor.name.clone())
+            .unwrap_or_default();
+
+        let meta = self
+            .tensor_meta(&name)
+            .context("Missing tensor meta for output shape")?;
+        self.tensor_meta_to_shape(meta)
+    }
+
     pub(crate) fn dim_size_to_expr(&self, dim: &DimSize) -> Result<Expression> {
         match dim {
             DimSize::Int(i) => Ok(Expression::from(i.as_int)),

--- a/crates/luminal_python/rust/src/translator/movement.rs
+++ b/crates/luminal_python/rust/src/translator/movement.rs
@@ -65,6 +65,105 @@ impl<'a> Translator<'a> {
         })
     }
 
+    pub(crate) fn translate_upsample_nearest2d(&mut self, node: &Node) -> Result<GraphTensor> {
+        let input = self.get_input_tensor(node, 0)?;
+        let input_dimensions = input.dims();
+
+        anyhow::ensure!(
+            input_dimensions.len() == 4,
+            "upsample_nearest2d expects a 4D (N, C, H, W) input, got {}D",
+            input_dimensions.len()
+        );
+
+        let input_height = input_dimensions[2]
+            .to_usize()
+            .context("upsample_nearest2d requires a static input height")?;
+
+        let input_width = input_dimensions[3]
+            .to_usize()
+            .context("upsample_nearest2d requires a static input width")?;
+
+        let output_dimensions = self.output_meta_shape(node)?;
+
+        anyhow::ensure!(
+            output_dimensions.len() == 4,
+            "upsample_nearest2d expects a 4D output, got {}D",
+            output_dimensions.len()
+        );
+
+        let output_height = output_dimensions[2]
+            .to_usize()
+            .context("upsample_nearest2d requires a static output height")?;
+
+        let output_width = output_dimensions[3]
+            .to_usize()
+            .context("upsample_nearest2d requires a static output width")?;
+
+        anyhow::ensure!(
+            input_height != 0 && input_width != 0 && output_height != 0 && output_width != 0,
+            "upsample_nearest2d requires non-zero spatial dims \
+               (in {input_height}x{input_width} -> out {output_height}x{output_width})"
+        );
+
+        // Optional explicit scale_factors (arg 2): ATen's general branch
+        // indexes by floor(j / s) when scales are provided, which differs
+        // from floor(j * in / out) when in * s is non-integral.
+        let scales: Option<(f64, f64)> = node.inputs.get(2).and_then(|i| match &i.arg {
+            Argument::Other(v) => {
+                let a = v.get("as_floats")?.as_array()?;
+                if a.len() == 2 {
+                    Some((a[0].as_f64()?, a[1].as_f64()?))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        });
+
+        let result =
+            self.upsample_nearest_axis(input, 2, input_height, output_height, scales.map(|s| s.0))?;
+        let result =
+            self.upsample_nearest_axis(result, 3, input_width, output_width, scales.map(|s| s.1))?;
+        Ok(result)
+    }
+
+    /// Nearest-neighbor resample of one axis. `out == in` and `out == 2*in`
+    /// are ATen kernel fast paths that ignore the scale, and integer scales
+    /// matching out/in are pure shape movement (`expand_dim` + `merge_dims`).
+    /// Everything else gathers with `src = min(floor(j * scale_inv), in-1)`
+    /// where scale_inv = 1/s when scales were provided else in/out — the
+    /// float chain deliberately mirrors ATen's float32 index math.
+    fn upsample_nearest_axis(
+        &mut self,
+        t: GraphTensor,
+        axis: usize,
+        in_dim: usize,
+        out_dim: usize,
+        scale: Option<f64>,
+    ) -> Result<GraphTensor> {
+        if out_dim.is_multiple_of(in_dim) {
+            let k = out_dim / in_dim;
+            let scale_matches = scale.is_none_or(|s| (s - k as f64).abs() < 1e-9);
+            if k <= 2 || scale_matches {
+                if k == 1 {
+                    return Ok(t);
+                }
+                return Ok(t.expand_dim(axis + 1, k).merge_dims(axis, axis + 1));
+            }
+        }
+
+        let scale_inv = scale.map_or(in_dim as f64 / out_dim as f64, |s| 1.0 / s) as f32;
+        let mut idx = (self.graph.arange(out_dim).cast(DType::F32) * scale_inv)
+            .minimum_f32((in_dim - 1) as f32)
+            .cast(DType::Int);
+        for (d, &dim) in t.dims().iter().enumerate() {
+            if d != axis {
+                idx = idx.expand_dim(d, dim);
+            }
+        }
+        Ok(super::movement_dynamic::pt2_gather_elements(t, idx, axis))
+    }
+
     pub(crate) fn translate_permute(&mut self, node: &Node) -> Result<GraphTensor> {
         let a = self.get_input_tensor(node, 0)?;
         let dims = self.get_ints_arg(node, 1)?;

--- a/crates/luminal_python/tests/test_models.py
+++ b/crates/luminal_python/tests/test_models.py
@@ -2478,3 +2478,44 @@ class SdpaWithBiasModel(torch.nn.Module):
         bias: torch.Tensor,
     ) -> torch.Tensor:
         return torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=bias)
+
+
+# ========== Nearest Upsample Test Models ==========
+
+
+class UpsampleNearestScaleModel(torch.nn.Module):
+    """`F.interpolate(scale_factor=..., mode="nearest")` — the
+    `scale_factors` overload (the SD UNet path)."""
+
+    def __init__(self, scale_factor: float = 2.0) -> None:
+        super().__init__()
+        self.scale_factor = scale_factor
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.interpolate(
+            x, scale_factor=self.scale_factor, mode="nearest"
+        )
+
+
+class UpsampleNearestScaleHWModel(torch.nn.Module):
+    """Non-square per-axis scale, `scale_factor=(sh, sw)`."""
+
+    def __init__(self, scale_h: float = 2.0, scale_w: float = 3.0) -> None:
+        super().__init__()
+        self.scale = (scale_h, scale_w)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.interpolate(
+            x, scale_factor=self.scale, mode="nearest"
+        )
+
+
+class UpsampleNearestSizeModel(torch.nn.Module):
+    """`F.interpolate(size=...)` — the `output_size` overload."""
+
+    def __init__(self, size: tuple[int, int] = (16, 16)) -> None:
+        super().__init__()
+        self.size = size
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return torch.nn.functional.interpolate(x, size=self.size, mode="nearest")

--- a/crates/luminal_python/tests/test_upsample.py
+++ b/crates/luminal_python/tests/test_upsample.py
@@ -1,0 +1,133 @@
+from typing import Callable
+
+import pytest
+import torch
+import torch._dynamo
+from test_models import (
+    UpsampleNearestScaleModel,
+    UpsampleNearestScaleHWModel,
+    UpsampleNearestSizeModel,
+)
+
+from luminal import luminal_backend
+
+# aten.upsample_nearest2d.vec (SD UNet Upsample2D blocks)
+
+
+def test_upsample_nearest_scale_2x(device):
+    """scale_factor=2.0 -> output_size=None, scale_factors=[2,2] (the SD path)."""
+    model = UpsampleNearestScaleModel(scale_factor=2.0).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((2, 3, 5, 7), device=device)
+    assert torch.allclose(model_compiled(x), model(x), atol=1e-5)
+
+
+def test_upsample_nearest_scale_non_square(device):
+    """Per-axis scale (2x height, 3x width)."""
+    model = UpsampleNearestScaleHWModel(scale_h=2.0, scale_w=3.0).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((2, 3, 4, 5), device=device)
+    assert torch.allclose(model_compiled(x), model(x), atol=1e-5)
+
+
+def test_upsample_nearest_size(device):
+    """size=(H, W) -> output_size=[H, W], scale_factors=None branch."""
+    model = UpsampleNearestSizeModel(size=(16, 16)).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((1, 4, 8, 8), device=device)
+    assert torch.allclose(model_compiled(x), model(x), atol=1e-5)
+
+
+# Per-axis skip branch (scale == 1 on one axis)
+
+
+def test_upsample_nearest_height_only(device):
+    """(2, 1): hits the `scale_width == 1` skip."""
+    model = UpsampleNearestScaleHWModel(scale_h=2.0, scale_w=1.0).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((2, 3, 4, 5), device=device)
+    assert torch.allclose(model_compiled(x), model(x), atol=1e-5)
+
+
+def test_upsample_nearest_width_only(device):
+    """(1, 2): hits the `scale_height == 1` skip."""
+    model = UpsampleNearestScaleHWModel(scale_h=1.0, scale_w=2.0).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((2, 3, 4, 5), device=device)
+    assert torch.allclose(model_compiled(x), model(x), atol=1e-5)
+
+
+# General path: fractional scales, downsampling, divergent explicit scales
+
+
+def test_upsample_nearest_fractional_scale(device):
+    """1.5x -> gather path; nearest is pure selection, must match eager exactly."""
+    model = UpsampleNearestScaleModel(scale_factor=1.5).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((1, 3, 4, 6), device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
+def test_upsample_nearest_downsample(device):
+    """0.5x nearest downsample."""
+    model = UpsampleNearestScaleModel(scale_factor=0.5).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((2, 3, 8, 6), device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
+def test_upsample_nearest_size_fractional(device):
+    """size=(5, 7) from (3, 4): non-divisible output_size overload."""
+    model = UpsampleNearestSizeModel(size=(5, 7)).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((1, 2, 3, 4), device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
+def test_upsample_nearest_mixed_paths(device):
+    """(2.0, 1.5): H takes the integer view path, W the gather path."""
+    model = UpsampleNearestScaleHWModel(scale_h=2.0, scale_w=1.5).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((2, 3, 4, 6), device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
+def test_upsample_nearest_scale_nonintegral_product(device):
+    """scale=1.7 on in=5: in*s non-integral, so floor(j/s) != floor(j*in/out)
+    — indices must honor the provided scale (ATen's general branch)."""
+    model = UpsampleNearestScaleModel(scale_factor=1.7).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((1, 2, 5, 5), device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
+def test_upsample_nearest_downsample_nonintegral(device):
+    """scale=0.7 on in=6 (out=4): fractional downsample with provided scale."""
+    model = UpsampleNearestScaleModel(scale_factor=0.7).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((1, 2, 6, 6), device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
+def test_upsample_nearest_noninteger_scale_same_size(device):
+    """scale=1.05, in=10 -> out=10: ATen's out==in kernel fast path ignores
+    the scale — identity, NOT floor(j/1.05)."""
+    model = UpsampleNearestScaleModel(scale_factor=1.05).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((1, 2, 10, 10), device=device)
+    ref = model(x)
+    assert torch.equal(ref, x)
+    assert torch.equal(model_compiled(x), ref)
+
+
+# dtype: fp16
+
+
+def test_upsample_nearest_fp16(device):
+    """Pure movement: fp16 must round-trip bit-exactly."""
+    if device.type != "cuda":
+        pytest.skip("fp16 upsample exercised on the CUDA backend")
+    model = UpsampleNearestScaleModel(scale_factor=2.0).to(device).half()
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x = torch.rand((2, 3, 5, 7), device=device, dtype=torch.float16)
+    assert torch.allclose(model_compiled(x), model(x), atol=1e-3)


### PR DESCRIPTION
Adds nearest-neighbor 2D upsample to the PT2 translator — the SD UNet Upsample2D path (`F.interpolate(mode="nearest")`), covering the full ATen contract. Used by flux kontext and Klein