### PR TITLE
luminal_cuda_lite: gate CUDA graph APIs on toolkit version

### DIFF
--- a/crates/luminal_cuda_lite/Cargo.toml
+++ b/crates/luminal_cuda_lite/Cargo.toml
@@ -4,13 +4,14 @@ version = "0.2.0"
 edition = "2024"
 description = "Cuda compiler for luminal"
 license = "MIT OR Apache-2.0"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 luminal = { path = "../.." }
 luminal_tracing = { path = "../luminal_tracing" }
-cudarc = {version="0.19.4", features=["cuda-version-from-build-system", "fallback-latest"]}
+cudarc = { version = "0.19.8", features = ["cuda-version-from-build-system", "fallback-latest"] }
 anyhow = "1.0"
 as-any = "0.3.2"
 itertools = "0.12.1"

--- a/crates/luminal_cuda_lite/build.rs
+++ b/crates/luminal_cuda_lite/build.rs
@@ -1,0 +1,78 @@
+// Luminal API-threshold cfgs are documented in `src/kernel/cuda_graph.rs`.
+// Luminal's version ladder is separate from cudarc's binding-release table.
+mod cuda_version {
+    include!("build_support/cuda_version.rs");
+}
+
+use std::process::Command;
+
+const RERUN_ENV_VARS: [&str; 6] = [
+    "CUDARC_CUDA_VERSION",
+    "CUDA_HOME",
+    "CUDA_PATH",
+    "CUDA_ROOT",
+    "CUDA_TOOLKIT_ROOT_DIR",
+    "PATH",
+];
+
+fn main() {
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build_support/cuda_version.rs");
+    for var in RERUN_ENV_VARS {
+        println!("cargo:rerun-if-env-changed={var}");
+    }
+
+    for &(_, _, cfg) in cuda_version::API_LADDER {
+        println!("cargo:rustc-check-cfg=cfg({cfg})");
+    }
+
+    let (major, minor) = detect_cuda_version();
+    println!("cargo:rustc-env=LUMINAL_CUDA_MAJOR_VERSION={major}");
+    println!("cargo:rustc-env=LUMINAL_CUDA_MINOR_VERSION={minor}");
+
+    if let Some(warning) = cuda_version::maybe_warn_newer_major(major) {
+        println!("cargo:warning={warning}");
+    }
+
+    for cfg in cuda_version::threshold_cfgs(major, minor) {
+        println!("cargo:rustc-cfg={cfg}");
+    }
+}
+
+fn detect_cuda_version() -> (usize, usize) {
+    if let Ok(version) = std::env::var("CUDARC_CUDA_VERSION") {
+        let parsed = cuda_version::parse_cudarc_env(version.trim()).unwrap_or_else(|| {
+            panic!(
+                "Malformed `$CUDARC_CUDA_VERSION={}` (expected format like `12030` for CUDA 12.3)",
+                version.trim()
+            );
+        });
+        validate_version(parsed);
+        return parsed;
+    }
+
+    if let Some(parsed) = detect_cuda_version_from_nvcc() {
+        validate_version(parsed);
+        return parsed;
+    }
+
+    let fallback = cuda_version::FALLBACK_CUDA_VERSION;
+    println!(
+        "cargo:warning=Failed to run `nvcc --version`. Using Luminal fallback CUDA {fallback:?} for API threshold cfgs."
+    );
+    fallback
+}
+
+fn validate_version((major, minor): (usize, usize)) {
+    if let Err(message) = cuda_version::ensure_supported_version(major, minor) {
+        panic!("{message}");
+    }
+}
+
+fn detect_cuda_version_from_nvcc() -> Option<(usize, usize)> {
+    let output = Command::new("nvcc").arg("--version").output().ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    cuda_version::parse_nvcc_stdout(&String::from_utf8_lossy(&output.stdout))
+}

--- a/crates/luminal_cuda_lite/build_support/cuda_version.rs
+++ b/crates/luminal_cuda_lite/build_support/cuda_version.rs
@@ -1,0 +1,101 @@
+// Luminal CUDA API-threshold ladder for #[cfg] gating (see `cuda_graph` module docs).
+// This is separate from cudarc's binding-release table.
+
+/// Minimum CUDA toolkit version Luminal supports (below this, graph APIs are unavailable).
+pub const MIN_SUPPORTED_CUDA: (usize, usize) = (11, 4);
+
+/// Last major toolkit version Luminal has validated; newer majors emit a build warning only.
+#[allow(dead_code)] // used by `build.rs`, not unit tests
+pub const MAX_VALIDATED_MAJOR: usize = 13;
+
+/// API change points where `cuda_graph.rs` branches on `#[cfg(luminal_cuda_ge_*)]`.
+/// Add a rung only when compilation reveals a new driver API variant.
+pub const API_LADDER: &[(usize, usize, &str)] = &[
+    (12, 0, "luminal_cuda_ge_12_0"),
+    (12, 3, "luminal_cuda_ge_12_3"),
+    (12, 8, "luminal_cuda_ge_12_8"),
+];
+
+/// Used when `nvcc` is unavailable; top ladder rung (same cfgs as any version >= 12.8).
+pub const FALLBACK_CUDA_VERSION: (usize, usize) = (12, 8);
+
+#[allow(dead_code)] // used by unit tests and for documenting the CUDARC_CUDA_VERSION encoding
+pub fn cudarc_env_format(major: usize, minor: usize) -> String {
+    format!("{major}0{minor}0")
+}
+
+/// Parse `CUDARC_CUDA_VERSION` (`{major}0{minor}0`) without validating against cudarc releases.
+pub fn parse_cudarc_env(version: &str) -> Option<(usize, usize)> {
+    let version = version.trim();
+    if !version.ends_with('0') || version.len() < 3 {
+        return None;
+    }
+    let inner = &version[..version.len() - 1];
+    let sep = inner.find('0')?;
+    if sep == 0 {
+        return None;
+    }
+    let major: usize = inner[..sep].parse().ok()?;
+    let minor: usize = if inner[sep + 1..].is_empty() {
+        0
+    } else {
+        inner[sep + 1..].parse().ok()?
+    };
+    Some((major, minor))
+}
+
+fn parse_major_minor(version_number: &str) -> Option<(usize, usize)> {
+    let mut parts = version_number.split('.');
+    let major: usize = parts.next()?.parse().ok()?;
+    let minor: usize = parts.next()?.parse().ok()?;
+    Some((major, minor))
+}
+
+/// Parse `nvcc --version` stdout using cudarc's line-3 layout; accept any `major.minor`.
+pub fn parse_nvcc_stdout(stdout: &str) -> Option<(usize, usize)> {
+    let version_line = stdout.lines().nth(3)?;
+    let release_section = version_line.split(", ").nth(1)?;
+    let version_number = release_section.split(' ').nth(1)?;
+    parse_major_minor(version_number)
+}
+
+pub fn version_at_least(
+    major: usize,
+    minor: usize,
+    req_major: usize,
+    req_minor: usize,
+) -> bool {
+    major > req_major || (major == req_major && minor >= req_minor)
+}
+
+/// Returns `Err` with a message when `(major, minor)` is below [`MIN_SUPPORTED_CUDA`].
+pub fn ensure_supported_version(major: usize, minor: usize) -> Result<(), String> {
+    let (min_major, min_minor) = MIN_SUPPORTED_CUDA;
+    if version_at_least(major, minor, min_major, min_minor) {
+        Ok(())
+    } else {
+        Err(format!(
+            "CUDA {major}.{minor} is below Luminal's minimum supported toolkit ({min_major}.{min_minor})"
+        ))
+    }
+}
+
+pub fn threshold_cfgs(major: usize, minor: usize) -> Vec<&'static str> {
+    API_LADDER
+        .iter()
+        .filter(|&&(req_major, req_minor, _)| version_at_least(major, minor, req_major, req_minor))
+        .map(|&(_, _, cfg)| cfg)
+        .collect()
+}
+
+#[allow(dead_code)] // used by `build.rs`, not unit tests
+pub fn maybe_warn_newer_major(major: usize) -> Option<String> {
+    if major > MAX_VALIDATED_MAJOR {
+        Some(format!(
+            "CUDA {major}.x is newer than the last validated major ({MAX_VALIDATED_MAJOR}); \
+             graph API struct layouts and driver symbols are assumed compatible — verify."
+        ))
+    } else {
+        None
+    }
+}

--- a/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/cublaslt/mod.rs
@@ -1277,6 +1277,14 @@ fn run_cublaslt_matmul(
 
 #[cfg(test)]
 pub(crate) fn cublaslt_graph_capture_supported(stream: &Arc<CudaStream>) -> bool {
+    if !cfg!(luminal_cuda_ge_12_3) {
+        return false;
+    }
+    cublaslt_graph_capture_probe(stream)
+}
+
+#[cfg(all(test, luminal_cuda_ge_12_3))]
+fn cublaslt_graph_capture_probe(stream: &Arc<CudaStream>) -> bool {
     fn probe(stream: &Arc<CudaStream>) -> anyhow::Result<()> {
         let capture_stream = stream.context().new_stream()?;
         let cublaslt = try_create_cublaslt(stream.clone())

--- a/crates/luminal_cuda_lite/src/kernel/cuda_graph.rs
+++ b/crates/luminal_cuda_lite/src/kernel/cuda_graph.rs
@@ -1,5 +1,38 @@
 #![allow(clippy::missing_safety_doc, clippy::not_unsafe_ptr_arg_deref)]
 //! CUDA Graph API wrappers for explicit graph construction and surgical updates.
+//!
+//! # Build-time API selection
+//!
+//! Driver graph API variants are chosen at **compile time** via custom cfgs emitted by
+//! [`build.rs`](../../build.rs) from `CUDARC_CUDA_VERSION` (preferred, shared with cudarc)
+//! or `nvcc --version`. There is no runtime dispatch: a binary built against newer graph
+//! APIs is not safe on an older driver (cudarc dynamic-loading resolves symbols at runtime
+//! and panics if they are missing).
+//!
+//! Luminal maintains an **API-threshold ladder** (not a mirror of cudarc's release table).
+//! Newer toolkit versions (e.g. 13.4, 14.x) receive all `ge_*` cfgs their version qualifies
+//! for; add a new ladder rung only when compilation reveals a driver API variant that needs
+//! a separate `#[cfg]` branch. cudarc binding support is independent — pin
+//! `CUDARC_CUDA_VERSION` or upgrade cudarc when its binding set lags the host toolkit.
+//!
+//! | cfg | CUDA toolkit | APIs |
+//! | --- | --- | --- |
+//! | `luminal_cuda_ge_12_0` | ≥ 12.0 | kernel / exec `_v2` graph APIs |
+//! | `luminal_cuda_ge_12_3` | ≥ 12.3 | dependency `_v2`, `cuStreamBeginCaptureToGraph`, cuBLASLt / FlashInfer graph islands |
+//! | `luminal_cuda_ge_12_8` | ≥ 12.8 | `cuEventElapsedTime_v2` |
+//!
+//! To add a new gate: extend `API_LADDER` in [`build_support/cuda_version.rs`](../../build_support/cuda_version.rs),
+//! declare `cargo:rustc-check-cfg` in `build.rs`, and branch in this module.
+//!
+//! Below 12.3, cuBLASLt and FlashInfer are **not** captured into CUDA graphs; they remain
+//! standalone [`HostOp`](crate::host::HostOp) nodes in the execution graph.
+//!
+//! The devcontainer CUDA image (12.8) enables all thresholds and the island-capture path.
+//!
+//! # Follow-up CI
+//!
+//! Cross-build cfg branches with separate `CARGO_TARGET_DIR` values, e.g.
+//! `CUDARC_CUDA_VERSION=12000 cargo check -p luminal_cuda_lite` (planned CI matrix PR).
 
 use std::ffi::c_void;
 use std::mem::MaybeUninit;
@@ -60,7 +93,17 @@ impl CudaGraphHandle {
 
         let mut node = MaybeUninit::uninit();
         unsafe {
+            #[cfg(luminal_cuda_ge_12_0)]
             sys::cuGraphAddKernelNode_v2(
+                node.as_mut_ptr(),
+                self.cu_graph,
+                dependencies.as_ptr(),
+                dependencies.len(),
+                &params,
+            )
+            .result()?;
+            #[cfg(not(luminal_cuda_ge_12_0))]
+            sys::cuGraphAddKernelNode(
                 node.as_mut_ptr(),
                 self.cu_graph,
                 dependencies.as_ptr(),
@@ -98,7 +141,12 @@ impl CudaGraphHandle {
             ctx: std::ptr::null_mut(),
         };
 
-        unsafe { sys::cuGraphKernelNodeSetParams_v2(node, &params).result() }
+        unsafe {
+            #[cfg(luminal_cuda_ge_12_0)]
+            return sys::cuGraphKernelNodeSetParams_v2(node, &params).result();
+            #[cfg(not(luminal_cuda_ge_12_0))]
+            return sys::cuGraphKernelNodeSetParams(node, &params).result();
+        }
     }
 
     /// Adds an empty dependency node to the graph.
@@ -134,10 +182,22 @@ impl CudaGraphHandle {
     ) -> Result<(), DriverError> {
         assert_eq!(from.len(), to.len());
         self.ctx.bind_to_thread()?;
+        #[cfg(luminal_cuda_ge_12_3)]
+        unsafe {
+            sys::cuGraphAddDependencies_v2(
+                self.cu_graph,
+                from.as_ptr(),
+                to.as_ptr(),
+                std::ptr::null(),
+                from.len(),
+            )
+            .result()
+        }
+        #[cfg(not(luminal_cuda_ge_12_3))]
         unsafe {
             sys::cuGraphAddDependencies(self.cu_graph, from.as_ptr(), to.as_ptr(), from.len())
+                .result()
         }
-        .result()
     }
 
     /// Removes dependency edges from the mutable graph.
@@ -148,10 +208,22 @@ impl CudaGraphHandle {
     ) -> Result<(), DriverError> {
         assert_eq!(from.len(), to.len());
         self.ctx.bind_to_thread()?;
+        #[cfg(luminal_cuda_ge_12_3)]
+        unsafe {
+            sys::cuGraphRemoveDependencies_v2(
+                self.cu_graph,
+                from.as_ptr(),
+                to.as_ptr(),
+                std::ptr::null(),
+                from.len(),
+            )
+            .result()
+        }
+        #[cfg(not(luminal_cuda_ge_12_3))]
         unsafe {
             sys::cuGraphRemoveDependencies(self.cu_graph, from.as_ptr(), to.as_ptr(), from.len())
+                .result()
         }
-        .result()
     }
 
     /// Returns all nodes currently in the graph.
@@ -176,6 +248,17 @@ impl CudaGraphHandle {
     pub fn dependencies(&self, node: CUgraphNode) -> Result<Vec<CUgraphNode>, DriverError> {
         self.ctx.bind_to_thread()?;
         let mut count = 0usize;
+        #[cfg(luminal_cuda_ge_12_3)]
+        unsafe {
+            sys::cuGraphNodeGetDependencies_v2(
+                node,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut count,
+            )
+            .result()?;
+        }
+        #[cfg(not(luminal_cuda_ge_12_3))]
         unsafe {
             sys::cuGraphNodeGetDependencies(node, std::ptr::null_mut(), &mut count).result()?;
         }
@@ -183,6 +266,17 @@ impl CudaGraphHandle {
             return Ok(Vec::new());
         }
         let mut deps = vec![std::ptr::null_mut(); count];
+        #[cfg(luminal_cuda_ge_12_3)]
+        unsafe {
+            sys::cuGraphNodeGetDependencies_v2(
+                node,
+                deps.as_mut_ptr(),
+                std::ptr::null_mut(),
+                &mut count,
+            )
+            .result()?;
+        }
+        #[cfg(not(luminal_cuda_ge_12_3))]
         unsafe {
             sys::cuGraphNodeGetDependencies(node, deps.as_mut_ptr(), &mut count).result()?;
         }
@@ -194,6 +288,17 @@ impl CudaGraphHandle {
     pub fn dependent_nodes(&self, node: CUgraphNode) -> Result<Vec<CUgraphNode>, DriverError> {
         self.ctx.bind_to_thread()?;
         let mut count = 0usize;
+        #[cfg(luminal_cuda_ge_12_3)]
+        unsafe {
+            sys::cuGraphNodeGetDependentNodes_v2(
+                node,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+                &mut count,
+            )
+            .result()?;
+        }
+        #[cfg(not(luminal_cuda_ge_12_3))]
         unsafe {
             sys::cuGraphNodeGetDependentNodes(node, std::ptr::null_mut(), &mut count).result()?;
         }
@@ -201,6 +306,17 @@ impl CudaGraphHandle {
             return Ok(Vec::new());
         }
         let mut deps = vec![std::ptr::null_mut(); count];
+        #[cfg(luminal_cuda_ge_12_3)]
+        unsafe {
+            sys::cuGraphNodeGetDependentNodes_v2(
+                node,
+                deps.as_mut_ptr(),
+                std::ptr::null_mut(),
+                &mut count,
+            )
+            .result()?;
+        }
+        #[cfg(not(luminal_cuda_ge_12_3))]
         unsafe {
             sys::cuGraphNodeGetDependentNodes(node, deps.as_mut_ptr(), &mut count).result()?;
         }
@@ -209,6 +325,10 @@ impl CudaGraphHandle {
     }
 
     /// Begins stream capture that appends captured work into this graph.
+    ///
+    /// Requires CUDA 12.3+ (`luminal_cuda_ge_12_3`). Below that threshold, cuBLASLt /
+    /// FlashInfer islands are not captured into graphs.
+    #[cfg(luminal_cuda_ge_12_3)]
     pub fn begin_capture_to_graph(
         &mut self,
         stream: &CudaStream,
@@ -229,6 +349,7 @@ impl CudaGraphHandle {
     }
 
     /// Ends stream capture previously started by begin_capture_to_graph.
+    #[cfg(luminal_cuda_ge_12_3)]
     pub fn end_capture(&mut self, stream: &CudaStream) -> Result<(), DriverError> {
         self.ctx.bind_to_thread()?;
         let mut graph = MaybeUninit::uninit();
@@ -325,38 +446,79 @@ impl CudaGraphExecHandle {
             ctx: std::ptr::null_mut(),
         };
 
-        unsafe { sys::cuGraphExecKernelNodeSetParams_v2(self.cu_graph_exec, node, &params) }
-            .result()
+        unsafe {
+            #[cfg(luminal_cuda_ge_12_0)]
+            {
+                sys::cuGraphExecKernelNodeSetParams_v2(self.cu_graph_exec, node, &params).result()
+            }
+            #[cfg(not(luminal_cuda_ge_12_0))]
+            {
+                sys::cuGraphExecKernelNodeSetParams(self.cu_graph_exec, node, &params).result()
+            }
+        }
     }
 
     /// Attempts to update this executable graph from an already-mutated source graph.
     pub fn update_from_graph(&mut self, graph: &CudaGraphHandle) -> Result<(), DriverError> {
         self.ctx.bind_to_thread()?;
-        let mut result = CUgraphExecUpdateResultInfo {
-            result: CUgraphExecUpdateResult::CU_GRAPH_EXEC_UPDATE_SUCCESS,
-            errorNode: std::ptr::null_mut(),
-            errorFromNode: std::ptr::null_mut(),
-        };
-        let status =
-            unsafe { sys::cuGraphExecUpdate_v2(self.cu_graph_exec, graph.cu_graph, &mut result) };
-        if status != sys::CUresult::CUDA_SUCCESS
-            || result.result != CUgraphExecUpdateResult::CU_GRAPH_EXEC_UPDATE_SUCCESS
+        #[cfg(luminal_cuda_ge_12_0)]
         {
-            if std::env::var_os("LUMINAL_CUDA_DEBUG_CUBLASLT_RECAPTURE").is_some() {
-                let node_count = graph.nodes().map(|nodes| nodes.len()).ok();
-                eprintln!(
-                    "CudaGraph exec update rejected: status={status:?} result={:?} error_node={:?} error_from_node={:?} source_nodes={node_count:?}",
-                    result.result, result.errorNode, result.errorFromNode,
-                );
-            }
-            let err = if status == sys::CUresult::CUDA_SUCCESS {
-                sys::CUresult::CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE
-            } else {
-                status
+            let mut result = CUgraphExecUpdateResultInfo {
+                result: CUgraphExecUpdateResult::CU_GRAPH_EXEC_UPDATE_SUCCESS,
+                errorNode: std::ptr::null_mut(),
+                errorFromNode: std::ptr::null_mut(),
             };
-            return Err(DriverError(err));
+            let status = unsafe {
+                sys::cuGraphExecUpdate_v2(self.cu_graph_exec, graph.cu_graph, &mut result)
+            };
+            if status != sys::CUresult::CUDA_SUCCESS
+                || result.result != CUgraphExecUpdateResult::CU_GRAPH_EXEC_UPDATE_SUCCESS
+            {
+                if std::env::var_os("LUMINAL_CUDA_DEBUG_CUBLASLT_RECAPTURE").is_some() {
+                    let node_count = graph.nodes().map(|nodes| nodes.len()).ok();
+                    eprintln!(
+                        "CudaGraph exec update rejected: status={status:?} result={:?} error_node={:?} error_from_node={:?} source_nodes={node_count:?}",
+                        result.result, result.errorNode, result.errorFromNode,
+                    );
+                }
+                let err = if status == sys::CUresult::CUDA_SUCCESS {
+                    sys::CUresult::CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE
+                } else {
+                    status
+                };
+                return Err(DriverError(err));
+            }
+            Ok(())
         }
-        Ok(())
+        #[cfg(not(luminal_cuda_ge_12_0))]
+        {
+            let mut error_node = std::ptr::null_mut();
+            let mut result = CUgraphExecUpdateResult::CU_GRAPH_EXEC_UPDATE_SUCCESS;
+            let status = unsafe {
+                sys::cuGraphExecUpdate(
+                    self.cu_graph_exec,
+                    graph.cu_graph,
+                    &mut error_node,
+                    &mut result,
+                )
+            };
+            if status != sys::CUresult::CUDA_SUCCESS
+                || result != CUgraphExecUpdateResult::CU_GRAPH_EXEC_UPDATE_SUCCESS
+            {
+                if std::env::var_os("LUMINAL_CUDA_DEBUG_CUBLASLT_RECAPTURE").is_some() {
+                    eprintln!(
+                        "CudaGraph exec update rejected: status={status:?} result={result:?} error_node={error_node:?}"
+                    );
+                }
+                let err = if status == sys::CUresult::CUDA_SUCCESS {
+                    sys::CUresult::CUDA_ERROR_GRAPH_EXEC_UPDATE_FAILURE
+                } else {
+                    status
+                };
+                return Err(DriverError(err));
+            }
+            Ok(())
+        }
     }
 }
 
@@ -571,7 +733,10 @@ pub fn event_elapsed_ms(
     ctx.bind_to_thread()?;
     let mut ms: f32 = 0.0;
     unsafe {
+        #[cfg(luminal_cuda_ge_12_8)]
         sys::cuEventElapsedTime_v2(&mut ms, start, end).result()?;
+        #[cfg(not(luminal_cuda_ge_12_8))]
+        sys::cuEventElapsedTime(&mut ms, start, end).result()?;
     }
     Ok(ms)
 }

--- a/crates/luminal_cuda_lite/src/kernel/to_host.rs
+++ b/crates/luminal_cuda_lite/src/kernel/to_host.rs
@@ -1285,6 +1285,7 @@ impl CudaGraphOp {
             profile.source_kernel_update += timer.elapsed();
 
             let mut recaptured_cublaslt = false;
+            #[cfg(luminal_cuda_ge_12_3)]
             if !state.cublaslt_ops.is_empty() {
                 let mut pending_recaptures = Vec::new();
                 let mut prepared_cache_plan = state.cublaslt_prepare_cache.clone();
@@ -1424,6 +1425,7 @@ impl CudaGraphOp {
                 }
             }
 
+            #[cfg(luminal_cuda_ge_12_3)]
             if !state.flashinfer_ops.is_empty() {
                 let mut pending_recaptures = Vec::new();
                 for idx in 0..state.flashinfer_ops.len() {
@@ -1666,6 +1668,7 @@ impl CudaGraphOp {
             .collect()
     }
 
+    #[cfg(luminal_cuda_ge_12_3)]
     fn capture_cublaslt_island_nodes(
         graph: &mut CudaGraphHandle,
         stream: &Arc<CudaStream>,
@@ -1729,6 +1732,7 @@ impl CudaGraphOp {
         Ok((captured_nodes, exit_deps))
     }
 
+    #[cfg(luminal_cuda_ge_12_3)]
     fn capture_cublaslt_island(
         graph: &mut CudaGraphHandle,
         stream: &Arc<CudaStream>,
@@ -1755,6 +1759,7 @@ impl CudaGraphOp {
         Ok((captured_nodes, exit_node))
     }
 
+    #[cfg(luminal_cuda_ge_12_3)]
     #[allow(clippy::too_many_arguments)]
     fn capture_flashinfer_decode_island(
         graph: &mut CudaGraphHandle,
@@ -1825,6 +1830,7 @@ impl CudaGraphOp {
         Ok((captured_nodes, exit_node))
     }
 
+    #[cfg(luminal_cuda_ge_12_3)]
     fn collect_cublaslt_island_nodes(
         graph: &CudaGraphHandle,
         entry_node: CUgraphNode,
@@ -1844,6 +1850,7 @@ impl CudaGraphOp {
         Ok(seen.into_iter().collect())
     }
 
+    #[cfg(luminal_cuda_ge_12_3)]
     fn recapture_cublaslt_island(
         graph: &mut CudaGraphHandle,
         stream: &Arc<CudaStream>,
@@ -1933,6 +1940,7 @@ impl CudaGraphOp {
         Ok(())
     }
 
+    #[cfg(luminal_cuda_ge_12_3)]
     fn recapture_flashinfer_decode_island(
         graph: &mut CudaGraphHandle,
         stream: &Arc<CudaStream>,
@@ -2252,6 +2260,7 @@ impl CudaGraphOp {
                         previous_graph_node = Some(graph_node);
                     }
                 }
+                #[cfg(luminal_cuda_ge_12_3)]
                 CompiledStep::CuBlasLt(idx) => {
                     let mut deps = Self::graph_deps_for_inputs(
                         &state.producer_to_graph_node,
@@ -2309,6 +2318,7 @@ impl CudaGraphOp {
                         previous_graph_node = Some(exit_node);
                     }
                 }
+                #[cfg(luminal_cuda_ge_12_3)]
                 CompiledStep::FlashInferDecode(idx) => {
                     let mut deps = Self::graph_deps_for_inputs(
                         &state.producer_to_graph_node,
@@ -2379,6 +2389,10 @@ impl CudaGraphOp {
                     if serialize_internal_steps {
                         previous_graph_node = Some(exit_node);
                     }
+                }
+                #[cfg(not(luminal_cuda_ge_12_3))]
+                CompiledStep::CuBlasLt(_) | CompiledStep::FlashInferDecode(_) => {
+                    unreachable!("cuBLASLt / FlashInfer graph islands require CUDA 12.3+");
                 }
             }
         }
@@ -2455,10 +2469,15 @@ pub fn kernel_to_host(
     let graph_packagable_ops = llir_graph
         .node_indices()
         .filter(|n| {
-            llir_graph[*n].to_dialect::<dyn KernelOp>().is_some()
-                || llir_graph[*n].to_dialect::<dyn HostOp>().is_some_and(|op| {
+            if llir_graph[*n].to_dialect::<dyn KernelOp>().is_some() {
+                return true;
+            }
+            #[cfg(luminal_cuda_ge_12_3)]
+            {
+                if let Some(op) = llir_graph[*n].to_dialect::<dyn HostOp>() {
                     let host = op.as_ref().as_ref();
-                    host.as_any()
+                    return host
+                        .as_any()
                         .downcast_ref::<CuBlasLt>()
                         .is_some_and(|cublaslt| cublaslt.graph_inputs() > 0)
                         || host
@@ -2468,8 +2487,10 @@ pub fn kernel_to_host(
                                 let incoming =
                                     llir_graph.edges_directed(*n, Direction::Incoming).count();
                                 incoming == flashinfer.graph_inputs() || incoming == 6
-                            })
-                })
+                            });
+                }
+            }
+            false
         })
         .collect::<FxHashSet<_>>();
 

--- a/crates/luminal_cuda_lite/src/runtime.rs
+++ b/crates/luminal_cuda_lite/src/runtime.rs
@@ -238,6 +238,8 @@ impl CudaRuntime {
     pub fn new() -> Result<Self, cudarc::driver::DriverError> {
         let ctx = cudarc::driver::CudaContext::new(0)?;
         ctx.bind_to_thread()?;
+        // cudarc omits `CudaContext::set_flags` for the `cuda-12000` feature (exactly 12.0).
+        #[cfg(not(all(luminal_cuda_ge_12_0, not(luminal_cuda_ge_12_3))))]
         ctx.set_flags(cudarc::driver::sys::CUctx_flags::CU_CTX_SCHED_BLOCKING_SYNC)?;
         let stream = ctx.default_stream();
 

--- a/crates/luminal_cuda_lite/src/tests/dtype_contract.rs
+++ b/crates/luminal_cuda_lite/src/tests/dtype_contract.rs
@@ -601,6 +601,7 @@ fn probe_bf16_subpaths() {
 /// bounds how much of a decode step is launch/serialization overhead for a
 /// ~1100-node graph.
 #[test]
+#[cfg(luminal_cuda_ge_12_3)]
 #[ignore = "perf measurement, run explicitly with --ignored --nocapture"]
 fn bench_cuda_graph_node_overhead() {
     use crate::compile_module_image_for_current_device;

--- a/crates/luminal_cuda_lite/tests/cuda_version_detect.rs
+++ b/crates/luminal_cuda_lite/tests/cuda_version_detect.rs
@@ -1,0 +1,96 @@
+mod cuda_version {
+    include!("../build_support/cuda_version.rs");
+}
+
+use cuda_version::{
+    FALLBACK_CUDA_VERSION, cudarc_env_format, ensure_supported_version, parse_cudarc_env,
+    parse_nvcc_stdout, threshold_cfgs,
+};
+
+#[test]
+fn parse_cudarc_env_known_versions() {
+    assert_eq!(parse_cudarc_env("12030"), Some((12, 3)));
+    assert_eq!(parse_cudarc_env("13030"), Some((13, 3)));
+    assert_eq!(parse_cudarc_env("11080"), Some((11, 8)));
+    assert_eq!(parse_cudarc_env("13040"), Some((13, 4)));
+    assert_eq!(parse_cudarc_env("12000"), Some((12, 0)));
+}
+
+#[test]
+fn parse_cudarc_env_roundtrip_format() {
+    assert_eq!(cudarc_env_format(12, 3), "12030");
+    assert_eq!(parse_cudarc_env(&cudarc_env_format(12, 0)), Some((12, 0)));
+}
+
+#[test]
+fn parse_cudarc_env_rejects_malformed() {
+    assert_eq!(parse_cudarc_env("99999"), None);
+    assert_eq!(parse_cudarc_env(""), None);
+    assert_eq!(parse_cudarc_env("abc"), None);
+}
+
+#[test]
+fn parse_nvcc_stdout_fixture_12_8() {
+    let stdout = "nvcc: NVIDIA (R) Cuda compiler driver
+Copyright (c) 2005-2024 NVIDIA Corporation
+Built on ...
+Cuda compilation tools, release 12.8, V12.8.89
+";
+    assert_eq!(parse_nvcc_stdout(stdout), Some((12, 8)));
+}
+
+#[test]
+fn parse_nvcc_stdout_newer_versions() {
+    let make = |ver: &str| {
+        format!(
+            "nvcc: NVIDIA (R) Cuda compiler driver
+Copyright (c) 2005-2025 NVIDIA Corporation
+Built on ...
+Cuda compilation tools, release {ver}, V{ver}.0
+"
+        )
+    };
+    assert_eq!(parse_nvcc_stdout(&make("13.4")), Some((13, 4)));
+    assert_eq!(parse_nvcc_stdout(&make("14.0")), Some((14, 0)));
+    assert_eq!(parse_nvcc_stdout(&make("12.7")), Some((12, 7)));
+}
+
+#[test]
+fn threshold_cfgs_by_version() {
+    assert!(threshold_cfgs(11, 8).is_empty());
+    assert_eq!(threshold_cfgs(12, 2), vec!["luminal_cuda_ge_12_0"]);
+    assert_eq!(
+        threshold_cfgs(12, 3),
+        vec!["luminal_cuda_ge_12_0", "luminal_cuda_ge_12_3"]
+    );
+    assert_eq!(
+        threshold_cfgs(12, 7),
+        vec!["luminal_cuda_ge_12_0", "luminal_cuda_ge_12_3"]
+    );
+    assert_eq!(
+        threshold_cfgs(12, 8),
+        vec![
+            "luminal_cuda_ge_12_0",
+            "luminal_cuda_ge_12_3",
+            "luminal_cuda_ge_12_8"
+        ]
+    );
+    assert_eq!(threshold_cfgs(13, 4), threshold_cfgs(13, 3));
+}
+
+#[test]
+fn ensure_supported_version_floor() {
+    assert!(ensure_supported_version(11, 4).is_ok());
+    assert!(ensure_supported_version(12, 0).is_ok());
+    let err = ensure_supported_version(11, 2).unwrap_err();
+    assert!(err.contains("below Luminal's minimum"));
+}
+
+#[test]
+fn fallback_is_top_ladder_rung() {
+    assert_eq!(FALLBACK_CUDA_VERSION, (12, 8));
+    assert_eq!(
+        threshold_cfgs(FALLBACK_CUDA_VERSION.0, FALLBACK_CUDA_VERSION.1),
+        threshold_cfgs(13, 3)
+    );
+}


### PR DESCRIPTION
Fixes #370
> **TLDR (going forward):** Luminal gates CUDA graph driver APIs via a compile-time threshold ladder (`ge_12_0` / `ge_12_3` / `ge_12_8`), independent of cudarc's binding-release table; cudarc owns FFI bindings, Luminal owns `#[cfg]` branches—extend the ladder only when a new driver API variant requires it.

## Summary

`main` fails to compile on CUDA 13.x because `cuda_graph.rs` mixes v1 and v2 CUDA graph driver APIs. cudarc 0.19.x only exposes `_v2` dependency/node-query symbols when built against CUDA 13.x, so calls like `cuGraphAddDependencies` (v1) fail at compile time.

This PR adds build-time toolkit detection and gates graph driver APIs behind an API-threshold ladder aligned with cudarc's version gates:

| cfg | CUDA toolkit | APIs |
| --- | --- | --- |
| `luminal_cuda_ge_12_0` | ≥ 12.0 | kernel / exec `_v2` graph APIs |
| `luminal_cuda_ge_12_3` | ≥ 12.3 | dependency `_v2`, `cuStreamBeginCaptureToGraph`, cuBLASLt / FlashInfer graph islands |
| `luminal_cuda_ge_12_8` | ≥ 12.8 | `cuEventElapsedTime_v2` |

On toolkits below 12.3, cuBLASLt and FlashInfer islands are not captured into CUDA graphs; they run as standalone host ops instead.

## Changes

- **`build.rs`** + **`build_support/cuda_version.rs`** — detect CUDA version from `CUDARC_CUDA_VERSION` (preferred) or `nvcc --version`; emit threshold cfgs; floor at 11.4; warn (not panic) on unvalidated newer majors
- **`cuda_graph.rs`** — `#[cfg]`-gated v1/v2 branches for all graph driver API families
- **`to_host.rs`** / **`cublaslt/mod.rs`** — skip island capture below 12.3
- **`tests/cuda_version_detect.rs`** — 8 unit tests for version parsing and threshold selection
- **`Cargo.toml`** — bump cudarc pin to 0.19.8; add `build = "build.rs"`

9 files, +503 / −32 lines.

## Test plan

- [x] `cargo test -p luminal_cuda_lite --test cuda_version_detect` — 8/8 passed
- [x] `cargo test -p luminal_cuda_lite` — 200 passed (192 unit + 8 integration), 122 ignored
- [x] `cargo clippy -p luminal_cuda_lite -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Verified `origin/main` fails to compile on CUDA 13.3 with the 6 missing v1 symbol errors from #370
- [x] `cargo clippy -p luminal_cuda_lite --all-targets -- -D warnings` — clean (host + devcontainer CUDA 12.8)
- [x] Devcontainer smoke (`ghcr.io/luminal-ai/luminal-docker:cuda`, CUDA 12.8): `cuda_graph::tests` 12/12 passed
- [x] `cargo build -p <all 11 examples>` on CUDA 13.3 — all passed

## Notes

- Luminal's API ladder is decoupled from cudarc's binding-release table; newer toolkit versions (13.4, 14.x) parse freely and receive all applicable `ge_*` cfgs
- No runtime dispatch — API selection is compile-time only; binaries built against newer graph APIs are not safe on older drivers
- Follow-up (out of scope): CI compile matrix for multiple CUDA toolkit versions