### PR TITLE
FusedMoE host op

### DIFF
--- a/crates/luminal_cuda_lite/src/host/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/mod.rs
@@ -10,6 +10,7 @@ pub type Ops = (
     cublaslt::CuBlasLt,
     cublaslt::CuBlasLtScaled,
     moe::GLUMoE,
+    moe::fused::FusedMoE,
     flashinfer::FlashInferAttention,
 );
 

--- a/crates/luminal_cuda_lite/src/host/moe/decode.cu
+++ b/crates/luminal_cuda_lite/src/host/moe/decode.cu
@@ -1,0 +1,219 @@
+// Fused MoE decode: phase 1 gate_up GEMV + clamped SwiGLU, phase 2 down
+// GEMV + routed sum. Two launches; the boundary is the barrier (every down
+// dot needs the pair's ENTIRE hidden vector).
+// Weights: fp4 blocks [E, N, K/2] (lo nibble = even k), e8m0 scales
+// [E, N, K/32], bf16 biases. One warp per task, R=4 outputs per warp:
+//   phase 1: task = (pair, j-block)  -> hidden[pair][j0..j0+R]
+//   phase 2: task = (token, r-block) -> out[t][r0..r0+R]
+
+#include <cuda_bf16.h>
+
+
+__constant__ float FP4_LUT[16] = {
+    0.0f, 0.5f, 1.0f, 1.5f, 2.0f, 3.0f, 4.0f, 6.0f,
+    -0.0f, -0.5f, -1.0f, -1.5f, -2.0f, -3.0f, -4.0f, -6.0f,
+};
+
+// __constant__ serializes on divergent nibble indices; stage LUT in smem.
+#define STAGE_LUT(name)                       \
+    __shared__ float name[16];                \
+    if (threadIdx.x < 16) {                   \
+        name[threadIdx.x] = FP4_LUT[threadIdx.x]; \
+    }                                         \
+    __syncthreads();
+
+__device__ __forceinline__ float warp_reduce_sum(float v) {
+#pragma unroll
+    for (int o = 16; o > 0; o >>= 1) {
+        v += __shfl_down_sync(0xffffffffu, v, o);
+    }
+    return v;
+}
+
+// One scale-group (32 cols): activation float4s loaded once, dotted vs R rows.
+template <int R>
+__device__ __forceinline__ void mxfp4_group_dot_rows(
+    const unsigned char* __restrict__ b_q,
+    const unsigned char* __restrict__ b_scale,
+    long long expert,
+    int n_dim,
+    int k_dim,
+    int row0, // rows row0 .. row0+R-1
+    int g,
+    const float* __restrict__ vec,
+    const float* __restrict__ lut,
+    float* __restrict__ acc // [R]
+) {
+    const float4* v4 = reinterpret_cast<const float4*>(vec + g * 32);
+    const float4 a0 = v4[0], a1 = v4[1], a2 = v4[2], a3 = v4[3];
+    const float4 a4 = v4[4], a5 = v4[5], a6 = v4[6], a7 = v4[7];
+#pragma unroll
+    for (int r = 0; r < R; ++r) {
+        const long long row = row0 + r;
+        const unsigned char* qrow = b_q + (expert * n_dim + row) * (long long)(k_dim / 2);
+        const unsigned char* srow = b_scale + (expert * n_dim + row) * (long long)(k_dim / 32);
+        // e8m0 == IEEE-754 exponent field: 2^(sc-127) = bits(sc<<23).
+        const float scale = __uint_as_float((unsigned int)srow[g] << 23);
+        const uint4 q = *reinterpret_cast<const uint4*>(qrow + g * 16);
+        const unsigned int words[4] = {q.x, q.y, q.z, q.w};
+        float gacc = 0.0f;
+        const float4 av[8] = {a0, a1, a2, a3, a4, a5, a6, a7};
+#pragma unroll
+        for (int w = 0; w < 4; ++w) {
+            const unsigned int word = words[w];
+            const float4 a = av[2 * w];
+            const float4 b = av[2 * w + 1];
+            gacc = fmaf(lut[(word >> 0) & 0xF], a.x, gacc);
+            gacc = fmaf(lut[(word >> 4) & 0xF], a.y, gacc);
+            gacc = fmaf(lut[(word >> 8) & 0xF], a.z, gacc);
+            gacc = fmaf(lut[(word >> 12) & 0xF], a.w, gacc);
+            gacc = fmaf(lut[(word >> 16) & 0xF], b.x, gacc);
+            gacc = fmaf(lut[(word >> 20) & 0xF], b.y, gacc);
+            gacc = fmaf(lut[(word >> 24) & 0xF], b.z, gacc);
+            gacc = fmaf(lut[(word >> 28) & 0xF], b.w, gacc);
+        }
+        acc[r] = fmaf(gacc, scale, acc[r]);
+    }
+}
+
+// Phase 1: 2R gate/up-interleaved rows per warp task.
+template <int R>
+__device__ __forceinline__ void phase1_body(
+    unsigned long long x_ptr, unsigned long long gu_q_ptr,
+    unsigned long long gu_scale_ptr, unsigned long long gu_bias_ptr,
+    unsigned long long topk_ids_ptr, unsigned long long hidden_ptr,
+    int hidden_dim, int inter, int top_k, int seq, int idx_row_stride,
+    float alpha, float limit
+) {
+    const float* x = (const float*)x_ptr;
+    const unsigned char* gu_q = (const unsigned char*)gu_q_ptr;
+    const unsigned char* gu_scale = (const unsigned char*)gu_scale_ptr;
+    const __nv_bfloat16* gu_bias = (const __nv_bfloat16*)gu_bias_ptr;
+    const int* topk_ids = (const int*)topk_ids_ptr;
+    float* hidden = (float*)hidden_ptr;
+    STAGE_LUT(slut)
+    const int lane = threadIdx.x % 32;
+    const int warp_global = (blockIdx.x * blockDim.x + threadIdx.x) / 32;
+    const int jblocks = inter / R;
+    const int gate_up_n = 2 * inter;
+    const long long total = (long long)seq * top_k * jblocks;
+    const long long task = warp_global;
+    if (task < total) {
+        // ── routing: which expert this (token, k) pair goes to ──
+        const int pair = (int)(task / jblocks);
+        const int j0 = (int)(task % jblocks) * R;
+        const int t = pair / top_k;
+        const long long e = topk_ids[(long long)t * idx_row_stride + pair % top_k];
+        const float* xt = x + (long long)t * hidden_dim;
+
+        // ── gate & up dots: 2R interleaved rows of W_gu[e] · x[t] ──
+        float acc[2 * R];
+#pragma unroll
+        for (int r = 0; r < 2 * R; ++r) acc[r] = 0.0f;
+        for (int g = lane; g < hidden_dim / 32; g += 32) {
+            mxfp4_group_dot_rows<2 * R>(
+                gu_q, gu_scale, e, gate_up_n, hidden_dim, 2 * j0, g, xt, slut, acc);
+        }
+#pragma unroll
+        for (int r = 0; r < 2 * R; ++r) acc[r] = warp_reduce_sum(acc[r]);
+
+        // ── bias + clamp + SwiGLU epilogue → hidden[pair][j] ──
+        if (lane == 0) {
+#pragma unroll
+            for (int jj = 0; jj < R; ++jj) {
+                float gate = acc[2 * jj] + __bfloat162float(gu_bias[e * gate_up_n + 2 * (j0 + jj)]);
+                float up = acc[2 * jj + 1] + __bfloat162float(gu_bias[e * gate_up_n + 2 * (j0 + jj) + 1]);
+                gate = fminf(gate, limit);
+                up = fminf(fmaxf(up, -limit), limit);
+                const float sig = 1.0f / (1.0f + expf(-alpha * gate));
+                hidden[(long long)pair * inter + j0 + jj] = (up + 1.0f) * gate * sig;
+            }
+        }
+    }
+}
+
+// Phase 2: R output rows per warp task; top_k expert loop inside.
+template <int R>
+__device__ __forceinline__ void phase2_body(
+    unsigned long long dn_q_ptr, unsigned long long dn_scale_ptr,
+    unsigned long long dn_bias_ptr, unsigned long long topk_ids_ptr,
+    unsigned long long topk_w_ptr, unsigned long long hidden_ptr,
+    unsigned long long out_ptr,
+    int hidden_dim, int inter, int top_k, int seq, int idx_row_stride
+) {
+    const unsigned char* dn_q = (const unsigned char*)dn_q_ptr;
+    const unsigned char* dn_scale = (const unsigned char*)dn_scale_ptr;
+    const __nv_bfloat16* dn_bias = (const __nv_bfloat16*)dn_bias_ptr;
+    const int* topk_ids = (const int*)topk_ids_ptr;
+    const float* topk_w = (const float*)topk_w_ptr;
+    float* hidden = (float*)hidden_ptr;
+    float* out = (float*)out_ptr;
+    STAGE_LUT(slut)
+    const int lane = threadIdx.x % 32;
+    const int warp_global = (blockIdx.x * blockDim.x + threadIdx.x) / 32;
+    const int rblocks = hidden_dim / R;
+    const long long total = (long long)seq * rblocks;
+    const long long task = warp_global;
+    if (task < total) {
+        const int t = (int)(task / rblocks);
+        const int r0 = (int)(task % rblocks) * R;
+        float mix[R];
+#pragma unroll
+        for (int r = 0; r < R; ++r) mix[r] = 0.0f;
+
+        // ── one pass per routed expert of token t ──
+        for (int kk = 0; kk < top_k; ++kk) {
+            const long long e = topk_ids[(long long)t * idx_row_stride + kk];
+            const int pair = t * top_k + kk;
+            const float* hv = hidden + (long long)pair * inter;
+
+            // ── down dots: R rows of W_dn[e] · hidden[pair] ──
+            float acc[R];
+#pragma unroll
+            for (int r = 0; r < R; ++r) acc[r] = 0.0f;
+            for (int g = lane; g < inter / 32; g += 32) {
+                mxfp4_group_dot_rows<R>(dn_q, dn_scale, e, hidden_dim, inter, r0, g, hv, slut, acc);
+            }
+#pragma unroll
+            for (int r = 0; r < R; ++r) acc[r] = warp_reduce_sum(acc[r]);
+
+            // ── bias, then accumulate weighted by the routing score ──
+            if (lane == 0) {
+                const float w = topk_w[(long long)t * top_k + kk];
+#pragma unroll
+                for (int r = 0; r < R; ++r)
+                    mix[r] = fmaf(w, acc[r] + __bfloat162float(dn_bias[e * hidden_dim + r0 + r]), mix[r]);
+            }
+        }
+
+        // ── routed sum over the top_k experts → out[t] ──
+        if (lane == 0) {
+#pragma unroll
+            for (int r = 0; r < R; ++r) out[(long long)t * hidden_dim + r0 + r] = mix[r];
+        }
+    }
+}
+
+extern "C" __global__ void moe_phase1_r4(
+    unsigned long long x_ptr, unsigned long long gu_q_ptr,
+    unsigned long long gu_scale_ptr, unsigned long long gu_bias_ptr,
+    unsigned long long topk_ids_ptr, unsigned long long hidden_ptr,
+    int hidden_dim, int inter, int top_k, int seq, int idx_row_stride,
+    float alpha, float limit
+) {
+    phase1_body<4>(x_ptr, gu_q_ptr, gu_scale_ptr, gu_bias_ptr, topk_ids_ptr,
+                   hidden_ptr, hidden_dim, inter, top_k, seq, idx_row_stride,
+                   alpha, limit);
+}
+
+extern "C" __global__ void moe_phase2_r4(
+    unsigned long long dn_q_ptr, unsigned long long dn_scale_ptr,
+    unsigned long long dn_bias_ptr, unsigned long long topk_ids_ptr,
+    unsigned long long topk_w_ptr, unsigned long long hidden_ptr,
+    unsigned long long out_ptr,
+    int hidden_dim, int inter, int top_k, int seq, int idx_row_stride
+) {
+    phase2_body<4>(dn_q_ptr, dn_scale_ptr, dn_bias_ptr, topk_ids_ptr,
+                   topk_w_ptr, hidden_ptr, out_ptr, hidden_dim, inter, top_k,
+                   seq, idx_row_stride);
+}

--- a/crates/luminal_cuda_lite/src/host/moe/decode.rs
+++ b/crates/luminal_cuda_lite/src/host/moe/decode.rs
@@ -1,0 +1,142 @@
+//! Launchers for decode.cu: the full MoE block as two stream-ordered
+//! launches. Writes `out` f32 [seq, hidden]; needs one scratch buffer,
+//! `hidden` f32 [seq*top_k, inter].
+
+use std::sync::{Arc, OnceLock};
+
+use crate::{
+    compile_module_image_for_current_device,
+    cudarc::driver::{CudaFunction, CudaModule, CudaStream, LaunchConfig, PushKernelArg},
+};
+
+const SOURCE: &str = include_str!("decode.cu");
+const BLOCK_THREADS: u32 = 256;
+
+struct DecodeKernel {
+    _module: Arc<CudaModule>,
+    /// The two phase kernels (R=4 row-blocked).
+    phase1: CudaFunction,
+    phase2: CudaFunction,
+}
+
+// Process-wide cache (NOT per-instance: ops are cloned during GA profiling).
+static KERNEL: OnceLock<DecodeKernel> = OnceLock::new();
+
+fn kernel(stream: &Arc<CudaStream>) -> &'static DecodeKernel {
+    KERNEL.get_or_init(|| {
+        let image = compile_module_image_for_current_device(stream.context(), SOURCE)
+            .expect("moe decode kernel should compile");
+        let module = stream
+            .context()
+            .load_module(image)
+            .expect("moe decode module should load");
+        let phase1 = module
+            .load_function("moe_phase1_r4")
+            .expect("moe_phase1_r4 should exist");
+        let phase2 = module
+            .load_function("moe_phase2_r4")
+            .expect("moe_phase2_r4 should exist");
+        DecodeKernel {
+            _module: module,
+            phase1,
+            phase2,
+        }
+    })
+}
+
+/// Force the NVRTC compile (idempotent); called at extract time so the
+/// cost lands outside timed profiling trials.
+pub fn warm(stream: &Arc<CudaStream>) {
+    let _ = kernel(stream);
+}
+
+/// Outputs per warp; must match the kernels' template instantiation.
+const GEMV_ROWS: usize = 4;
+
+/// The MoE block for `seq` tokens as two stream-ordered launches. All
+/// pointers are device addresses; see decode.cu for layouts. Dims must be
+/// multiples of 32.
+#[allow(clippy::too_many_arguments)]
+pub fn fused_moe_decode(
+    stream: &Arc<CudaStream>,
+    x_ptr: u64,
+    gu_q_ptr: u64,
+    gu_scale_ptr: u64,
+    gu_bias_ptr: u64,
+    dn_q_ptr: u64,
+    dn_scale_ptr: u64,
+    dn_bias_ptr: u64,
+    topk_ids_ptr: u64,
+    topk_w_ptr: u64,
+    hidden_scratch_ptr: u64,
+    out_ptr: u64,
+    hidden_dim: usize,
+    inter: usize,
+    top_k: usize,
+    seq: usize,
+    idx_row_stride: usize,
+    alpha: f32,
+    limit: f32,
+) -> anyhow::Result<()> {
+    // %32 (the e8m0 group width) also gives the 16B rows uint4 loads need.
+    anyhow::ensure!(
+        hidden_dim.is_multiple_of(32) && inter.is_multiple_of(32),
+        "decode GEMV requires 32-aligned dims (e8m0 group width): hidden={hidden_dim}, inter={inter}"
+    );
+    anyhow::ensure!(idx_row_stride >= top_k, "idx_row_stride must be >= top_k");
+    if seq == 0 || top_k == 0 {
+        return Ok(());
+    }
+
+    let rows = GEMV_ROWS; // dims % 32 == 0 guarantees % GEMV_ROWS == 0
+    let k = kernel(stream);
+    let (p1, p2) = (&k.phase1, &k.phase2);
+    // One warp per task, unbounded grid; stream order is the phase barrier.
+    let warps_per_block = (BLOCK_THREADS / 32) as usize;
+    let grid = |tasks: usize| LaunchConfig {
+        grid_dim: (tasks.div_ceil(warps_per_block).max(1) as u32, 1, 1),
+        block_dim: (BLOCK_THREADS, 1, 1),
+        shared_mem_bytes: 0,
+    };
+    let (h, i, tk, s, stride) = (
+        hidden_dim as i32,
+        inter as i32,
+        top_k as i32,
+        seq as i32,
+        idx_row_stride as i32,
+    );
+    unsafe {
+        stream
+            .launch_builder(p1)
+            .arg(&x_ptr)
+            .arg(&gu_q_ptr)
+            .arg(&gu_scale_ptr)
+            .arg(&gu_bias_ptr)
+            .arg(&topk_ids_ptr)
+            .arg(&hidden_scratch_ptr)
+            .arg(&h)
+            .arg(&i)
+            .arg(&tk)
+            .arg(&s)
+            .arg(&stride)
+            .arg(&alpha)
+            .arg(&limit)
+            .launch(grid(seq * top_k * inter / rows))?;
+        stream
+            .launch_builder(p2)
+            .arg(&dn_q_ptr)
+            .arg(&dn_scale_ptr)
+            .arg(&dn_bias_ptr)
+            .arg(&topk_ids_ptr)
+            .arg(&topk_w_ptr)
+            .arg(&hidden_scratch_ptr)
+            .arg(&out_ptr)
+            .arg(&h)
+            .arg(&i)
+            .arg(&tk)
+            .arg(&s)
+            .arg(&stride)
+            .launch(grid(seq * hidden_dim / rows))?;
+    }
+    Ok(())
+}

--- a/crates/luminal_cuda_lite/src/host/moe/fused.rs
+++ b/crates/luminal_cuda_lite/src/host/moe/fused.rs
@@ -1,0 +1,333 @@
+//! FusedMoE: the gpt-oss MXFP4 MoE as one host op — a stream-ordered pair
+//! of GEMV launches (see `decode.cu`) at every batch size: phase 1 gate_up
+//! dequant-GEMV + clamped SwiGLU, phase 2 down projection + top-k weighted
+//! mix. (An expert-grouped tensor-core chain for large prefill batches was
+//! built and benched during bring-up but removed before upstreaming:
+//! post-row-blocking, it only beat the GEMV by ~10% at 512 pairs.)
+//!
+//! Installed by the union-only rewrite in `fused_moe_rewrite.egg`, whose LHS
+//! is the model's dense reference spelling (`moe_naive`). Enforcement of the
+//! fused choice is the candidate memory filter: the raw naive spelling
+//! materializes expert-dense tensors no genome can afford.
+//!
+//! Inputs (graph edges, in order):
+//!   0: x            [s, hidden]               F32
+//!   1: topk_idx     [s, >=top_k] row-major    Int  (argsort tensor; row
+//!      stride derived from the buffer length, GLUMoE-style)
+//!   2: topk_weights [s, top_k]                F32
+//!   3: gu_blocks    [E, 2*inter, hidden/2]    U8 (packed fp4, lo nibble = even k)
+//!   4: gu_scales    [E, 2*inter, hidden/32]   U8 (e8m0)
+//!   5: gu_bias      [E, 2*inter]              BF16
+//!   6: dn_blocks    [E, hidden, inter/2]      U8
+//!   7: dn_scales    [E, hidden, inter/32]     U8
+//!   8: dn_bias      [E, hidden]               BF16
+//!
+//! Output: [s, hidden] F32.
+//!
+//! `num_experts` is derived from the weight buffer lengths (not op metadata).
+//! No host readback, no mid-execute synchronize: every launch is
+//! stream-ordered, and the kernels live in a process-wide cache
+//! (decode.rs's static), so cloning this op during GA profiling costs
+//! nothing.
+
+use std::sync::Arc;
+
+use luminal::{
+    egglog_utils::{
+        api::{Rule, SortDef, sort},
+        base::{EXPRESSION, OP_KIND},
+        extract_expr,
+    },
+    op::{EgglogOp, LLIROp},
+    prelude::*,
+    shape::Expression,
+};
+
+use crate::{
+    cudarc::driver::CudaStream,
+    host::{DeviceBuffer, HostOp},
+};
+
+use super::decode;
+
+const SWIGLU_ALPHA: f32 = 1.702;
+const SWIGLU_LIMIT: f32 = 7.0;
+
+/// Force the process-wide NVRTC compile of the decode module, once.
+/// Extraction has no runtime stream, so this binds the device's primary
+/// context itself; if no device is available the compile stays lazy (first
+/// execute will pay it, as before).
+fn ensure_kernels_compiled() {
+    use std::sync::OnceLock;
+    static ONCE: OnceLock<()> = OnceLock::new();
+    ONCE.get_or_init(|| {
+        if let Ok(ctx) = crate::cudarc::driver::CudaContext::new(0) {
+            let stream = ctx.default_stream();
+            decode::warm(&stream);
+        }
+    });
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct FusedMoE {
+    hidden: Expression,
+    intermediate: Expression,
+    top_k: Expression,
+}
+
+impl EgglogOp for FusedMoE {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "FusedMoE",
+            &[
+                ("hidden", EXPRESSION),
+                ("intermediate", EXPRESSION),
+                ("top_k", EXPRESSION),
+            ],
+        )
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        vec![
+            Rule::raw(
+                "(rule
+                (
+                    (= ?e (Op (FusedMoE ?hidden ?intermediate ?top_k) ?inputs))
+                )
+                (
+                    (set (dtype ?e) (F32))
+                )
+                :ruleset dtype_prop
+            )",
+            ),
+            Rule::raw(include_str!["fused_moe_rewrite.egg"]),
+        ]
+    }
+
+    fn n_inputs(&self) -> usize {
+        9
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a luminal::egglog_utils::SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        _list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let hidden = extract_expr(egraph, kind_children[0], expr_cache).unwrap();
+        let intermediate = extract_expr(egraph, kind_children[1], expr_cache).unwrap();
+        let top_k = extract_expr(egraph, kind_children[2], expr_cache).unwrap();
+        let extracted = FusedMoE {
+            hidden,
+            intermediate,
+            top_k,
+        };
+        // Compile the decode kernels now (flashinfer precedent: JIT at
+        // extract, not first execute) so the NVRTC cost never lands inside a
+        // timed profiling trial.
+        ensure_kernels_compiled();
+        (
+            LLIROp::new::<dyn HostOp>(Box::new(extracted) as Box<dyn HostOp>),
+            input_enodes,
+        )
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+}
+
+impl HostOp for FusedMoE {
+    fn execute(
+        &self,
+        stream: &Arc<CudaStream>,
+        self_node: NodeIndex,
+        inputs: &[NodeIndex],
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        dyn_map: &FxHashMap<char, usize>,
+    ) -> anyhow::Result<()> {
+        if inputs.len() < 9 {
+            anyhow::bail!("FusedMoE expected 9 inputs, got {}", inputs.len());
+        }
+
+        let hidden = self
+            .hidden
+            .exec(dyn_map)
+            .ok_or_else(|| anyhow::anyhow!("FusedMoE hidden dim is unresolved"))?;
+        let intermediate = self
+            .intermediate
+            .exec(dyn_map)
+            .ok_or_else(|| anyhow::anyhow!("FusedMoE intermediate dim is unresolved"))?;
+        let top_k = self
+            .top_k
+            .exec(dyn_map)
+            .ok_or_else(|| anyhow::anyhow!("FusedMoE top_k is unresolved"))?;
+        if top_k == 0 {
+            return Ok(());
+        }
+        anyhow::ensure!(
+            hidden % 32 == 0 && intermediate % 32 == 0,
+            "FusedMoE dims must be multiples of 32 (e8m0 group width): hidden={hidden}, intermediate={intermediate}"
+        );
+        let gate_up_n = 2 * intermediate;
+
+        let output_bytes = self
+            .output_bytes()
+            .exec(dyn_map)
+            .ok_or_else(|| anyhow::anyhow!("FusedMoE output byte size is unresolved"))?;
+        anyhow::ensure!(
+            output_bytes % (hidden * 4) == 0,
+            "FusedMoE output bytes {output_bytes} not divisible by row bytes {}",
+            hidden * 4
+        );
+        let seq = output_bytes / (hidden * 4);
+        if seq == 0 {
+            return Ok(());
+        }
+        let num_pairs = seq * top_k;
+
+        let get_buffer = |name: &str, node: NodeIndex| -> anyhow::Result<DeviceBuffer> {
+            buffers.get(&node).copied().ok_or_else(|| {
+                anyhow::anyhow!("FusedMoE missing {name} buffer for LLIR node {node:?}")
+            })
+        };
+        let x_buf = get_buffer("x", inputs[0])?;
+        let topk_idx_buf = get_buffer("topk indices", inputs[1])?;
+        let topk_vals_buf = get_buffer("topk weights", inputs[2])?;
+        let gu_blocks_buf = get_buffer("gate_up blocks", inputs[3])?;
+        let gu_scales_buf = get_buffer("gate_up scales", inputs[4])?;
+        let gu_bias_buf = get_buffer("gate_up bias", inputs[5])?;
+        let dn_blocks_buf = get_buffer("down blocks", inputs[6])?;
+        let dn_scales_buf = get_buffer("down scales", inputs[7])?;
+        let dn_bias_buf = get_buffer("down bias", inputs[8])?;
+        let output_buf = get_buffer("output", self_node)?;
+
+        // num_experts is derived from the resident weight buffers.
+        let gu_stride = gate_up_n * hidden / 2;
+        anyhow::ensure!(
+            gu_stride > 0 && gu_blocks_buf.len() % gu_stride == 0,
+            "FusedMoE gate_up blocks len {} not a multiple of per-expert stride {gu_stride}",
+            gu_blocks_buf.len()
+        );
+        let num_experts = gu_blocks_buf.len() / gu_stride;
+        anyhow::ensure!(num_experts > 0, "FusedMoE derived zero experts");
+        let checks: [(&str, usize, usize); 5] = [
+            (
+                "gate_up scales",
+                gu_scales_buf.len(),
+                num_experts * gate_up_n * hidden / 32,
+            ),
+            (
+                "gate_up bias",
+                gu_bias_buf.len(),
+                num_experts * gate_up_n * 2,
+            ),
+            (
+                "down blocks",
+                dn_blocks_buf.len(),
+                num_experts * hidden * intermediate / 2,
+            ),
+            (
+                "down scales",
+                dn_scales_buf.len(),
+                num_experts * hidden * intermediate / 32,
+            ),
+            ("down bias", dn_bias_buf.len(), num_experts * hidden * 2),
+        ];
+        for (name, have, want) in checks {
+            anyhow::ensure!(
+                have >= want,
+                "FusedMoE {name} buffer too small: {have} < {want}"
+            );
+        }
+        anyhow::ensure!(
+            x_buf.len() >= seq * hidden * 4,
+            "FusedMoE x buffer too small: {} < {}",
+            x_buf.len(),
+            seq * hidden * 4
+        );
+        anyhow::ensure!(
+            output_buf.len() >= output_bytes,
+            "FusedMoE output buffer too small: {} < {output_bytes}",
+            output_buf.len()
+        );
+
+        // Row strides derived from buffer lengths (the rewrite binds the full
+        // [s, E] argsort tensor as topk_idx; weights come from the softmax as
+        // [s, top_k], but derive anyway).
+        let derive_stride = |name: &str, len_bytes: usize| -> anyhow::Result<usize> {
+            anyhow::ensure!(
+                len_bytes.is_multiple_of(4) && (len_bytes / 4).is_multiple_of(seq),
+                "FusedMoE {name} buffer len {len_bytes} not divisible into {seq} rows"
+            );
+            let stride = len_bytes / 4 / seq;
+            anyhow::ensure!(
+                stride >= top_k,
+                "FusedMoE {name} row stride {stride} < top_k {top_k}"
+            );
+            Ok(stride)
+        };
+        let idx_row_stride = derive_stride("topk index", topk_idx_buf.len())?;
+        let vals_row_stride = derive_stride("topk weights", topk_vals_buf.len())?;
+        anyhow::ensure!(
+            vals_row_stride == top_k,
+            "FusedMoE topk weights must be contiguous [s, top_k]; got row stride {vals_row_stride}"
+        );
+
+        let span = tracing::span!(
+            tracing::Level::TRACE,
+            "FusedMoE",
+            seq,
+            num_pairs,
+            num_experts,
+            hidden,
+            intermediate
+        );
+        let _guard = span.enter();
+
+        let hidden_scratch = unsafe { stream.alloc::<u8>(num_pairs * intermediate * 4)? };
+        let hs_ptr = {
+            use crate::cudarc::driver::DevicePtr;
+            hidden_scratch.device_ptr(stream).0
+        };
+        decode::fused_moe_decode(
+            stream,
+            x_buf.ptr(),
+            gu_blocks_buf.ptr(),
+            gu_scales_buf.ptr(),
+            gu_bias_buf.ptr(),
+            dn_blocks_buf.ptr(),
+            dn_scales_buf.ptr(),
+            dn_bias_buf.ptr(),
+            topk_idx_buf.ptr(),
+            topk_vals_buf.ptr(),
+            hs_ptr,
+            output_buf.ptr(),
+            hidden,
+            intermediate,
+            top_k,
+            seq,
+            idx_row_stride,
+            SWIGLU_ALPHA,
+            SWIGLU_LIMIT,
+        )?;
+        Ok(())
+    }
+
+    fn output_size(&self) -> Expression {
+        // [seq, hidden] F32; 's' is the seq dim by model convention (GLUMoE
+        // does the same).
+        Expression::from('s') * self.hidden
+    }
+
+    fn output_bytes(&self) -> Expression {
+        self.output_size() * 4 // F32
+    }
+
+    fn stats_name(&self) -> Option<&'static str> {
+        Some("FusedMoE")
+    }
+}

--- a/crates/luminal_cuda_lite/src/host/moe/fused_moe_rewrite.egg
+++ b/crates/luminal_cuda_lite/src/host/moe/fused_moe_rewrite.egg
@@ -1,0 +1,120 @@
+; AUTO-GENERATED from an LLIR dump of the naive (unfused) MoE spelling — if
+; that spelling drifts, regenerate this pattern from a fresh dump rather
+; than editing the match by hand.
+; Fuses the DENSE reference MoE spelling (moe_naive) into the FusedMoE host op.
+; Dims fixed: hidden=2880, intermediate=2880, top_k=4.
+
+(datatype*
+    (FusedMoeUnpackState (MkFusedMoeUnpack IR IR))
+    (FusedMoeDensifyState (MkFusedMoeDensify IR IR IR))
+    (FusedMoeGateUpState (MkFusedMoeGateUp IR IR IR IR IR))
+)
+(function fused_moe_unpack (IR) FusedMoeUnpackState :merge new)
+(function fused_moe_densify (IR) FusedMoeDensifyState :merge new)
+(function fused_moe_gate_up (IR) FusedMoeGateUpState :merge new)
+
+(rule
+    (
+        (= ?t297 (Op (Cast ?w737 (Int)) (ICons ?t40 (INil))))
+        (= ?t298 (Op (Gather ?w738 ?w739 ?w740 ?w741) (ICons ?t297 (ICons ?t10 (INil)))))
+        (= ?t299 (Op (Gather ?w742 ?w743 ?w744 ?w745) (ICons ?t297 (ICons ?t12 (INil)))))
+        (= ?t301 (Op (Gather ?w748 ?w749 ?w750 ?w751) (ICons ?t300 (ICons ?t298 (INil)))))
+        (= ?t303 (Op (Cast ?w754 (Bf16)) (ICons ?t302 (INil))))
+        (= ?t304 (Op (Mul ?w755 ?w756 ?w757 ?w758) (ICons ?t301 (ICons ?t303 (INil)))))
+        (= ?t306 (Op (Gather ?w761 ?w762 ?w763 ?w764) (ICons ?t305 (ICons ?t299 (INil)))))
+        (= ?t308 (Op (Cast ?w767 (Bf16)) (ICons ?t307 (INil))))
+        (= ?t309 (Op (Mul ?w768 ?w769 ?w770 ?w771) (ICons ?t306 (ICons ?t308 (INil)))))
+        (= ?t310 (Op (Add ?w772 ?w773 ?w774 ?w775) (ICons ?t304 (ICons ?t309 (INil)))))
+        (= ?t311 (Op (Cast ?w776 (Bf16)) (ICons ?t42 (INil))))
+        (= ?t312 (Op (Mul ?w777 ?w778 ?w779 ?w780) (ICons ?t310 (ICons ?t311 (INil)))))
+    )
+    (
+        (set (fused_moe_unpack ?t312) (MkFusedMoeUnpack ?t40 ?t42))
+    )
+    :ruleset glumoe
+    :name "fused_moe unpack marker"
+)
+
+(rule
+    (
+        (= ?t247 (Op (Mul ?w593 ?w594 ?w595 ?w596) (ICons ?t245 (ICons ?t246 (INil)))))
+        (= ?t248 (Op (Sum ?w597 ?w598 ?w599 ?w600 ?w601) (ICons ?t247 (INil))))
+        (= ?t250 (Op (Add ?w603 ?w604 ?w605 ?w606) (ICons ?t248 (ICons ?t249 (INil)))))
+        (= ?t269 (Op (Add ?w656 ?w657 ?w658 ?w659) (ICons ?t268 (ICons ?t267 (INil)))))
+        (= ?t270 (Op (Gather ?w660 ?w661 ?w662 ?w663) (ICons ?t269 (ICons ?t250 (INil)))))
+        (= ?t271 (Op (Max ?w664 ?w665 ?w666 ?w667 ?w668) (ICons ?t270 (INil))))
+        (= ?t273 (Op (Mul ?w670 ?w671 ?w672 ?w673) (ICons ?t271 (ICons ?t272 (INil)))))
+        (= ?t274 (Op (Add ?w674 ?w675 ?w676 ?w677) (ICons ?t270 (ICons ?t273 (INil)))))
+        (= ?t276 (Op (Mul ?w679 ?w680 ?w681 ?w682) (ICons ?t274 (ICons ?t275 (INil)))))
+        (= ?t277 (Op (Exp2 ?w683 ?w684 ?w685) (ICons ?t276 (INil))))
+        (= ?t278 (Op (Sum ?w686 ?w687 ?w688 ?w689 ?w690) (ICons ?t277 (INil))))
+        (= ?t279 (Op (Recip ?w691 ?w692 ?w693) (ICons ?t278 (INil))))
+        (= ?t280 (Op (Mul ?w694 ?w695 ?w696 ?w697) (ICons ?t277 (ICons ?t279 (INil)))))
+        (= ?t283 (Op (Cast ?w701 (F32)) (ICons ?t267 (INil))))
+        (= ?t284 (Op (LessThan ?w702 ?w703 ?w704 ?w705) (ICons ?t283 (ICons ?t282 (INil)))))
+        (= ?t285 (Op (Cast ?w706 (F32)) (ICons ?t284 (INil))))
+        (= ?t286 (Op (LessThan ?w707 ?w708 ?w709 ?w710) (ICons ?t282 (ICons ?t283 (INil)))))
+        (= ?t287 (Op (Cast ?w711 (F32)) (ICons ?t286 (INil))))
+        (= ?t288 (Op (Add ?w712 ?w713 ?w714 ?w715) (ICons ?t285 (ICons ?t287 (INil)))))
+        (= ?t290 (Op (Mul ?w717 ?w718 ?w719 ?w720) (ICons ?t288 (ICons ?t289 (INil)))))
+        (= ?t292 (Op (Add ?w722 ?w723 ?w724 ?w725) (ICons ?t290 (ICons ?t291 (INil)))))
+        (= ?t293 (Op (Cast ?w726 (Bool)) (ICons ?t292 (INil))))
+        (= ?t294 (Op (Cast ?w727 (F32)) (ICons ?t293 (INil))))
+        (= ?t295 (Op (Mul ?w728 ?w729 ?w730 ?w731) (ICons ?t294 (ICons ?t280 (INil)))))
+        (= ?t296 (Op (Sum ?w732 ?w733 ?w734 ?w735 ?w736) (ICons ?t295 (INil))))
+    )
+    (
+        (set (fused_moe_densify ?t296) (MkFusedMoeDensify ?t267 ?t280 ?t245))
+    )
+    :ruleset glumoe
+    :name "fused_moe densify marker"
+)
+
+(rule
+    (
+        (= ?gu_unpack (fused_moe_unpack ?t312))
+        (= ?gu_unpack (MkFusedMoeUnpack ?gu_blocks ?gu_scales))
+        (= ?t313 (Op (Cast ?w781 (Bf16)) (ICons ?t245 (INil))))
+        (= ?t314 (Op (Mul ?w782 ?w783 ?w784 ?w785) (ICons ?t313 (ICons ?t312 (INil)))))
+        (= ?t315 (Op (Sum ?w786 ?w787 ?w788 ?w789 ?w790) (ICons ?t314 (INil))))
+        (= ?t316 (Op (Add ?w791 ?w792 ?w793 ?w794) (ICons ?t315 (ICons ?t44 (INil)))))
+    )
+    (
+        (set (fused_moe_gate_up ?t316)
+            (MkFusedMoeGateUp ?t245 ?gu_blocks ?gu_scales ?t44 ?t312))
+    )
+    :ruleset glumoe
+    :name "fused_moe gate_up marker"
+)
+
+(rule
+    (
+        (= ?dn_unpack (fused_moe_unpack ?t410))
+        (= ?dn_unpack (MkFusedMoeUnpack ?dn_blocks ?dn_scales))
+        (= ?gu_state (fused_moe_gate_up ?w1097))
+        (= ?gu_state (MkFusedMoeGateUp ?t245 ?gu_blocks ?gu_scales ?gu_bias ?w1098))
+        (= ?dense_state (fused_moe_densify ?t296))
+        (= ?dense_state (MkFusedMoeDensify ?t267 ?t280 ?t245))
+        (= ?t411 (Op (Mul ?w1021 ?w1022 ?w1023 ?w1024) (ICons ?t394 (ICons ?t410 (INil)))))
+        (= ?t412 (Op (Sum ?w1025 ?w1026 ?w1027 ?w1028 ?w1029) (ICons ?t411 (INil))))
+        (= ?t413 (Op (Add ?w1030 ?w1031 ?w1032 ?w1033) (ICons ?t412 (ICons ?t50 (INil)))))
+        (= ?t414 (Op (Cast ?w1034 (F32)) (ICons ?t413 (INil))))
+        (= ?t415 (Op (Mul ?w1035 ?w1036 ?w1037 ?w1038) (ICons ?t414 (ICons ?t296 (INil)))))
+        (= ?t378 (Op (Mul ?w1317 ?w1318 ?w1319 ?w1320) (ICons ?t337 (ICons ?t377 (INil)))))
+        (= ?t381 (Op (Mul ?w1321 ?w1322 ?w1323 ?w1324) (ICons ?t378 (ICons ?t380 (INil)))))
+        (= ?t384 (Op (Mul ?w1325 ?w1326 ?w1327 ?w1328) (ICons ?t381 (ICons ?t383 (INil)))))
+        (= ?t385 (Op (Exp2 ?w1329 ?w1330 ?w1331) (ICons ?t384 (INil))))
+        (= ?t388 (Op (Add ?w1332 ?w1333 ?w1334 ?w1335) (ICons ?t385 (ICons ?t387 (INil)))))
+        (= ?t389 (Op (Recip ?w1336 ?w1337 ?w1338) (ICons ?t388 (INil))))
+        (= ?t390 (Op (Mul ?w1339 ?w1340 ?w1341 ?w1342) (ICons ?t337 (ICons ?t389 (INil)))))
+        (= ?t393 (Op (Add ?w1343 ?w1344 ?w1345 ?w1346) (ICons ?t375 (ICons ?t392 (INil)))))
+        (= ?t394 (Op (Mul ?w1347 ?w1348 ?w1349 ?w1350) (ICons ?t393 (ICons ?t390 (INil)))))
+        (= ?t416 (Op (Sum ?w1039 ?w1040 ?w1041 ?w1042 ?w1043) (ICons ?t415 (INil))))
+    )
+    (
+        (let ?fused (Op (FusedMoE (MNum 2880) (MNum 2880) (MNum 4)) (ICons ?t245 (ICons ?t267 (ICons ?t280 (ICons ?gu_blocks (ICons ?gu_scales (ICons ?gu_bias (ICons ?dn_blocks (ICons ?dn_scales (ICons ?t50 (INil))))))))))))
+        (union ?t416 ?fused)
+    )
+    :ruleset glumoe
+    :name "fused_moe final fusion"
+)

--- a/crates/luminal_cuda_lite/src/host/moe/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/moe/mod.rs
@@ -1,3 +1,6 @@
+pub mod decode;
+pub mod fused;
+
 use std::sync::{Arc, OnceLock};
 
 use luminal::{


### PR DESCRIPTION
a MoE Fused decode op for gpt-oss style MoE routing and expert evaluation. 

Launch parameters have been tuned slightly for an h100. 

Kernel works by at thread execution time routing tokens to experts(which are keep in MXfp4 quant until the dot product)

mxfp4_group_dot_rows computes the token @ expert dot product one sliver of each at a time, accumulating into acc, and then doing a __shfl_down_sync to gather the results all together. 

mxfp4_group_dot_rows preforms interleaved multiplications because we read the weights off in an interleaved format as well.

Look up table callout

STAGE_LUT is a piece of shared memory per warp, it is a copy of the __constant__ float FP4_LUT[16] which was stored in global memory and was causing issues with all of the thread reading from global memory at once, instead each one only reads from its own warp memory

Egglog: unoptimized, left hand pattern was taken from dumping the hlir spelling 