### PR TITLE
Whisper enablement: aten.repeat + SDPA boolean mask semantics

### DIFF
--- a/crates/luminal_python/rust/src/translator/attention.rs
+++ b/crates/luminal_python/rust/src/translator/attention.rs
@@ -137,10 +137,22 @@ impl<'a> Translator<'a> {
             let (scores_b, mask_b) = broadcast_binary(scores, neg_large);
             scores = scores_b + mask_b;
         }
-        if let Some(bias) = additive {
-            let (scores_b, bias_b) = ensure_same_dtype(scores, bias);
-            let (scores_b, bias_b) = broadcast_binary(scores_b, bias_b);
-            scores = scores_b + bias_b;
+        if let Some(mask) = additive {
+            // torch.nn.functional.scaled_dot_product_attention's attn_mask
+            // contract: "A boolean mask where a value of True indicates that
+            // the element should take part in attention. A float mask ...
+            // that is added to the attention score." Convert the bool
+            // keep-mask to an additive offset (-1e9 where false) before adding.
+            let mask_offset = if mask.dtype == DType::Bool {
+                let keep = mask.cast(DType::F32);
+                let one = keep.graph().constant_float(1.0).expand_rhs(keep.shape);
+                (one - keep) * -1e9_f32
+            } else {
+                mask
+            };
+            let (scores_b, offset_b) = ensure_same_dtype(scores, mask_offset);
+            let (scores_b, offset_b) = broadcast_binary(scores_b, offset_b);
+            scores = scores_b + offset_b;
         }
 
         let attn = scores.softmax(q_ndim - 1);

--- a/crates/luminal_python/rust/src/translator/dispatch.rs
+++ b/crates/luminal_python/rust/src/translator/dispatch.rs
@@ -88,6 +88,7 @@ impl<'a> Translator<'a> {
             // Shape ops
             "torch.ops.aten.view.default" => self.translate_reshape(node)?,
             "torch.ops.aten.upsample_nearest2d.vec" => self.translate_upsample_nearest2d(node)?,
+            "torch.ops.aten.repeat.default" => self.translate_repeat(node)?,
             "torch.ops.aten.permute.default" => self.translate_permute(node)?,
             "torch.ops.aten.unsqueeze.default" => {
                 let a = self.get_input_tensor(node, 0)?;

--- a/crates/luminal_python/rust/src/translator/movement.rs
+++ b/crates/luminal_python/rust/src/translator/movement.rs
@@ -65,6 +65,28 @@ impl<'a> Translator<'a> {
         })
     }
 
+    /// `aten.repeat`: tile the tensor `repeats[d]` times along each dim.
+    /// Leading entries beyond the input rank prepend new dims (torch
+    /// semantics); the tiling itself delegates to the core `repeat` view.
+    pub(crate) fn translate_repeat(&mut self, node: &Node) -> Result<GraphTensor> {
+        let mut t = self.get_input_tensor(node, 0)?;
+        let repeats = self.get_ints_arg(node, 1)?;
+        anyhow::ensure!(
+            repeats.len() >= t.shape.len(),
+            "repeat expects at least as many repeats ({}) as dims ({})",
+            repeats.len(),
+            t.shape.len()
+        );
+        anyhow::ensure!(
+            repeats.iter().all(|&r| r >= 1),
+            "repeat counts must be >= 1, got {repeats:?}"
+        );
+        for _ in 0..(repeats.len() - t.shape.len()) {
+            t = t.unsqueeze(0);
+        }
+        Ok(t.repeat(repeats.iter().map(|&r| r as usize).collect::<Vec<_>>()))
+    }
+
     pub(crate) fn translate_upsample_nearest2d(&mut self, node: &Node) -> Result<GraphTensor> {
         let input = self.get_input_tensor(node, 0)?;
         let input_dimensions = input.dims();

--- a/crates/luminal_python/tests/test_hlir_ops.py
+++ b/crates/luminal_python/tests/test_hlir_ops.py
@@ -1801,6 +1801,60 @@ def test_unsqueeze_middle(device: torch.device):
     assert torch.allclose(output, original)
 
 
+# ========== Repeat Tests (aten.repeat.default) ==========
+
+
+def test_repeat_1d(device: torch.device):
+    """(3,).repeat(4) -> (12,): tiling order must be abab, not aabb."""
+    from test_models import RepeatModel
+
+    model: torch.nn.Module = RepeatModel((4,)).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x: torch.Tensor = torch.rand(3, device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
+def test_repeat_2d_both_axes(device: torch.device):
+    """(2, 3).repeat(2, 3) -> (4, 9): tiling on every axis."""
+    from test_models import RepeatModel
+
+    model: torch.nn.Module = RepeatModel((2, 3)).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x: torch.Tensor = torch.rand((2, 3), device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
+def test_repeat_identity_axis(device: torch.device):
+    """(2, 3).repeat(1, 2): the `r == 1` skip on the first axis."""
+    from test_models import RepeatModel
+
+    model: torch.nn.Module = RepeatModel((1, 2)).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x: torch.Tensor = torch.rand((2, 3), device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
+def test_repeat_leading_dims(device: torch.device):
+    """(2, 3).repeat(4, 1, 1) -> (4, 2, 3): `len(repeats) > ndim` prepends
+    dims (the whisper positional-embedding batch broadcast)."""
+    from test_models import RepeatModel
+
+    model: torch.nn.Module = RepeatModel((4, 1, 1)).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x: torch.Tensor = torch.rand((2, 3), device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
+def test_repeat_leading_and_tile(device: torch.device):
+    """(3,).repeat(2, 3) -> (2, 9): prepend a dim AND tile the original."""
+    from test_models import RepeatModel
+
+    model: torch.nn.Module = RepeatModel((2, 3)).to(device)
+    model_compiled: Callable = torch.compile(model, backend=luminal_backend)
+    x: torch.Tensor = torch.rand(3, device=device)
+    assert torch.equal(model_compiled(x), model(x))
+
+
 # ========== Greater Tests ==========
 
 

--- a/crates/luminal_python/tests/test_models.py
+++ b/crates/luminal_python/tests/test_models.py
@@ -2480,6 +2480,18 @@ class SdpaWithBiasModel(torch.nn.Module):
         return torch.nn.functional.scaled_dot_product_attention(q, k, v, attn_mask=bias)
 
 
+class RepeatModel(torch.nn.Module):
+    """`Tensor.repeat(*repeats)` — tiles `repeats[d]` copies along each dim;
+    when `len(repeats) > ndim`, size-1 leading dims are prepended first."""
+
+    def __init__(self, repeats: tuple[int, ...]) -> None:
+        super().__init__()
+        self.repeats = repeats
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x.repeat(*self.repeats)
+
+
 # ========== Nearest Upsample Test Models ==========
 
 

--- a/src/shape/tracker.rs
+++ b/src/shape/tracker.rs
@@ -158,6 +158,11 @@ impl ShapeTracker {
             .zip(self.strides.iter_mut())
             .zip(repeats)
         {
+            // r == 1 leaves the axis untouched; skip the mod-wrap so untiled
+            // axes keep clean stride expressions.
+            if repeat == Expression::from(1) {
+                continue;
+            }
             let original_dim = *dim;
             *dim = (*dim * repeat).simplify();
             *stride = stride.substitute('z', expr('z') % original_dim).simplify();


### PR DESCRIPTION
getting whisper to work through pytorch

two changes

1. matching how we handle bool masks to torch sdpa attention 
2. Adding the repeat pytorch op 

Tests added for the repeat op 