### PR TITLE
luminal_python: lower sym_sum before torch.export.save (serde gap workaround)

### DIFF
--- a/crates/luminal_python/src/luminal/pt2.py
+++ b/crates/luminal_python/src/luminal/pt2.py
@@ -163,6 +163,55 @@ def _collect_input_device_ptrs(ep, user_inputs):
     return ptrs
 
 
+
+def _lower_sym_sum(ep) -> None:
+    """Rewrite `torch.sym_sum` nodes into chains of `operator.add` so the
+    ExportedProgram survives `torch.export.save`.
+
+    WORKAROUND for a torch.export inconsistency: the export VERIFIER allows
+    sym_sum in graphs (pytorch#159111, landed 2025-07), but the PT2 serde's
+    `_SYM_OPS` table never got the matching entry, so `torch.export.save`
+    raises `AssertionError: op sym_sum is not in _SYM_OPS` on any graph the
+    verifier just blessed. sym_sum appears whenever shape arithmetic sums
+    three or more SymInts (sympy's Add is n-ary) — e.g. HF llama under
+    attn_implementation="sdpa" with a growing KV cache.
+
+    The upstream one-line fix exists inside the (larger, still-open)
+    duck-sizing PR: https://github.com/pytorch/pytorch/pull/186373
+    This pass checks torch's own table first, so it becomes a no-op — and
+    can be DELETED — once we run a torch that includes that fix.
+    """
+    import operator
+
+    if not hasattr(torch, "sym_sum"):
+        return  # torch too old to ever emit it
+    try:
+        from torch._export.serde.serialize import _SYM_OPS
+
+        if torch.sym_sum in _SYM_OPS:
+            return  # torch can serialize it natively (pytorch#186373 landed)
+    except ImportError:
+        pass  # private module moved — fall through and lower defensively
+
+    gm = ep.graph_module
+    changed = False
+    for node in list(gm.graph.nodes):
+        if node.op != "call_function" or node.target is not torch.sym_sum:
+            continue
+        (terms,) = node.args
+        terms = list(terms)
+        with gm.graph.inserting_before(node):
+            acc = terms[0]
+            for term in terms[1:]:
+                acc = gm.graph.call_function(operator.add, (acc, term))
+        node.replace_all_uses_with(acc)
+        gm.graph.erase_node(node)
+        changed = True
+    if changed:
+        gm.graph.lint()
+        gm.recompile()
+
+
 def _save_and_compile(
     ep_or_path, factory, search_iterations, user_indices=None, input_device_ptrs=None
 ):
@@ -180,6 +229,7 @@ def _save_and_compile(
     try:
         if owns_tmpdir:
             pt2_path = os.path.join(tmpdir, "model.pt2")
+            _lower_sym_sum(ep_or_path)  # serde gap workaround; see docstring
             torch.export.save(ep_or_path, pt2_path)
             weight_source = ep_or_path.state_dict
         else:

--- a/crates/luminal_python/tests/test_lower_sym_sum.py
+++ b/crates/luminal_python/tests/test_lower_sym_sum.py
@@ -1,0 +1,42 @@
+"""_lower_sym_sum: sym_sum nodes must not survive to torch.export.save.
+
+Three distinct-sized dynamic inputs concatenated force the output length
+s0+s1+s2 — an n-ary sympy Add that torch FX-ifies as torch.sym_sum on
+affected versions. Whether or not this torch build emits sym_sum, the
+contract is the same: after the pass, no sym_sum nodes remain and save()
+succeeds. CPU-only.
+"""
+import os
+import tempfile
+
+import torch
+from torch.export import Dim, export
+
+from luminal.pt2 import _lower_sym_sum
+
+
+class Cat3(torch.nn.Module):
+    def forward(self, a, b, c):
+        out = torch.cat([a, b, c])
+        return out + out.shape[0]
+
+
+def test_lower_sym_sum_roundtrip():
+    m = Cat3()
+    ex = (torch.randn(3), torch.randn(5), torch.randn(7))
+    dyn = {"a": {0: Dim("s0")}, "b": {0: Dim("s1")}, "c": {0: Dim("s2")}}
+    ep = export(m, ex, dynamic_shapes=dyn)
+
+    _lower_sym_sum(ep)
+
+    assert not any(
+        n.op == "call_function" and n.target is getattr(torch, "sym_sum", None)
+        for n in ep.graph_module.graph.nodes
+    )
+    with tempfile.TemporaryDirectory() as td:
+        torch.export.save(ep, os.path.join(td, "m.pt2"))  # must not raise
+
+    # Semantics preserved.
+    got = ep.module()(*ex)
+    want = m(*ex)
+    torch.testing.assert_close(got, want)


### PR DESCRIPTION
## What

`torch.export.save` crashes with `AssertionError: op sym_sum is not in _SYM_OPS` on graphs that `torch.export.export` itself just produced and verified. The export **verifier** allowlists `sym_sum` (pytorch#159111, landed July 2025 as `0b01e11416`); the PT2 **serde** table never got the matching entry — still absent on pytorch main today. `sym_sum` appears whenever shape arithmetic sums 3+ SymInts (sympy `Add` is n-ary); concretely, HF llama with `attn_implementation="sdpa"` + a growing KV cache is unexportable through our pipeline (hit while investigating nightly TTFT variance — 3/3 deterministic repro on Modal H200s).

This adds `_lower_sym_sum(ep)`: rewrites `sym_sum([a,b,c,...])` into the chain of binary `operator.add`s serde already handles, immediately before `torch.export.save` in `_save_and_compile`. Semantics identical.

## Self-retiring by design

The pass first checks torch's own `torch._export.serde.serialize._SYM_OPS` and no-ops if `sym_sum` is present. The upstream one-line fix already exists inside the still-open duck-sizing PR: **https://github.com/pytorch/pytorch/pull/186373** (jansel) — once we run a torch build containing it, this pass does nothing and can be deleted.

## Test

`tests/test_lower_sym_sum.py`: CPU-only — three distinct dynamic dims concatenated (forces the n-ary shape sum), pass applied, asserts no `sym_sum` nodes remain, `save()` succeeds, and outputs match eager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L3ALDdUvaFd6RFmpr44m9F