### PR TITLE
cuda_lite: SinkAttention host op — FA3 (SM90) paged attention with sinks

### DIFF
--- a/crates/luminal_cuda_lite/src/host/flashinfer/jit.rs
+++ b/crates/luminal_cuda_lite/src/host/flashinfer/jit.rs
@@ -175,10 +175,63 @@ pub type PrefillRunFn = unsafe extern "C" fn(
     stream: *mut c_void,
 ) -> i32;
 
+// ── FA3 (SM90 / Hopper) wrapper function types — match wrapper_fa3.h ──
+
+pub type Fa3PrefillPlanFn = unsafe extern "C" fn(
+    float_workspace: *mut c_void,
+    float_ws_size: usize,
+    int_workspace: *mut c_void,
+    page_locked_int_workspace: *mut c_void,
+    int_ws_size: usize,
+    qo_indptr_h: *mut i32,
+    kv_indptr_h: *mut i32,
+    kv_len_arr_h: *mut i32,
+    total_num_rows: i32,
+    batch_size: i32,
+    num_qo_heads: i32,
+    num_kv_heads: i32,
+    page_size: i32,
+    stream: *mut c_void,
+    plan_info_out: *mut i64,
+    plan_info_len_out: *mut i32,
+) -> i32;
+
+pub type Fa3PrefillRunFn = unsafe extern "C" fn(
+    int_workspace: *mut c_void,
+    plan_info_vec: *mut i64,
+    plan_info_len: i32,
+    q: *mut c_void,
+    k_cache: *mut c_void,
+    v_cache: *mut c_void,
+    kv_indices: *mut i32,
+    sink: *mut f32,
+    output: *mut c_void,
+    nnz_qo: i32,
+    num_qo_heads: i32,
+    num_kv_heads: i32,
+    page_size: i32,
+    sm_scale: f32,
+    window_left: i32,
+    stream: *mut c_void,
+) -> i32;
+
+/// Shared shape for both FA3 layout-transpose entry points (the bf16-q and
+/// f32-output variants differ only in the loaded symbol).
+pub type Fa3TransposeFn = unsafe extern "C" fn(
+    src: *const c_void,
+    dst: *mut c_void,
+    batch: i32,
+    heads: i32,
+    dim: i32,
+    stream: *mut c_void,
+) -> i32;
+
 // ── Embedded CUDA sources ──
 
 const WRAPPER_CU: &str = include_str!("wrapper.cu");
 const WRAPPER_H: &str = include_str!("wrapper.h");
+const WRAPPER_FA3_CU: &str = include_str!("wrapper_fa3.cu");
+const WRAPPER_FA3_H: &str = include_str!("wrapper_fa3.h");
 
 // ── Loaded library handle ──
 
@@ -261,27 +314,106 @@ impl FlashInferLib {
     }
 }
 
-/// Compile wrapper.cu for the given HEAD_DIM/variant, or return cached .so path.
-fn compile_or_cache(head_dim: usize, use_swa: bool) -> PathBuf {
+// ── FA3 (SM90 / Hopper) library: AttentionSink paged batch prefill ──
+//
+// Separate .so from the FA2 wrapper: the hopper kernels need -arch=sm_90a
+// (WGMMA/TMA) and the CUTLASS/CuTe headers, and gpt-oss's sink variant is
+// baked into this wrapper. Decode uses the same entry at qo_len=1.
+
+pub struct Fa3Lib {
+    _lib: libloading::Library,
+    pub prefill_plan: Fa3PrefillPlanFn,
+    pub prefill_run: Fa3PrefillRunFn,
+    pub transpose_output_f32: Fa3TransposeFn,
+    pub transpose_q_bf16: Fa3TransposeFn,
+}
+
+// SAFETY: same rationale as FlashInferLib — process-lifetime pointers, calls
+// serialized by CUDA stream.
+unsafe impl Send for Fa3Lib {}
+unsafe impl Sync for Fa3Lib {}
+
+/// One compiled FA3 wrapper per (HEAD_DIM, use_sliding_window) pair.
+static FA3_LIBS: OnceLock<
+    std::sync::Mutex<std::collections::HashMap<(usize, bool), &'static Fa3Lib>>,
+> = OnceLock::new();
+
+/// Ensure the FA3/Hopper sink-attention library is compiled and loaded for
+/// the given HEAD_DIM and sliding-window variant. Thread-safe. Panics on
+/// compile failure; the caller gates on Hopper (compute capability 9.x).
+pub fn ensure_compiled_fa3(head_dim: usize, use_swa: bool) -> &'static Fa3Lib {
+    let libs = FA3_LIBS.get_or_init(Default::default);
+    let mut libs = libs.lock().unwrap();
+    if let Some(lib) = libs.get(&(head_dim, use_swa)) {
+        return lib;
+    }
+    assert!(
+        matches!(head_dim, 64 | 128 | 256),
+        "FlashInfer FA3: unsupported HEAD_DIM={} (SM90 paged prefill supports 64, 128, 256)",
+        head_dim
+    );
+    let so_path = compile_or_cache_fa3(head_dim, use_swa);
+    let lib: &'static Fa3Lib = Box::leak(Box::new(unsafe {
+        Fa3Lib::load(&so_path)
+            .unwrap_or_else(|e| panic!("Failed to load FlashInfer FA3 library: {e}"))
+    }));
+    libs.insert((head_dim, use_swa), lib);
+    lib
+}
+
+impl Fa3Lib {
+    /// Load a compiled FA3 wrapper .so and resolve function pointers.
+    ///
+    /// # Safety
+    /// The .so must be a valid wrapper compiled from wrapper_fa3.cu.
+    unsafe fn load(path: &Path) -> Result<Self, libloading::Error> {
+        let lib = unsafe { libloading::Library::new(path)? };
+        let prefill_plan: Fa3PrefillPlanFn =
+            unsafe { *lib.get::<Fa3PrefillPlanFn>(b"flashinfer_fa3_prefill_plan\0")? };
+        let prefill_run: Fa3PrefillRunFn =
+            unsafe { *lib.get::<Fa3PrefillRunFn>(b"flashinfer_fa3_prefill_run\0")? };
+        let transpose_output_f32: Fa3TransposeFn =
+            unsafe { *lib.get::<Fa3TransposeFn>(b"flashinfer_fa3_transpose_output_f32\0")? };
+        let transpose_q_bf16: Fa3TransposeFn =
+            unsafe { *lib.get::<Fa3TransposeFn>(b"flashinfer_fa3_transpose_q_bf16\0")? };
+        Ok(Self {
+            _lib: lib,
+            prefill_plan,
+            prefill_run,
+            transpose_output_f32,
+            transpose_q_bf16,
+        })
+    }
+}
+
+/// Shared nvcc compile-or-cache for both wrapper families. The .so name
+/// bakes head_dim, variant, arch, and a hash of the embedded sources, so
+/// stale caches self-invalidate when the wrappers change. On a cache hit no
+/// header tree is required.
+#[allow(clippy::too_many_arguments)] // private, two call sites, flags > struct
+fn compile_or_cache_common(
+    label: &str,
+    so_stem: &str,
+    head_dim: usize,
+    use_swa: bool,
+    arch: &str,
+    wrapper_hash: u64,
+    cu_path: &Path,
+    header_dir: &Path,
+    cutlass_tools_include: bool,
+    extra_flags: &[&str],
+    progress_note: &str,
+) -> PathBuf {
     let cache_dir = cache_directory();
-    std::fs::create_dir_all(&cache_dir).expect("Failed to create FlashInfer cache directory");
-
-    // Extract bundled wrapper sources to the cache so nvcc can compile them.
-    let (wrapper_cu_path, wrapper_h_dir) = extract_wrapper_sources(&cache_dir);
-
-    let arch = detect_cuda_arch();
-    // Bake a hash of the embedded wrapper into the .so name so old caches are
-    // discarded automatically when wrapper.cu or wrapper.h change.
-    let wrapper_hash = wrapper_source_hash();
     let so_name = format!(
-        "libflashinfer_hd{}_swa{}_{}_w{:016x}.so",
+        "{so_stem}_hd{}_swa{}_{}_w{:016x}.so",
         head_dim, use_swa as u8, arch, wrapper_hash
     );
     let so_path = cache_dir.join(&so_name);
 
     if so_path.exists() {
         eprintln!(
-            "FlashInfer: using cached library for HEAD_DIM={} ({})",
+            "{label}: using cached library for HEAD_DIM={} ({})",
             head_dim,
             so_path.display()
         );
@@ -297,34 +429,43 @@ fn compile_or_cache(head_dim: usize, use_swa: bool) -> PathBuf {
     };
 
     eprintln!(
-        "FlashInfer: JIT compiling for HEAD_DIM={}, arch={} ...",
-        head_dim, arch
+        "{label}: JIT compiling for HEAD_DIM={head_dim}, swa={}, arch={arch}{progress_note} ...",
+        use_swa as u8
     );
     let start = std::time::Instant::now();
 
+    let mut args = vec![
+        "-shared".to_string(),
+        "-o".to_string(),
+        so_path.to_str().unwrap().to_string(),
+        format!("-DLUMINAL_HEAD_DIM={head_dim}"),
+        format!("-DLUMINAL_USE_SWA={}", use_swa as u8),
+        cu_path.to_str().unwrap().to_string(),
+        "-I".to_string(),
+        flashinfer_include.to_str().unwrap().to_string(),
+        "-I".to_string(),
+        cutlass_include.to_str().unwrap().to_string(),
+    ];
+    if cutlass_tools_include {
+        // cutlass_utils.cuh also pulls in cutlass/util/* from the tools tree.
+        let tools = cutlass_include.parent().unwrap().join("tools/util/include");
+        args.push("-I".to_string());
+        args.push(tools.to_str().unwrap().to_string());
+    }
+    args.extend([
+        "-I".to_string(),
+        header_dir.to_str().unwrap().to_string(),
+        "-std=c++17".to_string(),
+        format!("-arch={arch}"),
+        "-O3".to_string(),
+        "--expt-relaxed-constexpr".to_string(),
+        "-w".to_string(),
+    ]);
+    args.extend(extra_flags.iter().map(|f| f.to_string()));
+    args.extend(["--compiler-options".to_string(), "-fPIC".to_string()]);
+
     let output = Command::new("nvcc")
-        .args([
-            "-shared",
-            "-o",
-            so_path.to_str().unwrap(),
-            &format!("-DLUMINAL_HEAD_DIM={}", head_dim),
-            &format!("-DLUMINAL_USE_SWA={}", use_swa as u8),
-            wrapper_cu_path.to_str().unwrap(),
-            "-I",
-            flashinfer_include.to_str().unwrap(),
-            "-I",
-            cutlass_include.to_str().unwrap(),
-            "-I",
-            wrapper_h_dir.to_str().unwrap(),
-            "-std=c++17",
-            &format!("-arch={}", arch),
-            "-O3",
-            "--expt-relaxed-constexpr",
-            "-w",
-            "-rdc=true",
-            "--compiler-options",
-            "-fPIC",
-        ])
+        .args(&args)
         .output()
         .expect("Failed to run nvcc. Is the CUDA toolkit installed?");
 
@@ -333,19 +474,68 @@ fn compile_or_cache(head_dim: usize, use_swa: bool) -> PathBuf {
         let stdout = String::from_utf8_lossy(&output.stdout);
         let _ = std::fs::remove_file(&so_path);
         panic!(
-            "FlashInfer JIT compilation failed (HEAD_DIM={}, arch={}):\nstdout: {}\nstderr: {}",
-            head_dim, arch, stdout, stderr
+            "{label} JIT compilation failed (HEAD_DIM={head_dim}, arch={arch}):\nstdout: {stdout}\nstderr: {stderr}"
         );
     }
 
-    let elapsed = start.elapsed();
     eprintln!(
-        "FlashInfer: compiled in {:.1}s → {}",
-        elapsed.as_secs_f64(),
+        "{label}: compiled in {:.1}s → {}",
+        start.elapsed().as_secs_f64(),
         so_path.display()
     );
-
     so_path
+}
+
+/// Compile wrapper_fa3.cu for the given HEAD_DIM/variant, or return the
+/// cached .so path. The hopper kernels use WGMMA/TMA, which nvcc only emits
+/// for the architecture-specific `sm_90a` target — plain `sm_90` will not
+/// compile them.
+fn compile_or_cache_fa3(head_dim: usize, use_swa: bool) -> PathBuf {
+    let cache_dir = cache_directory();
+    std::fs::create_dir_all(&cache_dir).expect("Failed to create FlashInfer cache directory");
+    let cu = cache_dir.join("wrapper_fa3.cu");
+    write_if_changed(&cu, WRAPPER_FA3_CU.as_bytes());
+    write_if_changed(&cache_dir.join("wrapper_fa3.h"), WRAPPER_FA3_H.as_bytes());
+    let wrapper_hash = {
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        WRAPPER_FA3_CU.hash(&mut hasher);
+        WRAPPER_FA3_H.hash(&mut hasher);
+        hasher.finish()
+    };
+    compile_or_cache_common(
+        "FlashInfer FA3",
+        "libflashinfer_fa3",
+        head_dim,
+        use_swa,
+        "sm_90a",
+        wrapper_hash,
+        &cu,
+        &cache_dir,
+        /*cutlass_tools_include=*/ true,
+        &[], // no -rdc=true (unlike FA2): it serializes the wgmma pipeline
+        " (hopper templates — takes a few minutes)",
+    )
+}
+
+/// Compile wrapper.cu for the given HEAD_DIM/variant, or return cached .so path.
+fn compile_or_cache(head_dim: usize, use_swa: bool) -> PathBuf {
+    let cache_dir = cache_directory();
+    std::fs::create_dir_all(&cache_dir).expect("Failed to create FlashInfer cache directory");
+    // Extract bundled wrapper sources to the cache so nvcc can compile them.
+    let (wrapper_cu_path, wrapper_h_dir) = extract_wrapper_sources(&cache_dir);
+    compile_or_cache_common(
+        "FlashInfer",
+        "libflashinfer",
+        head_dim,
+        use_swa,
+        &detect_cuda_arch(),
+        wrapper_source_hash(),
+        &wrapper_cu_path,
+        &wrapper_h_dir,
+        /*cutlass_tools_include=*/ false,
+        &["-rdc=true"],
+        "",
+    )
 }
 
 /// Returns ~/.cache/luminal/flashinfer/

--- a/crates/luminal_cuda_lite/src/host/flashinfer/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/flashinfer/mod.rs
@@ -1,5 +1,6 @@
 pub mod find_indptrs;
 pub mod jit;
+pub mod sink_attention;
 
 use std::sync::{Arc, Mutex, OnceLock};
 
@@ -295,7 +296,21 @@ pub(crate) fn resident_shared_device_memory_allocations() -> Vec<SharedDeviceMem
 
 static PAGE_LOCKED_WORKSPACE: OnceLock<PageLockedPtr> = OnceLock::new();
 
-struct PageLockedPtr(*mut u8);
+/// Process-wide page-locked (pinned) staging buffer for FlashInfer's
+/// host-side plan writes. Allocated once, never freed; shared by the FA2 and
+/// FA3 (SinkAttention) plan paths.
+pub(crate) fn page_locked_workspace() -> &'static PageLockedPtr {
+    PAGE_LOCKED_WORKSPACE.get_or_init(|| unsafe {
+        let mut ptr: *mut std::ffi::c_void = std::ptr::null_mut();
+        let status = libc::posix_memalign(&mut ptr, 4096, INT_WORKSPACE_SIZE);
+        assert_eq!(status, 0, "Failed to allocate page-locked workspace");
+        let cuda_status = cuda_pin_memory(ptr, INT_WORKSPACE_SIZE);
+        assert_eq!(cuda_status, 0, "Failed to pin memory");
+        PageLockedPtr(ptr as *mut u8)
+    })
+}
+
+pub(crate) struct PageLockedPtr(pub(crate) *mut u8);
 
 // SAFETY: The pointer is page-locked CUDA memory allocated once via
 // posix_memalign + cudaHostRegister and only mutated during OnceLock
@@ -779,14 +794,7 @@ impl FlashInferAttention {
 
         let (float_workspace, float_workspace_ptr, int_workspace, int_workspace_ptr) =
             flashinfer_workspaces(stream);
-        let page_locked_workspace = PAGE_LOCKED_WORKSPACE.get_or_init(|| unsafe {
-            let mut ptr: *mut std::ffi::c_void = std::ptr::null_mut();
-            let status = libc::posix_memalign(&mut ptr, 4096, INT_WORKSPACE_SIZE);
-            assert_eq!(status, 0, "Failed to allocate page-locked workspace");
-            let cuda_status = cuda_pin_memory(ptr, INT_WORKSPACE_SIZE);
-            assert_eq!(cuda_status, 0, "Failed to pin memory");
-            PageLockedPtr(ptr as *mut u8)
-        });
+        let page_locked_workspace = page_locked_workspace();
 
         let mut plan_info_buf = [0i64; 16];
         let mut plan_info_len: i32 = 0;

--- a/crates/luminal_cuda_lite/src/host/flashinfer/sink_attention.egg
+++ b/crates/luminal_cuda_lite/src/host/flashinfer/sink_attention.egg
@@ -1,0 +1,205 @@
+; AUTO-GENERATED from an LLIR dump of the paged reference attention spelling
+; (gptoss-serve's dump_egglog bin) — regenerate from a fresh dump, don't edit.
+;
+; Paged gpt-oss sink attention (GQA + sink-augmented softmax) -> FA3 host op.
+;
+; Masking is hybrid: causal + cross-sequence isolation is a host mask Input,
+; matched as a PROOF-ONLY anchor; the sliding window is in-graph
+; (k_pos vs q_abs-(W-1)), so sliding-vs-full is structurally proven AND the
+; layer bodies differ, driving the period-2 loop roll that keeps per-slot
+; masks loop-invariant — this rule matches inside rolled bodies. (The roll
+; needs >= 6 layers; shallower tests see different rolling regimes.)
+; qo/kv_indptr are free-floating named Inputs (size-1 joins) wired through
+; as runtime inputs.
+;
+; Staging (run order: _pre -> late x3 -> late2): sa_masked (_pre) ->
+; sa_island (late) -> op rule (late2). Depends on flashinfer_attention.egg's
+; const_like / flashinfer_head_dim_ok_16bit.
+
+; (masked, scores, scale_val, window_left): the masked-scores node, the raw
+; scores it was built from, the softmax scale constant, and the window
+; (-1.0 = full attention).
+(relation sa_masked (IR IR f64 f64))
+
+; Full attention: masked = scaled_scores + host_mask.
+(rule
+    (
+        (= ?masked (Op (Add ?m_s ?m_a ?m_b ?m_o)
+            (ICons ?scaled (ICons ?mask (INil)))))
+        (= ?scaled (Op (Mul ?sc_s ?sc_a ?sc_b ?sc_o)
+            (ICons ?scores (ICons ?scale_c (INil)))))
+        (const_like ?scale_c ?scale_val)
+        (= ?mask (Input ?mask_idx ?mask_name (F32)))
+    )
+    (
+        (sa_masked ?masked ?scores ?scale_val -1.0)
+    )
+    :ruleset kernel_fuse_late_pre
+    :name "SinkAttention masked fact (full)"
+)
+
+; Sliding window: masked = (scaled_scores + host_mask) + window_term, where
+; window_term = Cast(LessThan(k_pos, q_abs - W1)) * -1e30 and W1 is the
+; in-graph window constant (gpt-oss: 127 = SLIDING_WINDOW - 1, exactly
+; FlashInfer's window_left convention).
+(rule
+    (
+        (= ?masked (Op (Add ?o_s ?o_a ?o_b ?o_o)
+            (ICons ?base (ICons ?wterm (INil)))))
+        (= ?base (Op (Add ?b_s ?b_a ?b_b ?b_o)
+            (ICons ?scaled (ICons ?mask (INil)))))
+        (= ?scaled (Op (Mul ?sc_s ?sc_a ?sc_b ?sc_o)
+            (ICons ?scores (ICons ?scale_c (INil)))))
+        (const_like ?scale_c ?scale_val)
+        (= ?mask (Input ?mask_idx ?mask_name (F32)))
+        (= ?wterm (Op (Mul ?w_s ?w_a ?w_b ?w_o)
+            (ICons ?past_f (ICons ?negbig (INil)))))
+        (const_like ?negbig ?negbig_val)
+        (< ?negbig_val -900000000000000000000000000000.0)
+        (= ?past_f (Op (Cast ?pc_sz (F32)) (ICons ?past (INil))))
+        (= ?past (Op (LessThan ?lt_s ?lt_a ?lt_b ?lt_o)
+            (ICons ?k_posf (ICons ?wstart (INil)))))
+        (= ?wstart (Op (Add ?ws_s ?ws_a ?ws_b ?ws_o)
+            (ICons ?q_absf (ICons ?negw (INil)))))
+        (= ?negw (Op (Mul ?nw_s ?nw_a ?nw_b ?nw_o)
+            (ICons ?wconst (ICons ?negone1 (INil)))))
+        (const_like ?wconst ?window_val)
+        (const_like ?negone1 -1.000000)
+    )
+    (
+        (sa_masked ?masked ?scores ?scale_val ?window_val)
+    )
+    :ruleset kernel_fuse_late_pre
+    :name "SinkAttention masked fact (sliding window)"
+)
+
+; (out, q_bf16, k_pool, v_pool, flat_gather_idx, sinks_f32,
+;  nheads, kvdim, hdim, scale, window_left)
+(relation sa_island (IR IR IR IR IR IR Expression Expression Expression f64 f64))
+
+(rule
+    (
+        ; ── K/V pool scatters sharing one flat scatter index ──
+        (= ?k_pool (Op (Scatter ?ksd ?ksdst ?ksis ?ksistr ?ksss)
+            (ICons ?k_dest (ICons ?scat_idx (ICons ?k_src (INil))))))
+        (= ?v_pool (Op (Scatter ?vsd ?vsdst ?vsis ?vsistr ?vsss)
+            (ICons ?v_dest (ICons ?scat_idx (ICons ?v_src (INil))))))
+
+        ; ── Context gathers from both pools via ONE flat gather index ──
+        (= ?k_gathered (Op (Gather
+            (ECons (MVar "c") (ECons ?kvdim (ENil)))
+            ?kg_a
+            (ECons ?nslots (ECons ?kvdim2 (ENil)))
+            ?kg_b)
+            (ICons ?flat_gidx (ICons ?k_pool (INil)))))
+        (= ?k_ctx (Op (Cast ?kc_sz (F32)) (ICons ?k_gathered (INil))))
+        (= ?v_gathered (Op (Gather
+            (ECons (MVar "c") (ECons ?kvdim3 (ENil)))
+            ?vg_a
+            (ECons ?nslots2 (ECons ?kvdim4 (ENil)))
+            ?vg_b)
+            (ICons ?flat_gidx (ICons ?v_pool (INil)))))
+        (= ?v_ctx (Op (Cast ?vc_sz (F32)) (ICons ?v_gathered (INil))))
+
+        ; ── Q: the bf16 island operand, cast back up for the F32 chain ──
+        (= ?q_bf (Op (Cast ?qb_sz (Bf16)) (ICons ?q_rope (INil))))
+        (= ?q_f (Op (Cast ?qf_sz (F32)) (ICons ?q_bf (INil))))
+
+        ; ── Q·K^T: (nheads, s, c, hd) mul + reduce over hd ──
+        (= ?qk (Op (Mul
+            (ECons ?nheads (ECons (MVar "s") (ECons (MVar "c") (ECons ?hdim (ENil)))))
+            ?qk_a ?qk_b ?qk_o)
+            (ICons ?q_f (ICons ?k_ctx (INil)))))
+        (= ?scores (Op (Sum ?ss_shape ?hdim ?ss_in ?ss_iter ?ss_out)
+            (ICons ?qk (INil))))
+        (flashinfer_head_dim_ok_16bit ?hdim)
+
+        ; ── Masked scores: staged fact (full or sliding-window shape) ──
+        (sa_masked ?masked ?scores ?scale_val ?window_val)
+
+        ; ── Row max, then max(row_max, sink) in the lt-select spelling ──
+        (= ?rmax (Op (Max ?rm_shape (MVar "c") ?rm_in ?rm_iter ?rm_out)
+            (ICons ?masked (INil))))
+        (= ?sinks_f (Op (Cast ?sk_sz (F32)) (ICons ?sinks_w (INil))))
+        (= ?lt (Op (LessThan ?lt_s ?lt_a ?lt_b ?lt_o)
+            (ICons ?rmax (ICons ?sinks_f (INil)))))
+        (= ?lt_f (Op (Cast ?ltf_sz (F32)) (ICons ?lt (INil))))
+        (= ?sink_part (Op (Mul ?sp_s ?sp_a ?sp_b ?sp_o)
+            (ICons ?lt_f (ICons ?sinks_f (INil)))))
+        (= ?lt_neg (Op (Mul ?ln_s ?ln_a ?ln_b ?ln_o)
+            (ICons ?lt_f (ICons ?neg1a (INil)))))
+        (const_like ?neg1a -1.000000)
+        (= ?one_m (Op (Add ?om_s ?om_a ?om_b ?om_o)
+            (ICons ?lt_neg (ICons ?one_c (INil)))))
+        (const_like ?one_c 1.000000)
+        (= ?om_bool (Op (Cast ?omb_sz (Bool)) (ICons ?one_m (INil))))
+        (= ?om_f (Op (Cast ?omf_sz (F32)) (ICons ?om_bool (INil))))
+        (= ?max_part (Op (Mul ?mp_s ?mp_a ?mp_b ?mp_o)
+            (ICons ?om_f (ICons ?rmax (INil)))))
+        (= ?newmax (Op (Add ?nm_s ?nm_a ?nm_b ?nm_o)
+            (ICons ?sink_part (ICons ?max_part (INil)))))
+
+        ; ── exp2((masked - newmax) · log2e) and its row sum ──
+        (= ?nm_negc (Op (Mul ?nn_s ?nn_a ?nn_b ?nn_o)
+            (ICons ?newmax (ICons ?neg1b (INil)))))
+        (const_like ?neg1b -1.000000)
+        (= ?shifted (Op (Add ?sh_s ?sh_a ?sh_b ?sh_o)
+            (ICons ?masked (ICons ?nm_negc (INil)))))
+        (= ?sc2 (Op (Mul ?s2_s ?s2_a ?s2_b ?s2_o)
+            (ICons ?shifted (ICons ?log2e_a (INil)))))
+        (const_like ?log2e_a 1.442695)
+        (= ?num (Op (Exp2 ?ex_s ?ex_in ?ex_out) (ICons ?sc2 (INil))))
+        (= ?numsum (Op (Sum ?ns_shape (MVar "c") ?ns_in ?ns_iter ?ns_out)
+            (ICons ?num (INil))))
+
+        ; ── The sink joins the DENOMINATOR only ──
+        (= ?nm_negs (Op (Mul ?ng_s ?ng_a ?ng_b ?ng_o)
+            (ICons ?newmax (ICons ?neg1c (INil)))))
+        (const_like ?neg1c -1.000000)
+        (= ?sink_sh (Op (Add ?ks_s ?ks_a ?ks_b ?ks_o)
+            (ICons ?sinks_f (ICons ?nm_negs (INil)))))
+        (= ?sink_sc (Op (Mul ?kc_s ?kc_a ?kc_b ?kc_o)
+            (ICons ?sink_sh (ICons ?log2e_b (INil)))))
+        (const_like ?log2e_b 1.442695)
+        (= ?sink_exp (Op (Exp2 ?se_s ?se_in ?se_out) (ICons ?sink_sc (INil))))
+        (= ?denom (Op (Add ?d_s ?d_a ?d_b ?d_o)
+            (ICons ?numsum (ICons ?sink_exp (INil)))))
+        (= ?rdenom (Op (Recip ?r_s ?r_in ?r_out) (ICons ?denom (INil))))
+        (= ?probs (Op (Mul ?p_s ?p_a ?p_b ?p_o)
+            (ICons ?num (ICons ?rdenom (INil)))))
+
+        ; ── P·V: (nheads, s, hd, c) mul + reduce over c → output point ──
+        (= ?pv (Op (Mul
+            (ECons ?nheads2 (ECons (MVar "s") (ECons ?hdim2 (ECons (MVar "c") (ENil)))))
+            ?pv_a ?pv_b ?pv_o)
+            (ICons ?probs (ICons ?v_ctx (INil)))))
+        (= ?out (Op (Sum ?o_shape (MVar "c") ?o_in ?o_iter ?o_out)
+            (ICons ?pv (INil))))
+    )
+    (
+        (sa_island ?out ?q_bf ?k_pool ?v_pool ?flat_gidx ?sinks_f
+            ?nheads ?kvdim ?hdim ?scale_val ?window_val)
+    )
+    :ruleset kernel_fuse_late
+    :name "SinkAttention island fact"
+)
+
+; ── Op rule: window_left proven from the graph (sa_masked) ──
+
+(rule
+    (
+        (sa_island ?out ?q ?kp ?vp ?g ?s ?nheads ?kvdim ?hdim ?scale_val ?window_val)
+        (= ?qoi (Input ?qo_idx "qo_indptr" (Int)))
+        (= ?kvi (Input ?kv_idx "kv_indptr" (Int)))
+    )
+    (
+        (let ?fi (Op (SinkAttention
+            ?nheads (MDiv ?kvdim ?hdim) ?hdim (MVar "s") ?scale_val ?window_val)
+            (ICons ?q (ICons ?kp (ICons ?vp (ICons ?g
+                (ICons ?qoi (ICons ?kvi (ICons ?s (INil))))))))))
+        (union ?out ?fi)
+        (set (dtype ?fi) (F32))
+    )
+    :ruleset kernel_fuse_late2
+    :name "SinkAttention op"
+)

--- a/crates/luminal_cuda_lite/src/host/flashinfer/sink_attention.rs
+++ b/crates/luminal_cuda_lite/src/host/flashinfer/sink_attention.rs
@@ -1,0 +1,355 @@
+//! `SinkAttention` — host op wrapping the FA3/Hopper AttentionSink paged
+//! batch-prefill kernel.
+//!
+//! Runtime inputs (7): `q` (s, nq*hd) bf16, `k_pool`/`v_pool`
+//! (num_slots, nkv*hd) bf16 (post-scatter pool states), `kv_indices` (c,)
+//! Int (compact page table, page_size 1), `qo_indptr`/`kv_indptr` (r,) Int
+//! on DEVICE (read back per execute), `sinks` (nq,) F32.
+//!
+//! Output: (nq, s, hd) F32 — the layout+dtype of the reference chain's
+//! attention output point, produced by a fused transpose+upcast kernel.
+//! Decode is the same kernel at qo_len=1 (no SM90 decode-with-sink kernel).
+//!
+//! The rewrite rule (sink_attention.egg) matches the paged gpt-oss sink
+//! attention chain and unions this op in; which host-mask Input feeds the
+//! chain ("mask_sliding" vs "mask_full") selects window_left.
+
+use std::sync::Arc;
+
+use luminal::{
+    egglog_utils::api::{Rule, SortDef, sort},
+    egglog_utils::base::{EXPRESSION, F64, OP_KIND},
+    egglog_utils::{SerializedEGraph, extract_expr},
+    op::{EgglogOp, LLIROp},
+    prelude::*,
+    shape::Expression,
+};
+
+use crate::cudarc::driver::{CudaStream, DevicePtr, result};
+
+use super::super::{DeviceBuffer, HostOp};
+use super::jit;
+use super::{INT_WORKSPACE_SIZE, bytes_to_i32_vec, flashinfer_workspaces, page_locked_workspace};
+
+/// Grow-only device scratch (q transpose in, kernel output out), reused
+/// across calls instead of a per-call alloc + trailing sync. Stream-ordered
+/// reuse on the same stream is safe (each execute's indptr-readback sync
+/// drains prior consumers); on a stream change (tests) the old buffers are
+/// leaked rather than dropped, since their context may be gone. Bounded by
+/// the largest tick, so leaking on replace/grow costs nothing real.
+static SCRATCH: std::sync::Mutex<Option<(usize, crate::cudarc::driver::CudaSlice<u8>)>> =
+    std::sync::Mutex::new(None);
+
+#[derive(Debug)]
+pub struct SinkAttention {
+    pub num_qo_heads: usize,
+    pub num_kv_heads: usize,
+    pub head_dim: usize,
+    /// The 's' (batch tokens) dimension expression.
+    pub batch_dim: Expression,
+    /// Softmax scale; 0.0 = default `1/sqrt(head_dim)`.
+    pub sm_scale: f64,
+    /// FlashInfer window_left convention (visible previous positions);
+    /// -1 = full attention. Selects the swa .so variant at compile time.
+    pub window_left: i64,
+}
+
+impl Default for SinkAttention {
+    fn default() -> Self {
+        Self {
+            num_qo_heads: 0,
+            num_kv_heads: 0,
+            head_dim: 0,
+            batch_dim: Expression::default(),
+            sm_scale: 0.0,
+            window_left: -1,
+        }
+    }
+}
+
+impl EgglogOp for SinkAttention {
+    fn sort(&self) -> SortDef {
+        sort(
+            OP_KIND,
+            "SinkAttention",
+            &[
+                ("num_qo_heads", EXPRESSION),
+                ("num_kv_heads", EXPRESSION),
+                ("head_dim", EXPRESSION),
+                ("batch_dim", EXPRESSION),
+                ("sm_scale", F64),
+                ("window_left", F64),
+            ],
+        )
+    }
+
+    fn n_inputs(&self) -> usize {
+        // q, k_pool, v_pool, kv_indices, qo_indptr, kv_indptr, sinks
+        7
+    }
+
+    fn rewrites(&self) -> Vec<Rule> {
+        // The FA3 kernels are Hopper-only (sm_90a WGMMA/TMA): emit no rules
+        // on other architectures so the search never selects the op there.
+        if crate::device_compute_major() != 9 {
+            return vec![];
+        }
+        vec![Rule::raw(include_str!("sink_attention.egg"))]
+    }
+
+    fn extract<'a>(
+        &'a self,
+        egraph: &'a SerializedEGraph,
+        kind_children: &[&'a ENodeId],
+        input_enodes: Vec<&'a ENodeId>,
+        _list_cache: &mut FxHashMap<&'a ENodeId, Vec<Expression>>,
+        expr_cache: &mut FxHashMap<&'a ENodeId, Expression>,
+    ) -> (LLIROp, Vec<&'a ENodeId>) {
+        let num_qo_heads = extract_expr(egraph, kind_children[0], expr_cache)
+            .unwrap()
+            .exec(&FxHashMap::default())
+            .unwrap();
+        let num_kv_heads = extract_expr(egraph, kind_children[1], expr_cache)
+            .unwrap()
+            .exec(&FxHashMap::default())
+            .unwrap();
+        let head_dim = extract_expr(egraph, kind_children[2], expr_cache)
+            .unwrap()
+            .exec(&FxHashMap::default())
+            .unwrap();
+        let batch_dim = extract_expr(egraph, kind_children[3], expr_cache).unwrap();
+        let sm_scale: f64 = egraph.enodes[kind_children[4]]
+            .0
+            .replace('"', "")
+            .parse()
+            .unwrap();
+        let window_left = egraph.enodes[kind_children[5]]
+            .0
+            .replace('"', "")
+            .parse::<f64>()
+            .unwrap()
+            .round() as i64;
+
+        let extracted = Self {
+            num_qo_heads,
+            num_kv_heads,
+            head_dim,
+            batch_dim,
+            sm_scale,
+            window_left,
+        };
+
+        // JIT at extract time so the ~45s nvcc cost never lands inside a
+        // GA profiling trial (same rationale as FlashInferAttention).
+        let _ = jit::ensure_compiled_fa3(head_dim, window_left >= 0);
+
+        // The rule passes the FLAT gather index (proof anchor); recover the
+        // compact per-token page table the kernel consumes.
+        let flat_idx_node = input_enodes[3];
+        let gather_idx = super::find_indptrs::try_find_compact_gather_idx(egraph, flat_idx_node)
+            .expect("SinkAttention matched a gather without recoverable compact gather_idx");
+        let final_inputs = vec![
+            input_enodes[0], // q (bf16)
+            input_enodes[1], // k_pool
+            input_enodes[2], // v_pool
+            gather_idx,      // compact kv_indices
+            input_enodes[4], // qo_indptr
+            input_enodes[5], // kv_indptr
+            input_enodes[6], // sinks (f32)
+        ];
+
+        let op = LLIROp::new::<dyn HostOp>(Box::new(extracted) as Box<dyn HostOp>);
+        (op, final_inputs)
+    }
+
+    fn cleanup(&self) -> bool {
+        false
+    }
+}
+
+impl HostOp for SinkAttention {
+    fn execute(
+        &self,
+        stream: &Arc<CudaStream>,
+        self_node: NodeIndex,
+        inputs: &[NodeIndex],
+        buffers: &FxHashMap<NodeIndex, DeviceBuffer>,
+        _dyn_map: &FxHashMap<char, usize>,
+    ) -> anyhow::Result<()> {
+        anyhow::ensure!(
+            inputs.len() == 7,
+            "SinkAttention expects 7 inputs, got {}",
+            inputs.len()
+        );
+        let buf = |n: NodeIndex, what: &str| -> anyhow::Result<DeviceBuffer> {
+            buffers
+                .get(&n)
+                .copied()
+                .ok_or_else(|| anyhow::anyhow!("SinkAttention: missing buffer for {what}"))
+        };
+        let q = buf(inputs[0], "q")?;
+        let k_pool = buf(inputs[1], "k_pool")?;
+        let v_pool = buf(inputs[2], "v_pool")?;
+        let kv_indices = buf(inputs[3], "kv_indices")?;
+        let qo_indptr_buf = buf(inputs[4], "qo_indptr")?;
+        let kv_indptr_buf = buf(inputs[5], "kv_indptr")?;
+        let sinks = buf(inputs[6], "sinks")?;
+        let out = buf(self_node, "output")?;
+
+        let cu_stream = stream.cu_stream() as *mut std::ffi::c_void;
+
+        let lib = jit::ensure_compiled_fa3(self.head_dim, self.window_left >= 0);
+        let (_float_ws, float_ws_ptr, _int_ws, int_ws_ptr) = flashinfer_workspaces(stream);
+
+        // Read the indptrs back to the host: the FA3 plan is host-side and
+        // runs once per execute. The first read's synchronize also drains
+        // the previous execute's async traffic out of the shared pinned plan
+        // buffer and the scratch pools before this call rewrites them.
+        let read_device_i32s = |b: DeviceBuffer| -> anyhow::Result<Vec<i32>> {
+            let mut host_bytes = vec![0u8; b.len()];
+            unsafe {
+                result::memcpy_dtoh_async(&mut host_bytes, b.ptr(), stream.cu_stream())?;
+            }
+            stream.synchronize()?;
+            Ok(bytes_to_i32_vec(host_bytes))
+        };
+        let mut qo_indptr = read_device_i32s(qo_indptr_buf)?;
+        let mut kv_indptr = read_device_i32s(kv_indptr_buf)?;
+        anyhow::ensure!(
+            qo_indptr.len() == kv_indptr.len() && qo_indptr.len() >= 2,
+            "SinkAttention: malformed indptrs (qo len {}, kv len {})",
+            qo_indptr.len(),
+            kv_indptr.len()
+        );
+        let batch_size = qo_indptr.len() - 1;
+        let nnz_qo = *qo_indptr.last().unwrap() as usize;
+        let total_pages = *kv_indptr.last().unwrap() as usize;
+        anyhow::ensure!(
+            kv_indices.len() >= total_pages * std::mem::size_of::<i32>(),
+            "SinkAttention: kv_indices buffer smaller than kv_indptr total"
+        );
+        // page_size = 1: per-sequence kv length in tokens == pages.
+        let mut kv_len_arr: Vec<i32> = kv_indptr.windows(2).map(|w| w[1] - w[0]).collect();
+
+        let page_locked = page_locked_workspace();
+
+        let mut plan_info = [0i64; 16];
+        let mut plan_info_len: i32 = 0;
+        let plan_ret = unsafe {
+            (lib.prefill_plan)(
+                float_ws_ptr as *mut std::ffi::c_void,
+                super::FLOAT_WORKSPACE_SIZE,
+                int_ws_ptr as *mut std::ffi::c_void,
+                page_locked.0 as *mut std::ffi::c_void,
+                INT_WORKSPACE_SIZE,
+                qo_indptr.as_mut_ptr(),
+                kv_indptr.as_mut_ptr(),
+                kv_len_arr.as_mut_ptr(),
+                nnz_qo as i32,
+                batch_size as i32,
+                self.num_qo_heads as i32,
+                self.num_kv_heads as i32,
+                /*page_size=*/ 1,
+                cu_stream,
+                plan_info.as_mut_ptr(),
+                &mut plan_info_len,
+            )
+        };
+        anyhow::ensure!(plan_ret == 0, "SinkAttention: fa3 plan failed ({plan_ret})");
+
+        // Kernel-native (s, heads, dim) bf16 scratch (front half: transposed
+        // q in, back half: kernel out), from the grow-only pool. Reuse is
+        // stream-ordered; the refresh-path sync above covers growth.
+        let temp_bytes = (nnz_qo * self.num_qo_heads * self.head_dim * 2).max(1);
+        let mut scratch_guard = SCRATCH.lock().unwrap_or_else(|e| e.into_inner());
+        let stream_key = stream.cu_stream() as usize;
+        let needs_new = !matches!(&*scratch_guard,
+            Some((key, buf)) if *key == stream_key && buf.len() >= 2 * temp_bytes);
+        if needs_new {
+            stream.synchronize()?; // in-flight users of the old scratch
+            let buf = unsafe { stream.alloc::<u8>((2 * temp_bytes).next_power_of_two())? };
+            if let Some((_, old)) = scratch_guard.take() {
+                std::mem::forget(old); // context may be gone; never free
+            }
+            *scratch_guard = Some((stream_key, buf));
+        }
+        let base_ptr = scratch_guard.as_ref().unwrap().1.device_ptr(stream).0;
+        let (q_temp_ptr, temp_ptr) = (base_ptr, base_ptr + temp_bytes as u64);
+
+        // The graph's q is (heads, s, dim) — the same heads-major layout
+        // world as the output point — but the kernel reads token-major
+        // (s, heads, dim) q. The layouts are byte-identical at s == 1
+        // (decode), which is how this survived every single-token path;
+        // prefill (s > 1) needs the transpose.
+        let qtr_ret = unsafe {
+            (lib.transpose_q_bf16)(
+                q.ptr() as *const std::ffi::c_void,
+                q_temp_ptr as *mut std::ffi::c_void,
+                nnz_qo as i32,
+                self.num_qo_heads as i32,
+                self.head_dim as i32,
+                cu_stream,
+            )
+        };
+        anyhow::ensure!(
+            qtr_ret == 0,
+            "SinkAttention: q transpose failed ({qtr_ret})"
+        );
+
+        let sm_scale = if self.sm_scale == 0.0 {
+            1.0 / (self.head_dim as f32).sqrt()
+        } else {
+            self.sm_scale as f32
+        };
+        let run_ret = unsafe {
+            (lib.prefill_run)(
+                int_ws_ptr as *mut std::ffi::c_void,
+                plan_info.as_mut_ptr(),
+                plan_info_len,
+                q_temp_ptr as *mut std::ffi::c_void,
+                k_pool.ptr() as *mut std::ffi::c_void,
+                v_pool.ptr() as *mut std::ffi::c_void,
+                kv_indices.ptr() as *mut i32,
+                sinks.ptr() as *mut f32,
+                temp_ptr as *mut std::ffi::c_void,
+                nnz_qo as i32,
+                self.num_qo_heads as i32,
+                self.num_kv_heads as i32,
+                /*page_size=*/ 1,
+                sm_scale,
+                self.window_left as i32,
+                cu_stream,
+            )
+        };
+        anyhow::ensure!(run_ret == 0, "SinkAttention: fa3 run failed ({run_ret})");
+
+        let tr_ret = unsafe {
+            (lib.transpose_output_f32)(
+                temp_ptr as *const std::ffi::c_void,
+                out.ptr() as *mut std::ffi::c_void,
+                nnz_qo as i32,
+                self.num_qo_heads as i32,
+                self.head_dim as i32,
+                cu_stream,
+            )
+        };
+        anyhow::ensure!(tr_ret == 0, "SinkAttention: output transpose failed");
+
+        // No trailing sync: scratch is pooled (never freed), so the enqueued
+        // kernels own it under stream ordering; the next tick's plan-refresh
+        // path syncs before touching shared host buffers or growing scratch.
+        Ok(())
+    }
+
+    fn output_size(&self) -> Expression {
+        self.batch_dim * self.num_qo_heads * self.head_dim
+    }
+
+    fn output_bytes(&self) -> Expression {
+        self.output_size() * 4 // F32 output
+    }
+
+    fn stats_name(&self) -> Option<&'static str> {
+        Some("SinkAttention")
+    }
+}

--- a/crates/luminal_cuda_lite/src/host/flashinfer/wrapper_fa3.cu
+++ b/crates/luminal_cuda_lite/src/host/flashinfer/wrapper_fa3.cu
@@ -1,0 +1,411 @@
+// FA3/Hopper (SM90) FlashInfer batch-prefill paged kernel with the
+// AttentionSink variant, for gpt-oss-style models (per-head learned sink
+// logit joining the softmax denominator).
+//
+// JIT-compiled at runtime with -DLUMINAL_HEAD_DIM=N and -DLUMINAL_USE_SWA=0|1
+// and -arch=sm_90a (WGMMA/TMA — Hopper only). bf16 Q/KV/O, fp32 accumulate,
+// page_size is a runtime parameter (1 in the paged engine).
+//
+// This TU is a hand-rendered equivalent of what FlashInfer's Python JIT
+// generates from csrc/batch_prefill_sm90_customize_config.jinja +
+// csrc/batch_prefill_paged_sm90_kernel_inst.jinja for the attention-sink
+// module (flashinfer/jit/attention/modules.py::gen_batch_prefill_attention_sink_module):
+//   - PagedParams with AdditionalParams { float* sink; double sm_scale; }
+//   - the AttentionSink variant + OnlineSoftmaxWithSink updater
+//     (flashinfer/jit/attention/variants.py::attention_sink_fa3_decl, verbatim)
+//   - plan via PrefillSM90Plan, run via BatchPrefillWithPagedKVCacheDispatched
+//     (mirrors csrc/batch_prefill_sm90.cu::BatchPrefillWithPagedKVCacheSM90Run)
+//
+// Decode is this same kernel at qo_len=1 — there is no SM90 decode-with-sink
+// kernel (upstream tests/attention/test_attention_sink.py does the same).
+
+#ifndef LUMINAL_HEAD_DIM
+#error "LUMINAL_HEAD_DIM must be defined (e.g. -DLUMINAL_HEAD_DIM=64)"
+#endif
+
+// The SM90 paged prefill only supports head_dim 64 / 128 / 256.
+#if LUMINAL_HEAD_DIM != 64 && LUMINAL_HEAD_DIM != 128 && LUMINAL_HEAD_DIM != 256
+#error "FA3 paged prefill supports LUMINAL_HEAD_DIM of 64, 128, or 256 only"
+#endif
+
+// Config headers first (same set as batch_prefill_sm90_customize_config.jinja),
+// so the variant decl below sees the hopper updater/variant machinery.
+#include <flashinfer/attention/hopper/attention_updater.cuh>
+#include <flashinfer/attention/hopper/variant_helper.cuh>
+#include <flashinfer/attention/hopper/variants.cuh>
+#include <flashinfer/math.cuh>
+#include <flashinfer/layout.cuh>
+#include <flashinfer/cutlass_utils.cuh>
+#include <flashinfer/attention/mask.cuh>
+
+#include "wrapper_fa3.h"
+
+#include <cstring>
+#include <vector>
+#include <cuda_bf16.h>
+
+using namespace flashinfer;
+
+using IdType = int32_t;
+using DTypeQ = cutlass_dtype_t<__nv_bfloat16>;
+using DTypeKV = cutlass_dtype_t<__nv_bfloat16>;
+using DTypeO = cutlass_dtype_t<__nv_bfloat16>;
+
+constexpr uint32_t HEAD_DIM_QK = LUMINAL_HEAD_DIM;
+constexpr uint32_t HEAD_DIM_VO = LUMINAL_HEAD_DIM;
+constexpr bool USE_SWA = LUMINAL_USE_SWA != 0;
+
+// ── PagedParams ─────────────────────────────────────────────────────────
+// Mirrors csrc/batch_prefill_sm90_customize_config.jinja::PagedParams with the
+// sink module's AdditionalParams. Field order matters only to us (we build it
+// by name), but the field SET must match what SparseCollectiveMainloop and
+// the tile schedulers read in prefill_sm90.cuh.
+
+struct PagedParams {
+  using DTypeQ = ::DTypeQ;
+  using DTypeKV = ::DTypeKV;
+  using DTypeO = ::DTypeO;
+  using IdType = ::IdType;
+
+  DTypeQ* q_ptr;
+  DTypeKV* k_ptr;
+  DTypeKV* v_ptr;
+  DTypeO* o_ptr;
+  float* lse_ptr;
+
+  // Plan-produced (pointers into the int workspace at plan_info offsets).
+  IdType* qo_tile_indices;
+  IdType* qo_indptr;
+  IdType* kv_indptr;
+  IdType* kv_indices; // user page table (NOT plan-produced)
+  IdType* qo_lens;
+  IdType* kv_lens;
+  IdType* head_indices;
+  IdType* work_indptr;
+  IdType* batch_indices;
+
+  struct AdditionalParams {
+    float* sink;     // [num_qo_heads] sink logits, indexed by qo_head_idx
+    double sm_scale; // softmax scale (1/sqrt(head_dim) for gpt-oss)
+  } additional_params;
+
+  int64_t q_stride_n;
+  int64_t k_stride_n;
+  int64_t v_stride_n;
+  int64_t o_stride_n;
+  int64_t q_stride_h;
+  int64_t k_stride_h;
+  int64_t v_stride_h;
+  int64_t o_stride_h;
+  int64_t nnz_qo;
+
+  // Stride between pages of the paged KV cache (paged_k_cache.stride(0)).
+  int64_t k_page_stride;
+  int64_t v_page_stride;
+
+  int head_dim;
+  int num_qo_heads;
+  int num_kv_heads;
+  int group_size;
+  int page_size;
+  int window_left;
+
+  bool causal;
+};
+
+// ── AttentionSink variant ───────────────────────────────────────────────
+// Verbatim port of flashinfer/jit/attention/variants.py::attention_sink_fa3_decl
+// (the code the Python JIT injects as {{ variant_decl }}).
+
+template <int NUM_ROWS_PER_THREAD>
+struct OnlineSoftmaxWithSink {
+  constexpr static float fill_value = -math::inf;
+  using TensorT = decltype(make_tensor<float>(Shape<Int<NUM_ROWS_PER_THREAD>>{}));
+  TensorT row_max, row_sum, scores_scale;
+  float sm_scale_log2;
+  float log_sink;
+
+  CUTLASS_DEVICE OnlineSoftmaxWithSink(float sm_scale_log2, float log_sink)
+      : sm_scale_log2(sm_scale_log2), log_sink(log_sink) {
+    clear(scores_scale);
+  };
+
+  __forceinline__ __device__ TensorT get_lse() const { return row_sum; }
+
+  template <bool init, typename Tensor0>
+  __forceinline__ __device__ void update(Tensor0& acc_s) {
+    // Reshape acc_s from ((2, 2, V), MMA_M, MMA_N) to (nrow=(2, MMA_M), ncol=(2, V, MMA_N))
+    Tensor scores = make_tensor(acc_s.data(), convert_layout_acc_rowcol(acc_s.layout()));
+
+    static_assert(decltype(size<0>(scores))::value == NUM_ROWS_PER_THREAD);
+    if constexpr (init) {
+      reduce_max</*init=*/true>(scores, row_max);
+      scale_apply_exp2(scores, row_max, sm_scale_log2);
+      reduce_sum</*init=*/true, /*warp_reduce=*/false>(scores, row_sum);
+    } else {
+      // update row_max
+      Tensor scores_max_prev = make_fragment_like(row_max);
+      cute::copy(row_max, scores_max_prev);
+      reduce_max</*init=*/false>(scores, row_max);
+      // update scores_scale and scale row_sum
+#pragma unroll
+      for (int mi = 0; mi < size(row_max); ++mi) {
+        float scores_max_cur = row_max(mi);
+        scores_scale(mi) = exp2f((scores_max_prev(mi) - scores_max_cur) * sm_scale_log2);
+        row_sum(mi) *= scores_scale(mi);
+      }
+      // perform exp2 on scores
+      scale_apply_exp2(scores, row_max, sm_scale_log2);
+      // update row_sum
+      reduce_sum</*init=*/false, /*warp_reduce=*/false>(scores, row_sum);
+    }
+  };
+
+  template <typename Tensor0>
+  __forceinline__ __device__ void finalize(Tensor0& acc_s, float pv_scale = 1.f) {
+    // Reshape acc_s from ((2, 2, V), MMA_M, MMA_N) to (nrow=(2, MMA_M), ncol=(2, V, MMA_N))
+    // Note (Yilong): use pv_scale to dequantize the output
+    Tensor scores = make_tensor(acc_s.data(), convert_layout_acc_rowcol(acc_s.layout()));
+    static_assert(decltype(size<0>(scores))::value == NUM_ROWS_PER_THREAD);
+    SumOp<float> sum_op;
+    quad_allreduce_(row_sum, row_sum, sum_op);
+
+#pragma unroll
+    for (int mi = 0; mi < size(row_max); ++mi) {
+      float m = row_max(mi) * sm_scale_log2;
+      float d = row_sum(mi);
+
+      float m_new = (log_sink > m) ? log_sink : m;
+      float scale = math::ptx_exp2(m - m_new);
+      float d_new = math::ptx_exp2(log_sink - m_new) + d * scale;
+
+      // Update m and d
+      row_max(mi) = m_new;
+      row_sum(mi) = d_new;
+
+      scores_scale(mi) = pv_scale * scale / d_new;
+      row_sum(mi) = row_max(mi) + math::ptx_log2(d_new);
+    }
+  };
+
+  template <typename Tensor1>
+  __forceinline__ __device__ void rescale_o(Tensor1& acc_o) {
+    // Reshape acc_o from (MMA=4, MMA_M, MMA_K) to (nrow=(2, MMA_M), ncol=(2, MMA_K))
+    Tensor acc_o_rowcol = make_tensor(acc_o.data(), convert_layout_acc_rowcol(acc_o.layout()));
+    static_assert(decltype(size<0>(acc_o_rowcol))::value == NUM_ROWS_PER_THREAD);
+#pragma unroll
+    for (int mi = 0; mi < size(row_max); ++mi) {
+#pragma unroll
+      for (int ni = 0; ni < size<1>(acc_o_rowcol); ++ni) {
+        acc_o_rowcol(mi, ni) *= scores_scale(mi);
+      }
+    }
+  };
+};
+
+struct AttentionSink : AttentionVariantBase {
+  float sm_scale_log2;
+  float log_sink;
+  float scale_pv;
+  int qo_len, kv_len;
+
+  // Init
+  template <typename MainloopParams, typename BlockCoord>
+  __device__ __host__ AttentionSink(const MainloopParams& params, const BlockCoord& block_coord) {
+    sm_scale_log2 = params.additional_params.sm_scale * math::log2e;
+    auto [_, qo_head_idx, kv_head_idx, ___, ____, qo_len_, kv_len_, batch_idx] = block_coord;
+    log_sink = params.additional_params.sink[qo_head_idx] * math::log2e;
+    scale_pv = get_v_scale(params.additional_params, kv_head_idx);
+
+    qo_len = qo_len_;
+    kv_len = kv_len_;
+  }
+
+  template <int NUM_ROWS_PER_THREAD>
+  __device__ auto GetAttentionUpdater() {
+    return OnlineSoftmaxWithSink<NUM_ROWS_PER_THREAD>(sm_scale_log2, log_sink);
+  }
+};
+
+// ── Kernel + plan ───────────────────────────────────────────────────────
+// Included AFTER the params/variant definitions (mirrors the generated
+// module structure: config .inc first, then prefill_sm90.cuh).
+
+#include <flashinfer/attention/hopper/prefill_sm90.cuh>
+#include <flashinfer/attention/scheduler.cuh>
+#include <flashinfer/allocator.h>
+
+extern "C" {
+
+int flashinfer_fa3_prefill_plan(
+    void* float_workspace, size_t float_ws_size,
+    void* int_workspace, void* page_locked_int_workspace, size_t int_ws_size,
+    int32_t* qo_indptr_h, int32_t* kv_indptr_h, int32_t* kv_len_arr_h,
+    int total_num_rows, int batch_size,
+    int num_qo_heads, int num_kv_heads, int page_size,
+    cudaStream_t stream,
+    int64_t* plan_info_out, int* plan_info_len_out)
+{
+    PrefillPlanSM90Info plan_info;
+    cudaError_t status = PrefillSM90Plan(
+        float_workspace, float_ws_size,
+        int_workspace, page_locked_int_workspace, int_ws_size,
+        plan_info,
+        (IdType*)qo_indptr_h, (IdType*)kv_indptr_h, (IdType*)kv_len_arr_h,
+        (uint32_t)total_num_rows, (uint32_t)batch_size,
+        (uint32_t)num_qo_heads, (uint32_t)num_kv_heads,
+        HEAD_DIM_QK, HEAD_DIM_VO,
+        (uint32_t)page_size,
+        /*causal=*/true,
+        /*enable_cuda_graph=*/false,
+        /*sizeof_dtype_o=*/2,
+        stream);
+
+    if (status != cudaSuccess) return (int)status;
+
+    auto vec = plan_info.ToVector();
+    *plan_info_len_out = (int)vec.size();
+    std::memcpy(plan_info_out, vec.data(), vec.size() * sizeof(int64_t));
+    return 0;
+}
+
+int flashinfer_fa3_prefill_run(
+    void* int_workspace,
+    int64_t* plan_info_vec, int plan_info_len,
+    void* q, void* k_cache, void* v_cache,
+    int32_t* kv_indices,
+    float* sink,
+    void* output,
+    int nnz_qo,
+    int num_qo_heads, int num_kv_heads, int page_size,
+    float sm_scale, int window_left,
+    cudaStream_t stream)
+{
+    if (sink == nullptr) return -1;
+    if (USE_SWA != (window_left >= 0)) return -1; // wrong .so variant for this window
+
+    PrefillPlanSM90Info plan_info;
+    plan_info.FromVector(std::vector<int64_t>(plan_info_vec, plan_info_vec + plan_info_len));
+
+    PagedParams params;
+    params.q_ptr = (DTypeQ*)q;
+    params.k_ptr = (DTypeKV*)k_cache;
+    params.v_ptr = (DTypeKV*)v_cache;
+    params.o_ptr = (DTypeO*)output;
+    params.lse_ptr = nullptr; // LSE only matters for split-KV merging; unused here
+
+    // Contiguous NHD layouts:
+    //   q/o: [nnz_qo, num_qo_heads, head_dim]
+    //   k/v: [num_pages, page_size, num_kv_heads, head_dim]
+    params.q_stride_n = (int64_t)num_qo_heads * HEAD_DIM_QK;
+    params.q_stride_h = HEAD_DIM_QK;
+    params.o_stride_n = (int64_t)num_qo_heads * HEAD_DIM_VO;
+    params.o_stride_h = HEAD_DIM_VO;
+    params.k_stride_n = (int64_t)num_kv_heads * HEAD_DIM_QK;
+    params.k_stride_h = HEAD_DIM_QK;
+    params.v_stride_n = (int64_t)num_kv_heads * HEAD_DIM_VO;
+    params.v_stride_h = HEAD_DIM_VO;
+    params.k_page_stride = (int64_t)page_size * num_kv_heads * HEAD_DIM_QK;
+    params.v_page_stride = (int64_t)page_size * num_kv_heads * HEAD_DIM_VO;
+
+    params.nnz_qo = nnz_qo;
+    params.head_dim = HEAD_DIM_QK;
+    params.num_qo_heads = num_qo_heads;
+    params.num_kv_heads = num_kv_heads;
+    params.group_size = num_qo_heads / num_kv_heads;
+    params.page_size = page_size;
+    params.window_left = window_left;
+    params.causal = true;
+
+    params.qo_tile_indices =
+        GetPtrFromBaseOffset<IdType>(int_workspace, plan_info.qo_tile_indices_offset);
+    params.qo_indptr = GetPtrFromBaseOffset<IdType>(int_workspace, plan_info.qo_indptr_offset);
+    params.kv_indptr = GetPtrFromBaseOffset<IdType>(int_workspace, plan_info.kv_indptr_offset);
+    params.qo_lens = GetPtrFromBaseOffset<IdType>(int_workspace, plan_info.qo_len_offset);
+    params.kv_lens = GetPtrFromBaseOffset<IdType>(int_workspace, plan_info.kv_len_offset);
+    params.head_indices =
+        GetPtrFromBaseOffset<IdType>(int_workspace, plan_info.head_indices_offset);
+    params.work_indptr = GetPtrFromBaseOffset<IdType>(int_workspace, plan_info.work_indptr_offset);
+    params.batch_indices =
+        GetPtrFromBaseOffset<IdType>(int_workspace, plan_info.batch_indices_offset);
+    params.kv_indices = (IdType*)kv_indices;
+
+    params.additional_params.sink = sink;
+    params.additional_params.sm_scale = sm_scale;
+
+    cudaError_t status;
+    if (plan_info.same_schedule_for_all_heads) {
+        status = BatchPrefillWithPagedKVCacheDispatched<
+            HEAD_DIM_QK, HEAD_DIM_VO, MaskMode::kCausal, USE_SWA,
+            /*SAME_SCHEDULER_FOR_ALL_HEADS=*/true, AttentionSink, PagedParams>(
+            params, /*enable_pdl=*/false, stream);
+    } else {
+        status = BatchPrefillWithPagedKVCacheDispatched<
+            HEAD_DIM_QK, HEAD_DIM_VO, MaskMode::kCausal, USE_SWA,
+            /*SAME_SCHEDULER_FOR_ALL_HEADS=*/false, AttentionSink, PagedParams>(
+            params, /*enable_pdl=*/false, stream);
+    }
+    return status == cudaSuccess ? 0 : (int)status;
+}
+
+} // extern "C"
+
+// ── Output transpose + upcast: (s, heads, dim) bf16 → (heads, s, dim) f32 ──
+// The kernel writes NHD; luminal's attention chain point being replaced is
+// (heads, s, dim) in F32 (the graph computes attention in F32 and o_proj
+// casts weights up). Fusing the layout change and the upcast into one pass
+// keeps the host-op boundary a single kernel.
+
+__global__ void fa3_transpose_upcast_kernel(
+    const __nv_bfloat16* src, float* dst, int batch, int heads, int dim) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * heads * dim;
+    if (idx >= total) return;
+    int d = idx % dim;
+    int h = (idx / dim) % heads;
+    int b = idx / (heads * dim);
+    dst[h * batch * dim + b * dim + d] = __bfloat162float(src[idx]);
+}
+
+extern "C" int flashinfer_fa3_transpose_output_f32(
+    const void* src, void* dst,
+    int batch, int heads, int dim,
+    cudaStream_t stream) {
+    int total = batch * heads * dim;
+    if (total == 0) return 0;
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    fa3_transpose_upcast_kernel<<<blocks, threads, 0, stream>>>(
+        (const __nv_bfloat16*)src, (float*)dst, batch, heads, dim);
+    return cudaGetLastError() == cudaSuccess ? 0 : -1;
+}
+
+// ── Q input transpose: (heads, s, dim) bf16 → (s, heads, dim) bf16 ──
+// The graph's q chain lives in the same heads-major layout world as the
+// output point above, but the kernel reads token-major q (q_stride_n =
+// heads*dim). The two layouts are byte-identical at s == 1, so decode and
+// single-token paths never expose the difference — prefill (s > 1) does.
+
+__global__ void fa3_transpose_q_kernel(
+    const __nv_bfloat16* src, __nv_bfloat16* dst, int batch, int heads, int dim) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    int total = batch * heads * dim;
+    if (idx >= total) return;
+    int d = idx % dim;
+    int h = (idx / dim) % heads;
+    int b = idx / (heads * dim);
+    dst[idx] = src[h * batch * dim + b * dim + d];
+}
+
+extern "C" int flashinfer_fa3_transpose_q_bf16(
+    const void* src, void* dst,
+    int batch, int heads, int dim,
+    cudaStream_t stream) {
+    int total = batch * heads * dim;
+    if (total == 0) return 0;
+    int threads = 256;
+    int blocks = (total + threads - 1) / threads;
+    fa3_transpose_q_kernel<<<blocks, threads, 0, stream>>>(
+        (const __nv_bfloat16*)src, (__nv_bfloat16*)dst, batch, heads, dim);
+    return cudaGetLastError() == cudaSuccess ? 0 : -1;
+}

--- a/crates/luminal_cuda_lite/src/host/flashinfer/wrapper_fa3.h
+++ b/crates/luminal_cuda_lite/src/host/flashinfer/wrapper_fa3.h
@@ -1,0 +1,74 @@
+// C API for the FA3/Hopper (SM90) FlashInfer batch-prefill paged kernel with
+// the AttentionSink variant. JIT-compiled from wrapper_fa3.cu — see jit.rs.
+//
+// Separate from wrapper.h: the FA3 kernels require -arch=sm_90a and pull in
+// the CUTLASS/CuTe hopper headers, so they live in their own .so and never
+// perturb the FA2 wrapper used by non-Hopper models.
+
+#pragma once
+
+#include <cuda_runtime.h>
+#include <stddef.h>
+#include <stdint.h>
+
+extern "C" {
+
+// Host-side scheduling for the SM90 batch prefill (PrefillSM90Plan).
+//
+// qo_indptr_h:  [batch_size + 1] HOST — cumulative query rows per sequence.
+// kv_indptr_h:  [batch_size + 1] HOST — cumulative PAGES per sequence
+//               (prefix sums into the kv_indices page table).
+// kv_len_arr_h: [batch_size]     HOST — per-sequence KV length in TOKENS.
+//
+// Writes the serialized PrefillPlanSM90Info (9 int64s) to plan_info_out.
+// Returns 0 on success, a cudaError_t code otherwise.
+int flashinfer_fa3_prefill_plan(
+    void* float_workspace, size_t float_ws_size,
+    void* int_workspace, void* page_locked_int_workspace, size_t int_ws_size,
+    int32_t* qo_indptr_h, int32_t* kv_indptr_h, int32_t* kv_len_arr_h,
+    int total_num_rows, int batch_size,
+    int num_qo_heads, int num_kv_heads, int page_size,
+    cudaStream_t stream,
+    int64_t* plan_info_out, int* plan_info_len_out);
+
+// Launch BatchPrefillWithPagedKVCacheDispatched<..., AttentionSink>.
+//
+// All device pointers; NHD layout, contiguous:
+//   q:       [nnz_qo, num_qo_heads, head_dim]
+//   k_cache: [num_pages, page_size, num_kv_heads, head_dim]
+//   v_cache: same layout as k_cache
+//   kv_indices: [total pages across batch] page table entries
+//   sink:    [num_qo_heads] f32 — per-head sink logits (REQUIRED; pass large
+//            negative values, e.g. -1e30, to recover sinkless softmax)
+//   output:  [nnz_qo, num_qo_heads, head_dim]
+//
+// q/k/v/output are bf16; the kernel is compiled causal (MaskMode::kCausal).
+// sm_scale: pass the real scale (e.g. 1/sqrt(head_dim)) — no 0.0 default.
+// window_left: -1 = full attention; >= 0 requires the swa=1 build variant.
+// Returns 0 on success, -1 on bad arguments, a cudaError_t code otherwise.
+int flashinfer_fa3_prefill_run(
+    void* int_workspace,
+    int64_t* plan_info_vec, int plan_info_len,
+    void* q, void* k_cache, void* v_cache,
+    int32_t* kv_indices,
+    float* sink,
+    void* output,
+    int nnz_qo,
+    int num_qo_heads, int num_kv_heads, int page_size,
+    float sm_scale, int window_left,
+    cudaStream_t stream);
+
+// (s, heads, dim) bf16 → (heads, s, dim) f32, one fused pass.
+int flashinfer_fa3_transpose_output_f32(
+    const void* src, void* dst,
+    int batch, int heads, int dim,
+    cudaStream_t stream);
+
+// (heads, s, dim) bf16 → (s, heads, dim) bf16: graph-layout q into the
+// kernel-native token-major layout `flashinfer_fa3_prefill_run` expects.
+int flashinfer_fa3_transpose_q_bf16(
+    const void* src, void* dst,
+    int batch, int heads, int dim,
+    cudaStream_t stream);
+
+} // extern "C"

--- a/crates/luminal_cuda_lite/src/host/mod.rs
+++ b/crates/luminal_cuda_lite/src/host/mod.rs
@@ -14,6 +14,7 @@ pub type Ops = (
     moe::GLUMoE,
     moe::fused::FusedMoE,
     flashinfer::FlashInferAttention,
+    flashinfer::sink_attention::SinkAttention,
 );
 
 #[cfg(test)]


### PR DESCRIPTION
FlashAttention-3 backend for attention-with-sinks (gpt-oss style):

- wrapper_fa3.cu/.h: C wrappers over FlashInfer's SM90 prefill kernels (plan + run), JIT-compiled at runtime like the existing FA2 wrapper 

- sink_attention.rs: the SinkAttention host op. Consumes a HOST-side mask expression plus free-floating qo_indptr/kv_indptr named inputs 

- sink_attention.egg: dim-generic island rewrite; anchors on the exact bf16->F32 sink cast structure.
